### PR TITLE
unknown host exception in local request

### DIFF
--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LocalRequest.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LocalRequest.java
@@ -1,5 +1,17 @@
 package org.zalando.logbook.httpclient;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.http.util.EntityUtils.toByteArray;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 /*
  * #%L
  * Logbook: HTTP Client
@@ -27,20 +39,8 @@ import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
-import org.apache.http.util.EntityUtils;
 import org.zalando.logbook.Origin;
 import org.zalando.logbook.RawHttpRequest;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.UnknownHostException;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.http.util.EntityUtils.toByteArray;
 
 final class LocalRequest implements RawHttpRequest, org.zalando.logbook.HttpRequest {
 
@@ -84,8 +84,8 @@ final class LocalRequest implements RawHttpRequest, org.zalando.logbook.HttpRequ
     public String getRemote() {
         try {
             return localhost.getAddress();
-        } catch (final UnknownHostException e) {
-            throw new IllegalStateException(e);
+        } catch (@SuppressWarnings("unused") UnknownHostException ex) {
+            return InetAddress.getLoopbackAddress().getHostAddress();
         }
     }
 

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LocalRequestTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LocalRequestTest.java
@@ -1,5 +1,23 @@
 package org.zalando.logbook.httpclient;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.http.util.EntityUtils.toByteArray;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hobsoft.hamcrest.compose.ComposeMatchers.hasFeature;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+
 /*
  * #%L
  * Logbook: HTTP Client
@@ -36,25 +54,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.zalando.logbook.BaseHttpRequest;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.http.util.EntityUtils.toByteArray;
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.matchesPattern;
-import static org.hobsoft.hamcrest.compose.ComposeMatchers.hasFeature;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public final class LocalRequestTest {
 
     @Rule
@@ -83,12 +82,10 @@ public final class LocalRequestTest {
 
     @Test
     public void shouldHandleUnknownHostException() throws UnknownHostException {
+        final LocalRequest unit = new LocalRequest(get("/"), localhost);
         when(localhost.getAddress()).thenThrow(new UnknownHostException());
 
-        exception.expect(IllegalStateException.class);
-        exception.expectCause(instanceOf(UnknownHostException.class));
-
-        unit(get("/")).getRemote();
+        assertThat(unit.getRemote(), unit(get("/")).getRemote(),  matchesPattern("(\\d{1,3}\\.){3}\\d{1,3}"));
     }
 
     @Test


### PR DESCRIPTION
Currently logbook will produce an unknown host exception whenever it cannot resolve the IP address of an host name.

```
Caused by: java.net.UnknownHostException: zalando: zalando: unknown error
	at java.net.InetAddress.getLocalHost(InetAddress.java:1505) ~[?:1.8.0_77]
	at org.zalando.logbook.httpclient.Localhost.getAddress(Localhost.java:29) ~[logbook-httpclient-1.0.0-RC3.jar:?]
	at org.zalando.logbook.httpclient.LocalRequest.getRemote(LocalRequest.java:86) ~[logbook-httpclient-1.0.0-RC3.jar:?]
	... 95 more
Caused by: java.net.UnknownHostException: zalando: unknown error
	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) ~[?:1.8.0_77]
	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:928) ~[?:1.8.0_77]
```

In this cases it may be helpful to provide a fallback to a the link local address to prevent local test servers from failing because of logbook.