### PR TITLE
Customization of HTTP/JSON output

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/DefaultHttpLogFormatter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/DefaultHttpLogFormatter.java
@@ -2,10 +2,10 @@ package org.zalando.logbook;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -14,34 +14,134 @@ import static org.zalando.logbook.Origin.REMOTE;
 
 public final class DefaultHttpLogFormatter implements HttpLogFormatter {
 
-    @Override
-    public String format(final Precorrelation<HttpRequest> precorrelation) throws IOException {
-        final HttpRequest request = precorrelation.getRequest();
-        return format(request, "Request", precorrelation.getId(), this::formatRequestLine);
+    private static final Map<String, String> REASON_PHRASES;
+
+    static {
+        final Map<String, String> phrases = new HashMap<>();
+
+        phrases.put("100", "Continue");
+        phrases.put("101", "Switching Protocols");
+        phrases.put("102", "Processing");
+
+        phrases.put("200", "OK");
+        phrases.put("201", "Created");
+        phrases.put("202", "Accepted");
+        phrases.put("203", "Non-Authoritative Information");
+        phrases.put("204", "No Content");
+        phrases.put("205", "Reset Content");
+        phrases.put("206", "Partial Content");
+        phrases.put("207", "Multi-Status");
+        phrases.put("208", "Already Reported");
+        phrases.put("226", "IM Used");
+
+        phrases.put("300", "Multiple Choices");
+        phrases.put("301", "Moved Permanently");
+        phrases.put("302", "Found");
+        phrases.put("303", "See Other");
+        phrases.put("304", "Not Modified");
+        phrases.put("305", "Use Proxy");
+        phrases.put("306", "Switch Proxy");
+        phrases.put("307", "Temporary Redirect");
+        phrases.put("308", "Permanent Redirect");
+
+        phrases.put("400", "Bad Request");
+        phrases.put("401", "Unauthorized");
+        phrases.put("402", "Payment Required");
+        phrases.put("403", "Forbidden");
+        phrases.put("404", "Not Found");
+        phrases.put("405", "Method Not Allowed");
+        phrases.put("406", "Not Acceptable");
+        phrases.put("407", "Proxy Authentication Required");
+        phrases.put("408", "Request Timeout");
+        phrases.put("409", "Conflict");
+        phrases.put("410", "Gone");
+        phrases.put("411", "Length Required");
+        phrases.put("412", "Precondition Failed");
+        phrases.put("413", "Payload Too Large");
+        phrases.put("414", "URI Too Long");
+        phrases.put("415", "Unsupported Media Type");
+        phrases.put("416", "Requested Range Not Satisfiable");
+        phrases.put("417", "Expectation Failed");
+        phrases.put("418", "I'm a teapot");
+        phrases.put("421", "Misdirected Request");
+        phrases.put("422", "Unprocessable Entity");
+        phrases.put("423", "Locked");
+        phrases.put("424", "Failed Dependency");
+        phrases.put("426", "Upgrade Required");
+        phrases.put("428", "Precondition Required");
+        phrases.put("429", "Too Many Requests");
+        phrases.put("431", "Request Header Fields Too Large");
+        phrases.put("444", "Connection Closed Without Response");
+        phrases.put("451", "Unavailable For Legal Reasons");
+        phrases.put("499", "Client Closed Request");
+
+        phrases.put("500", "Internal Server Error");
+        phrases.put("501", "Not Implemented");
+        phrases.put("502", "Bad Gateway");
+        phrases.put("503", "Service Unavailable");
+        phrases.put("504", "Gateway Timeout");
+        phrases.put("505", "HTTP Version Not Supported");
+        phrases.put("506", "Variant Also Negotiates");
+        phrases.put("507", "Insufficient Storage");
+        phrases.put("508", "Loop Detected");
+        phrases.put("510", "Not Extended");
+        phrases.put("511", "Network Authentication Required");
+        phrases.put("599", "Network Connect Timeout Error");
+
+        REASON_PHRASES = Collections.unmodifiableMap(phrases);
     }
 
-    private String formatRequestLine(final HttpRequest request) {
-        return String.format("%s %s %s", request.getMethod(), request.getRequestUri(), request.getProtocolVersion());
+    @Override
+    public String format(final Precorrelation<HttpRequest> precorrelation) throws IOException {
+        return format(prepare(precorrelation));
+    }
+
+    /**
+     * Produces an HTTP-like request in individual lines.
+     *
+     * @param precorrelation the request correlation
+     * @return a line-separated HTTP request
+     * @throws IOException
+     * @see #prepare(Correlation)
+     * @see #format(List)
+     * @see JsonHttpLogFormatter#prepare(Precorrelation)
+     */
+    public List<String> prepare(final Precorrelation<HttpRequest> precorrelation) throws IOException {
+        final HttpRequest request = precorrelation.getRequest();
+        final String requestLine = String.format("%s %s %s", request.getMethod(), request.getRequestUri(),
+                request.getProtocolVersion());
+        return prepare(request, "Request", precorrelation.getId(), requestLine);
     }
 
     @Override
     public String format(final Correlation<HttpRequest, HttpResponse> correlation) throws IOException {
+        return format(prepare(correlation));
+    }
+
+    /**
+     * Produces an HTTP-like response in individual lines.
+     *
+     * Pr@param correlation the response correlation
+     * @return a line-separated HTTP response
+     * @throws IOException
+     * @see #prepare(Precorrelation)
+     * @see #format(List)
+     * @see JsonHttpLogFormatter#prepare(Correlation)
+     */
+    public List<String> prepare(final Correlation<HttpRequest, HttpResponse> correlation) throws IOException {
         final HttpResponse response = correlation.getResponse();
-        return format(response, "Response", correlation.getId(), this::formatStatusLine);
+        final int status = response.getStatus();
+        final String reasonPhrase = REASON_PHRASES.getOrDefault(Integer.toString(status), "");
+        final String statusLine = String.format("%s %d %s", response.getProtocolVersion(), status, reasonPhrase).trim();
+        return prepare(response, "Response", correlation.getId(), statusLine);
     }
 
-    private String formatStatusLine(final HttpResponse response) {
-        // TODO we are missing the reason phrase here, e.g. "OK", but there is no complete list in the JDK alone
-        return String.format("%s %d", response.getProtocolVersion(), response.getStatus());
-    }
-
-    private <H extends HttpMessage> String format(final H message, final String type, final String correlationId,
-            final Function<H, String> lineCreator)
-            throws IOException {
+    private <H extends HttpMessage> List<String> prepare(final H message, final String type,
+            final String correlationId, final String line) throws IOException {
         final List<String> lines = new ArrayList<>();
 
         lines.add(direction(message) + " " + type + ": " + correlationId);
-        lines.add(lineCreator.apply(message));
+        lines.add(line);
         lines.addAll(formatHeaders(message));
 
         final String body = message.getBodyAsString();
@@ -51,7 +151,7 @@ public final class DefaultHttpLogFormatter implements HttpLogFormatter {
             lines.add(body);
         }
 
-        return join(lines);
+        return lines;
     }
 
     private String direction(final HttpMessage request) {
@@ -74,7 +174,16 @@ public final class DefaultHttpLogFormatter implements HttpLogFormatter {
         return String.format("%s: %s", entry.getKey(), entry.getValue());
     }
 
-    private String join(final Collection<String> lines) {
+    /**
+     * Renders an HTTP-like message into a printable string.
+     *
+     * @param lines lines of an HTTP message
+     * @return the whole message as a single string, separated by new lines
+     * @see #prepare(Precorrelation)
+     * @see #prepare(Correlation)
+     * @see JsonHttpLogFormatter#format(Map)
+     */
+    public String format(final List<String> lines) {
         return lines.stream().collect(joining("\n"));
     }
 

--- a/logbook-core/src/main/java/org/zalando/logbook/JsonHttpLogFormatter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/JsonHttpLogFormatter.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -37,6 +38,16 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
         return format(prepare(precorrelation));
     }
 
+    /**
+     * Produces a map of individual properties from an HTTP request.
+     *
+     * @param precorrelation the request correlation
+     * @return a map containing HTTP request attributes
+     * @throws IOException
+     * @see #prepare(Correlation)
+     * @see #format(Map)
+     * @see DefaultHttpLogFormatter#prepare(Precorrelation)
+     */
     public Map<String, Object> prepare(final Precorrelation<HttpRequest> precorrelation) throws IOException {
         final String correlationId = precorrelation.getId();
         final HttpRequest request = precorrelation.getRequest();
@@ -62,6 +73,16 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
         return format(prepare(correlation));
     }
 
+    /**
+     * Produces a map of individual properties from an HTTP response.
+     *
+     * @param correlation the response correlation
+     * @return a map containing HTTP response attributes
+     * @throws IOException
+     * @see #prepare(Correlation)
+     * @see #format(Map)
+     * @see DefaultHttpLogFormatter#prepare(Correlation)
+     */
     public Map<String, Object> prepare(final Correlation<HttpRequest, HttpResponse> correlation) throws IOException {
         final String correlationId = correlation.getId();
         final HttpResponse response = correlation.getResponse();
@@ -111,9 +132,8 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
             return new JsonBody(compactJson(body));
         } catch (final IOException e) {
             LOG.trace("Unable to parse body as JSON; embedding it as-is", e);
+            return body;
         }
-
-        return body;
     }
 
     private boolean isJson(final String type) {
@@ -168,6 +188,16 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
 
     }
 
+    /**
+     * Renders properties of an HTTP message into a JSON string.
+     *
+     * @param content individual parts of an HTTP message
+     * @return the whole message as a JSON object
+     * @throws IOException
+     * @see #prepare(Precorrelation)
+     * @see #prepare(Correlation)
+     * @see DefaultHttpLogFormatter#format(List)
+     */
     public String format(final Map<String, Object> content) throws IOException {
         return mapper.writeValueAsString(content);
     }

--- a/logbook-core/src/main/java/org/zalando/logbook/JsonHttpLogFormatter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/JsonHttpLogFormatter.java
@@ -34,6 +34,10 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
 
     @Override
     public String format(final Precorrelation<HttpRequest> precorrelation) throws IOException {
+        return format(prepare(precorrelation));
+    }
+
+    public Map<String, Object> prepare(final Precorrelation<HttpRequest> precorrelation) throws IOException {
         final String correlationId = precorrelation.getId();
         final HttpRequest request = precorrelation.getRequest();
 
@@ -50,11 +54,15 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
         addUnless(content, "headers", request.getHeaders(), Map::isEmpty);
         addBody(request, content);
 
-        return mapper.writeValueAsString(content);
+        return content;
     }
 
     @Override
     public String format(final Correlation<HttpRequest, HttpResponse> correlation) throws IOException {
+        return format(prepare(correlation));
+    }
+
+    public Map<String, Object> prepare(final Correlation<HttpRequest, HttpResponse> correlation) throws IOException {
         final String correlationId = correlation.getId();
         final HttpResponse response = correlation.getResponse();
 
@@ -65,10 +73,11 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
         content.put("correlation", correlationId);
         content.put("protocol", response.getProtocolVersion());
         content.put("status", response.getStatus());
+
         addUnless(content, "headers", response.getHeaders(), Map::isEmpty);
         addBody(response, content);
 
-        return mapper.writeValueAsString(content);
+        return content;
     }
 
     private static String translate(final Origin origin) {
@@ -157,6 +166,10 @@ public final class JsonHttpLogFormatter implements HttpLogFormatter {
             return json;
         }
 
+    }
+
+    public String format(final Map<String, Object> content) throws IOException {
+        return mapper.writeValueAsString(content);
     }
 
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
@@ -83,6 +83,7 @@ public final class DefaultHttpLogFormatterTest {
         final HttpResponse response = response()
                 .protocolVersion("HTTP/1.0")
                 .origin(Origin.REMOTE)
+                .status(201)
                 .headers(MockHeaders.of("Content-Type", "application/json"))
                 .body("{\"success\":true}")
                 .build();
@@ -90,7 +91,7 @@ public final class DefaultHttpLogFormatterTest {
         final String http = unit.format(new SimpleCorrelation<>(correlationId, request, response));
 
         assertThat(http, is("Incoming Response: 2d51bc02-677e-11e5-8b9b-10ddb1ee7671\n" +
-                "HTTP/1.0 200\n" +
+                "HTTP/1.0 201 Created\n" +
                 "Content-Type: application/json\n" +
                 "\n" +
                 "{\"success\":true}"));
@@ -102,13 +103,14 @@ public final class DefaultHttpLogFormatterTest {
         final HttpRequest request = MockHttpRequest.create();
         final HttpResponse response = response()
                 .origin(Origin.LOCAL)
+                .status(400)
                 .headers(MockHeaders.of("Content-Type", "application/json"))
                 .build();
 
         final String http = unit.format(new SimpleCorrelation<>(correlationId, request, response));
 
         assertThat(http, is("Outgoing Response: 3881ae92-6824-11e5-921b-10ddb1ee7671\n" +
-                "HTTP/1.1 200\n" +
+                "HTTP/1.1 400 Bad Request\n" +
                 "Content-Type: application/json"));
     }
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/WritingTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/WritingTest.java
@@ -86,7 +86,7 @@ public final class WritingTest {
 
         assertThat(correlation.getResponse(), startsWith("Outgoing Response:"));
         assertThat(correlation.getResponse(), endsWith(
-                "HTTP/1.1 200\n" +
+                "HTTP/1.1 200 OK\n" +
                         "Content-Type: application/json;charset=UTF-8\n" +
                         "\n" +
                         "{\"value\":\"Hello, world!\"}"));


### PR DESCRIPTION
Fixes #114 
@kakawait

Adds public `prepare` and `format` methods to the `Default`- and `JsonHttpLogFormatter`. Prepare returns a data structure that can be modified (`List<String>` and `Map<String, Object>` respectively). The format method renders the corresponding data structure into a string.

The intended use case is to write a custom formatter that has an instance of one of those two and uses it to generate and customize the output.