### PR TITLE
Added possibility to delay logging of requests until response can be inspected

### DIFF
--- a/logbook-api/src/main/java/org/zalando/logbook/Correlation.java
+++ b/logbook-api/src/main/java/org/zalando/logbook/Correlation.java
@@ -12,4 +12,8 @@ public interface Correlation<Request, Response> {
 
     Response getResponse();
 
+    HttpRequest getOriginalRequest();
+
+    HttpResponse getOriginalResponse();
+
 }

--- a/logbook-core/src/main/java/org/zalando/logbook/ChunkingHttpLogWriter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/ChunkingHttpLogWriter.java
@@ -23,7 +23,7 @@ public final class ChunkingHttpLogWriter implements HttpLogWriter {
         if (size <= 0) {
             throw new IllegalArgumentException("size is expected to be greater than zero");
         }
-        this.minChunkSize = (size > MIN_MAX_DELTA ? size - MIN_MAX_DELTA : size);
+        this.minChunkSize = size > MIN_MAX_DELTA ? size - MIN_MAX_DELTA : size;
         this.maxChunkSize = size;
         this.writer = writer;
     }
@@ -42,8 +42,13 @@ public final class ChunkingHttpLogWriter implements HttpLogWriter {
     @Override
     public void writeResponse(final Correlation<String, String> correlation) throws IOException {
         split(correlation.getResponse()).forEach(throwing(part ->
-                writer.writeResponse(new SimpleCorrelation<>(correlation.getId(), correlation.getDuration(),
-                        correlation.getRequest(), part))));
+                writer.writeResponse(new SimpleCorrelation<>(
+                        correlation.getId(),
+                        correlation.getDuration(),
+                        correlation.getRequest(),
+                        part,
+                        correlation.getOriginalRequest(),
+                        correlation.getOriginalResponse()))));
     }
 
     private static <T> Consumer<T> throwing(final ThrowingConsumer<T> consumer) {

--- a/logbook-core/src/main/java/org/zalando/logbook/DefaultLogbook.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/DefaultLogbook.java
@@ -54,9 +54,9 @@ final class DefaultLogbook implements Logbook {
                 final RawHttpResponse filteredRawHttpResponse = rawResponseFilter.filter(rawHttpResponse);
                 final HttpResponse response = responseFilter.filter(filteredRawHttpResponse.withBody());
                 final Correlation<HttpRequest, HttpResponse> correlation =
-                        new SimpleCorrelation<>(correlationId, duration, request, response);
+                        new SimpleCorrelation<>(correlationId, duration, request, response, request, response);
                 final String message = formatter.format(correlation);
-                writer.writeResponse(new SimpleCorrelation<>(correlationId, duration, format, message));
+                writer.writeResponse(new SimpleCorrelation<>(correlationId, duration, format, message, request, response));
             });
         } else {
             return Optional.empty();
@@ -91,12 +91,17 @@ final class DefaultLogbook implements Logbook {
         private final Duration duration;
         private final I request;
         private final O response;
+        private final HttpRequest originalRequest;
+        private final HttpResponse originalResponse;
 
-        public SimpleCorrelation(final String id, final Duration duration, final I request, final O response) {
+        SimpleCorrelation(final String id, final Duration duration, final I request, final O response,
+                final HttpRequest originalRequest, final HttpResponse originalResponse) {
             this.id = id;
             this.duration = duration;
             this.request = request;
             this.response = response;
+            this.originalRequest = originalRequest;
+            this.originalResponse = originalResponse;
         }
 
         @Override
@@ -117,6 +122,16 @@ final class DefaultLogbook implements Logbook {
         @Override
         public O getResponse() {
             return response;
+        }
+
+        @Override
+        public HttpRequest getOriginalRequest() {
+            return originalRequest;
+        }
+
+        @Override
+        public HttpResponse getOriginalResponse() {
+            return originalResponse;
         }
 
     }

--- a/logbook-core/src/test/java/org/zalando/logbook/ChunkingHttpLogWriterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/ChunkingHttpLogWriterTest.java
@@ -85,7 +85,8 @@ public final class ChunkingHttpLogWriterTest {
     }
 
     private List<String> captureResponse(final String response) throws IOException {
-        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("id", ZERO, "", response));
+        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("id", ZERO, "", response,
+                MockHttpRequest.create(), MockHttpResponse.create()));
 
         verify(delegate, atLeastOnce()).writeResponse(responseCaptor.capture());
 

--- a/logbook-core/src/test/java/org/zalando/logbook/CurlHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/CurlHttpLogFormatterTest.java
@@ -70,8 +70,11 @@ public final class CurlHttpLogFormatterTest {
         final HttpLogFormatter fallback = mock(HttpLogFormatter.class);
         final HttpLogFormatter unit = new CurlHttpLogFormatter(fallback);
 
+        final MockHttpRequest request = MockHttpRequest.create();
+        final MockHttpResponse response = MockHttpResponse.create();
+
         final Correlation<HttpRequest, HttpResponse> correlation = new SimpleCorrelation<>(
-                "3881ae92-6824-11e5-921b-10ddb1ee7671", ZERO, MockHttpRequest.create(), MockHttpResponse.create());
+                "3881ae92-6824-11e5-921b-10ddb1ee7671", ZERO, request, response, request, response);
 
         unit.format(correlation);
 

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
@@ -5,7 +5,6 @@ import org.zalando.logbook.DefaultLogbook.SimpleCorrelation;
 import org.zalando.logbook.DefaultLogbook.SimplePrecorrelation;
 
 import java.io.IOException;
-import java.time.Duration;
 
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.Matchers.is;
@@ -84,7 +83,8 @@ public final class DefaultHttpLogFormatterTest {
                 .withHeaders(MockHeaders.of("Content-Type", "application/json"))
                 .withBodyAsString("{\"success\":true}");
 
-        final String http = unit.format(new SimpleCorrelation<>(correlationId, ofMillis(125), request, response));
+        final String http = unit.format(new SimpleCorrelation<>(correlationId, ofMillis(125), request, response,
+                request, response));
 
         assertThat(http, is("Incoming Response: 2d51bc02-677e-11e5-8b9b-10ddb1ee7671\n" +
                 "Duration: 125 ms\n" +
@@ -103,7 +103,8 @@ public final class DefaultHttpLogFormatterTest {
                 .withStatus(400)
                 .withHeaders(MockHeaders.of("Content-Type", "application/json"));
 
-        final String http = unit.format(new SimpleCorrelation<>(correlationId, ofMillis(100), request, response));
+        final String http = unit.format(new SimpleCorrelation<>(correlationId, ofMillis(100), request, response,
+                request, response));
 
         assertThat(http, is("Outgoing Response: 3881ae92-6824-11e5-921b-10ddb1ee7671\n" +
                 "Duration: 100 ms\n" +

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogWriterLevelTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogWriterLevelTest.java
@@ -68,7 +68,8 @@ public final class DefaultHttpLogWriterLevelTest {
 
     @Test
     public void shouldLogResponseWithCorrectLevel() throws IOException {
-        unit.writeResponse(new SimpleCorrelation<>("1", ZERO, "foo", "bar"));
+        unit.writeResponse(new SimpleCorrelation<>("1", ZERO, "foo", "bar",
+                MockHttpRequest.create(), MockHttpResponse.create()));
 
         log.accept(verify(logger), "bar");
     }

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogWriterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogWriterTest.java
@@ -48,7 +48,8 @@ public final class DefaultHttpLogWriterTest {
         final Logger logger = mock(Logger.class);
         final HttpLogWriter unit = new DefaultHttpLogWriter(logger);
 
-        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("1", ZERO, "foo", "bar"));
+        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("1", ZERO, "foo", "bar",
+                MockHttpRequest.create(), MockHttpResponse.create()));
 
         verify(logger).trace("bar");
     }

--- a/logbook-core/src/test/java/org/zalando/logbook/DelayedResponseLogWriter.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DelayedResponseLogWriter.java
@@ -1,0 +1,32 @@
+package org.zalando.logbook;
+
+import org.zalando.logbook.DefaultLogbook.SimplePrecorrelation;
+
+import java.io.IOException;
+
+// proof of concept
+final class DelayedResponseLogWriter implements HttpLogWriter {
+
+    private final HttpLogWriter delegate;
+
+    DelayedResponseLogWriter(final HttpLogWriter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void writeRequest(final Precorrelation<String> precorrelation) throws IOException {
+        // do nothing
+    }
+
+    @Override
+    public void writeResponse(final Correlation<String, String> correlation) throws IOException {
+        final HttpResponse response = correlation.getOriginalResponse();
+
+        if (response.getStatus() >= 400) {
+            // delayed request logging until we have the response at hand
+            delegate.writeRequest(new SimplePrecorrelation<>(correlation.getId(), correlation.getRequest()));
+            delegate.writeResponse(correlation);
+        }
+    }
+
+}

--- a/logbook-core/src/test/java/org/zalando/logbook/DelayedResponseLogWriterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DelayedResponseLogWriterTest.java
@@ -1,0 +1,31 @@
+package org.zalando.logbook;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public final class DelayedResponseLogWriterTest {
+
+    private final HttpLogWriter delegate = Mockito.mock(HttpLogWriter.class);
+    private final HttpLogWriter unit = new DelayedResponseLogWriter(delegate);
+
+    @Test
+    public void shouldDelayRequestLogging() throws IOException {
+        final Logbook logbook = Logbook.builder().writer(unit).build();
+
+        final Correlator correlator = logbook.write(MockRawHttpRequest.create()).orElseThrow(AssertionError::new);
+
+        verify(delegate, never()).writeRequest(any());
+
+        correlator.write(MockRawHttpResponse.create().withStatus(404));
+
+        verify(delegate).writeRequest(any());
+        verify(delegate).writeResponse(any());
+    }
+
+}

--- a/logbook-core/src/test/java/org/zalando/logbook/JsonHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/JsonHttpLogFormatterTest.java
@@ -5,7 +5,6 @@ import org.zalando.logbook.DefaultLogbook.SimpleCorrelation;
 import org.zalando.logbook.DefaultLogbook.SimplePrecorrelation;
 
 import java.io.IOException;
-import java.time.Duration;
 
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.time.Duration.ZERO;
@@ -243,7 +242,8 @@ public final class JsonHttpLogFormatterTest {
                 .withContentType("application/xml")
                 .withBodyAsString("<success>true<success>");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ofMillis(125), request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ofMillis(125), request, response,
+                request, response));
 
         with(json)
                 .assertThat("$.origin", is("local"))
@@ -263,7 +263,8 @@ public final class JsonHttpLogFormatterTest {
         final HttpRequest request = MockHttpRequest.create();
         final HttpResponse response = create();
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, 
+                request, response));
 
         with(json)
                 .assertThat("$", not(hasKey("headers")));
@@ -277,7 +278,8 @@ public final class JsonHttpLogFormatterTest {
         final HttpResponse response = create()
                 .withBodyAsString("");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, request,
+                response));
 
         with(json)
                 .assertThat("$", not(hasKey("body")));
@@ -291,7 +293,8 @@ public final class JsonHttpLogFormatterTest {
                 .withContentType("application/json")
                 .withBodyAsString("{\"name\":\"Bob\"}");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, 
+                request, response));
 
         with(json)
                 .assertThat("$.body.name", is("Bob"));
@@ -305,7 +308,8 @@ public final class JsonHttpLogFormatterTest {
                 .withContentType("application/json")
                 .withBodyAsString("{\n  \"name\": \"Bob\"\n}");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, request,
+                response));
 
         assertThat(json, containsString("{\"name\":\"Bob\"}"));
     }
@@ -318,7 +322,8 @@ public final class JsonHttpLogFormatterTest {
                 .withContentType("application/custom+json")
                 .withBodyAsString("{\"name\":\"Bob\"}");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, request,
+                response));
 
         with(json)
                 .assertThat("$.body.name", is("Bob"));
@@ -332,7 +337,8 @@ public final class JsonHttpLogFormatterTest {
                 .withContentType("text/custom+json")
                 .withBodyAsString("{\"name\":\"Bob\"}");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, request,
+                response));
 
         with(json)
                 .assertThat("$.body", is("{\"name\":\"Bob\"}"));
