### PR TITLE
Fixed IllegalStateException when accessing AsyncContext

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -23,6 +23,7 @@ package org.zalando.logbook.servlet;
 import org.zalando.logbook.Correlator;
 import org.zalando.logbook.Logbook;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -92,7 +93,7 @@ public final class LogbookFilter implements HttpFilter {
     }
 
     private boolean isFirstRequest(final TeeRequest request) {
-        return request.getAsyncContext() == null;
+        return request.getDispatcherType() != DispatcherType.ASYNC;
     }
 
     private boolean isLastRequest(final TeeRequest request) {

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 
@@ -118,13 +119,12 @@ public final class AsyncDispatchTest {
     }
 
     private RequestBuilder async(final MvcResult result) throws Exception {
-        result.getAsyncResult();
+        final RequestBuilder builder = asyncDispatch(result);
 
         return context -> {
-            final MockHttpServletRequest request = result.getRequest();
-            // this was missing in the asyncDispatch builder from Spring
+            final MockHttpServletRequest request = builder.buildRequest(context);
+            // this is missing in MockMvcRequestBuilders#asyncDispatch
             request.setDispatcherType(DispatcherType.ASYNC);
-            request.setAsyncStarted(false);
             return request;
         };
     }


### PR DESCRIPTION
Turns out that `ServletRequest.getAsyncContext()` by contract is supposed to throw an `IllegalStateException` if no async process was started. I just used `request.getAsyncContext() == null` to see if the current filter pass was a part of an async dispatch. Coincidentally Tomcat doesn't adhere to the spec here and actually returns null, which made it look like it worked. Testing it with Undertow though showed the problem.

Additionally Spring MockMvc doesn't generate a *true* async dispatch request; the dispatcher type was still set to `REQUEST`. Fun stuff...