### PR TITLE
Fix NPE in header condition, when given header not found

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/Conditions.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/Conditions.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
 import static org.zalando.logbook.RequestURI.Component.AUTHORITY;
 import static org.zalando.logbook.RequestURI.Component.PATH;
 import static org.zalando.logbook.RequestURI.Component.SCHEME;
@@ -56,8 +57,9 @@ public final class Conditions {
     }
 
     public static <T extends BaseHttpMessage> Predicate<T> header(final String key, final Predicate<String> predicate) {
-        return message ->
-                message.getHeaders().get(key).stream().anyMatch(predicate);
+        return message -> ofNullable(message.getHeaders().get(key))
+                .map(hv -> hv.stream().anyMatch(predicate))
+                .orElse(predicate.test(null));
     }
 
     public static <T extends BaseHttpMessage> Predicate<T> header(final BiPredicate<String, String> predicate) {

--- a/logbook-core/src/test/java/org/zalando/logbook/ConditionsTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/ConditionsTest.java
@@ -2,6 +2,7 @@ package org.zalando.logbook;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
@@ -108,6 +109,13 @@ public final class ConditionsTest {
     @Test
     void headerShouldMatchNameAndValuePredicate() {
         final Predicate<BaseHttpMessage> unit = header("X-Secret", asList("true", "1")::contains);
+
+        assertThat(unit.test(request), is(true));
+    }
+
+    @Test
+    void headerShouldMatchNameAndValuePredicateWhenNull() {
+        final Predicate<BaseHttpMessage> unit = header("X-Nonexistent", Objects::isNull);
 
         assertThat(unit.test(request), is(true));
     }


### PR DESCRIPTION
The issue I ran into when using logbook, is that it was easy to check that a given header contains some value, but it was not so easy to check that a header was absent. Which I assume is quite often the case.

I tried to do this:
```java
header(MY_HEADER_NAME, Objects::isNull)
```
But got an NPE. This syntax seems totally correct, because this works, for example, when the header is there:
```java
header(MY_HEADER_NAME, StringUtils::isNotBlank)
```

I had to use this syntax to fulfill my goal, which looks a little bit too ugly for such a basic use-case:
```java
header((key, value) -> key.equals(MY_HEADER_NAME) && value == null)
```

Therefore I decided to fix this. Did I misunderstand something, or is it actually a good use case?

Anyway, here's a PR in a TDD style: first commit adds a breaking test, while second commit fixes the NPE in production code. Feel free to squash via GitHub when merging.

_P.S. Hi, Willi!_