@@ -345,7 +351,8 @@ public final class JsonHttpLogFormatterTest {
         final HttpResponse response = create()
                 .withContentType("application/json");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, request,
+                response));
 
         with(json)
                 .assertThat("$.body", is(emptyString()));
@@ -359,7 +366,8 @@ public final class JsonHttpLogFormatterTest {
                 .withContentType("text/custom+json")
                 .withBodyAsString("{\n \"name\":\"Bob\";;;\n;}");
 
-        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response));
+        final String json = unit.format(new SimpleCorrelation<>(correlationId, ZERO, request, response, request,
+                response));
 
         with(json)
                 .assertThat("$.body", is("{\n \"name\":\"Bob\";;;\n;}"));

--- a/logbook-core/src/test/java/org/zalando/logbook/StreamHttpLogWriterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/StreamHttpLogWriterTest.java
@@ -45,7 +45,8 @@ public final class StreamHttpLogWriterTest {
         final PrintStream stream = mock(PrintStream.class);
         final HttpLogWriter unit = new StreamHttpLogWriter(stream);
 
-        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("1", ZERO, "foo", "bar"));
+        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("1", ZERO, "foo", "bar", MockHttpRequest.create(),
+                MockHttpResponse.create()));
 
         verify(stream).println("bar");
     }
@@ -63,7 +64,8 @@ public final class StreamHttpLogWriterTest {
     public void shouldResponseToStdoutByDefault() throws IOException {
         final HttpLogWriter unit = new StreamHttpLogWriter();
 
-        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("1", ZERO, "foo", "bar"));
+        unit.writeResponse(new DefaultLogbook.SimpleCorrelation<>("1", ZERO, "foo", "bar", MockHttpRequest.create(),
+                MockHttpResponse.create()));
 
         assertThat(stdout.getLog(), is("bar" + lineSeparator()));
     }


### PR DESCRIPTION
As a side effect a writer now has access to the request/response object in case any decisions need to be taken based on them.

Fixes #165