### PR TITLE
First draft of Servlet 2.5 support

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncSupport.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncSupport.java
@@ -1,0 +1,14 @@
+package org.zalando.logbook.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+
+interface AsyncSupport {
+
+    AsyncSupport INSTANCE = ClassPath.load("javax.servlet.DispatcherType",
+            Servlet3AsyncSupport::new, Servlet25AsyncSupport::new);
+
+    boolean isFirstRequest(HttpServletRequest request);
+
+    boolean isLastRequest(HttpServletRequest request);
+
+}

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/ClassPath.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/ClassPath.java
@@ -1,0 +1,20 @@
+package org.zalando.logbook.servlet;
+
+import java.util.function.Supplier;
+
+final class ClassPath {
+
+    static <T> T load(final String name, final Supplier<? extends T> present, final Supplier<? extends T> absent) {
+        return exists(name) ? present.get() : absent.get();
+    }
+
+    private static boolean exists(final String name) {
+        try {
+            Class.forName(name);
+            return true;
+        } catch (final ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -13,10 +13,10 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -175,7 +175,7 @@ final class LocalResponse extends HttpServletResponseWrapper implements RawHttpR
     }
 
     private String format(final long date) {
-        return new Date(date).toInstant().atZone(ZoneId.of("GMT"))
+        return Instant.ofEpochMilli(date).atZone(ZoneId.of("GMT"))
                 .format(DateTimeFormatter.RFC_1123_DATE_TIME);
     }
 

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -1,22 +1,26 @@
 package org.zalando.logbook.servlet;
 
-import org.zalando.logbook.HttpResponse;
-import org.zalando.logbook.Origin;
-import org.zalando.logbook.RawHttpResponse;
-
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.function.Supplier;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.Origin;
+import org.zalando.logbook.RawHttpResponse;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -26,6 +30,16 @@ final class LocalResponse extends HttpServletResponseWrapper implements RawHttpR
 
     private boolean withBody;
     private Tee tee;
+
+    /**
+     * All the code connected to this field is to allow for compatibility with Servlet API 2.5
+     */
+    private int status = 200;
+
+    /**
+     * All the code connected to this field is to allow for compatibility with Servlet API 2.5
+     */
+    private final Map<String, List<String>> headers = new HashMap<>();
 
     LocalResponse(final HttpServletResponse response, final String protocolVersion) throws IOException {
         super(response);
@@ -46,11 +60,9 @@ final class LocalResponse extends HttpServletResponseWrapper implements RawHttpR
     @Override
     public Map<String, List<String>> getHeaders() {
         final HeadersBuilder builder = new HeadersBuilder();
-
-        for (final String header : getHeaderNames()) {
-            builder.put(header, getHeaders(header));
+        for (final String header : headers.keySet()) {
+            builder.put(header, headers.get(header));
         }
-
         return builder.build();
     }
 
@@ -106,6 +118,82 @@ final class LocalResponse extends HttpServletResponseWrapper implements RawHttpR
             tee = new Tee(super.getOutputStream());
         }
         return tee;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public void setStatus(final int status) {
+        this.status = status;
+        super.setStatus(status);
+    }
+
+    @Override
+    public void sendError(final int status) throws IOException {
+        this.status = status;
+        super.sendError(status);
+    }
+
+    @Override
+    public void sendError(final int status, final String msg) throws IOException {
+        this.status = status;
+        super.sendError(status, msg);
+    }
+
+    @Override
+    public void addDateHeader(final String name, final long date) {
+        super.addDateHeader(name, date);
+        addMultiMapHeader(name, format(date));
+    }
+
+    @Override
+    public void addHeader(final String name, final String value) {
+        super.addHeader(name, value);
+        addMultiMapHeader(name, value);
+    }
+
+    @Override
+    public void addIntHeader(final String name, final int value) {
+        super.addIntHeader(name, value);
+        addMultiMapHeader(name, String.valueOf(value));
+    }
+
+    @Override
+    public void setHeader(final String name, final String value) {
+        super.setHeader(name, value);
+        setMultiMapHeader(name, value);
+    }
+
+    @Override
+    public void setDateHeader(final String name, final long date) {
+        super.setDateHeader(name, date);
+        setMultiMapHeader(name, format(date));
+    }
+
+    private String format(final long date) {
+        return new Date(date).toInstant().atZone(ZoneId.of("GMT"))
+                .format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    }
+
+    @Override
+    public void setIntHeader(final String name, final int value) {
+        super.setIntHeader(name, value);
+        setMultiMapHeader(name, String.valueOf(value));
+    }
+
+    private void addMultiMapHeader(final String name, final String value) {
+        final List<String> values = headers.computeIfAbsent(name, key -> new ArrayList<>());
+        values.add(value);
+    }
+
+    private void setMultiMapHeader(final String name, final String value) {
+        headers.remove(name);
+        final ArrayList<String> values = new ArrayList<>();
+        values.add(value);
+        headers.put(name, values);
     }
 
     private static class Tee {

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -1,26 +1,27 @@
 package org.zalando.logbook.servlet;
 
+import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.Origin;
+import org.zalando.logbook.RawHttpResponse;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
-
-import org.zalando.logbook.HttpResponse;
-import org.zalando.logbook.Origin;
-import org.zalando.logbook.RawHttpResponse;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/NormalStrategy.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/NormalStrategy.java
@@ -13,10 +13,14 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static javax.servlet.RequestDispatcher.ERROR_EXCEPTION_TYPE;
 import static org.zalando.logbook.servlet.Attributes.CORRELATOR;
 
 final class NormalStrategy implements Strategy {
+
+    /**
+     * Do not use RequestDispatcher.ERROR_EXCEPTION_TYPE, since Servlet API 2.5 does not have this constant.
+     */
+    private static final String JAVAX_SERVLET_ERROR_EXCEPTION_TYPE = "javax.servlet.error.exception_type";
 
     private final RawRequestFilter filter;
 
@@ -55,7 +59,7 @@ final class NormalStrategy implements Strategy {
     }
 
     private RawHttpRequest skipBodyIfErrorDispatch(final RemoteRequest request) {
-        if (request.getAttribute(ERROR_EXCEPTION_TYPE) == null) {
+        if (request.getAttribute(JAVAX_SERVLET_ERROR_EXCEPTION_TYPE) == null) {
             return request;
         }
         return filter.filter(request);

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/RemoteRequest.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/RemoteRequest.java
@@ -69,6 +69,7 @@ final class RemoteRequest extends HttpServletRequestWrapper implements RawHttpRe
         return Optional.ofNullable(getQueryString()).orElse("");
     }
 
+    @SuppressWarnings("unchecked") // warnings appear when using Servlet API 2.5
     @Override
     public Map<String, List<String>> getHeaders() {
         final HeadersBuilder builder = new HeadersBuilder();

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecurityStrategy.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecurityStrategy.java
@@ -46,7 +46,7 @@ final class SecurityStrategy implements Strategy {
         }
     }
 
-    private boolean isUnauthorized(final HttpServletResponse response) {
+    private boolean isUnauthorized(final LocalResponse response) {
         return response.getStatus() == 401;
     }
 

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/Servlet25AsyncSupport.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/Servlet25AsyncSupport.java
@@ -1,0 +1,17 @@
+package org.zalando.logbook.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class Servlet25AsyncSupport implements AsyncSupport {
+
+    @Override
+    public boolean isFirstRequest(final HttpServletRequest request) {
+        return true;
+    }
+
+    @Override
+    public boolean isLastRequest(final HttpServletRequest request) {
+        return true;
+    }
+
+}

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/Servlet3AsyncSupport.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/Servlet3AsyncSupport.java
@@ -1,0 +1,18 @@
+package org.zalando.logbook.servlet;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.http.HttpServletRequest;
+
+public class Servlet3AsyncSupport implements AsyncSupport {
+
+    @Override
+    public boolean isFirstRequest(final HttpServletRequest request) {
+        return request.getDispatcherType() != DispatcherType.ASYNC;
+    }
+
+    @Override
+    public boolean isLastRequest(final HttpServletRequest request) {
+        return !request.isAsyncStarted();
+    }
+
+}

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/Strategy.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/Strategy.java
@@ -2,7 +2,6 @@ package org.zalando.logbook.servlet;
 
 import org.zalando.logbook.Logbook;
 
-import javax.servlet.DispatcherType;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -20,13 +19,11 @@ public interface Strategy {
             final FilterChain chain) throws ServletException, IOException;
 
     default boolean isFirstRequest(final HttpServletRequest request) {
-        return request.getDispatcherType() != DispatcherType.ASYNC;
+        return AsyncSupport.INSTANCE.isFirstRequest(request);
     }
 
     default boolean isLastRequest(final HttpServletRequest request) {
-        return !request.isAsyncStarted();
+        return AsyncSupport.INSTANCE.isLastRequest(request);
     }
-
-
 }
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ClassPathTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ClassPathTest.java
@@ -1,0 +1,20 @@
+package org.zalando.logbook.servlet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.zalando.logbook.servlet.ClassPath.load;
+
+class ClassPathTest {
+
+    @Test
+    void shouldLoadIfPresent() {
+        assertEquals("yes", load("java.lang.String", () -> "yes", () -> "no"));
+    }
+
+    @Test
+    void shouldLoadIfAbsent() {
+        assertEquals("no", load("java.lang.Unknown", () -> "yes", () -> "no"));
+    }
+
+}

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ClassPathTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ClassPathTest.java
@@ -2,7 +2,7 @@ package org.zalando.logbook.servlet;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.zalando.logbook.servlet.ClassPath.load;
 
 class ClassPathTest {

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/EnforceCoverageTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/EnforceCoverageTest.java
@@ -14,6 +14,11 @@ import static org.mockito.Mockito.mock;
 public final class EnforceCoverageTest {
 
     @Test
+    void shouldUseClassPathConstructor() {
+        new ClassPath();
+    }
+
+    @Test
     void shouldCreateLogbookFilter() {
         new LogbookFilter();
     }

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LocalResponseTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LocalResponseTest.java
@@ -8,7 +8,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -119,5 +121,87 @@ public class LocalResponseTest {
         when(mock.getContentType()).thenReturn(null);
 
         assertThat(unit.getContentType(), is(nullValue()));
+    }
+
+    @Test
+    void defaultStatusIs200() {
+        assertThat(unit.getStatus(), is(200));
+    }
+
+    @Test
+    void shouldSetStatus() {
+        unit.setStatus(300);
+
+        verify(mock).setStatus(300);
+        assertThat(unit.getStatus(), is(300));
+    }
+
+    @Test
+    void shouldSendErrorWithNoMessage() throws IOException {
+        unit.sendError(403);
+
+        verify(mock).sendError(403);
+        assertThat(unit.getStatus(), is(403));
+    }
+
+    @Test
+    void shouldSendErrorWithAMessage() throws IOException {
+        unit.sendError(403, "There is an error");
+
+        verify(mock).sendError(403, "There is an error");
+        assertThat(unit.getStatus(), is(403));
+    }
+
+    @Test
+    void shouldAddDateHeader() {
+        unit.addDateHeader("date", 111111);
+
+        verify(mock).addDateHeader("date", 111111);
+        assertThat(unit.getHeaders(), hasEntry("date", singletonList("Thu, 1 Jan 1970 00:01:51 GMT")));
+    }
+
+    @Test
+    void shouldAddHeader() {
+        unit.addHeader("example", "value");
+
+        verify(mock).addHeader("example", "value");
+        assertThat(unit.getHeaders(), hasEntry("example", singletonList("value")));
+    }
+
+    @Test
+    void shouldAddIntegerHeader() {
+        unit.addIntHeader("example", 123);
+
+        verify(mock).addIntHeader("example", 123);
+        assertThat(unit.getHeaders(), hasEntry("example", singletonList("123")));
+    }
+
+    @Test
+    void shouldSetHeader() {
+        unit.addHeader("example", "first value");
+        unit.setHeader("example", "Overwritten value");
+
+
+        verify(mock).setHeader("example", "Overwritten value");
+        assertThat(unit.getHeaders(), hasEntry("example", singletonList("Overwritten value")));
+    }
+
+    @Test
+    void shouldSetDateHeader() {
+        unit.addDateHeader("example", 111111);
+        unit.setDateHeader("example", 333333);
+
+        verify(mock).setDateHeader("example", 333333);
+        assertThat(unit.getHeaders(), hasEntry("example", singletonList("Thu, 1 Jan 1970 00:05:33 GMT")));
+    }
+
+    @Test
+    void shouldSetIntegerHeader() {
+        unit.addIntHeader("example", 111);
+        unit.setIntHeader("example", 4546);
+
+
+        verify(mock).setIntHeader("example", 4546);
+        assertThat(unit.getHeaders(), hasEntry("example", singletonList("4546")));
     }
 }

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/Servlet25AsyncSupportTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/Servlet25AsyncSupportTest.java
@@ -1,0 +1,26 @@
+package org.zalando.logbook.servlet;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class Servlet25AsyncSupportTest {
+
+    private final AsyncSupport unit = new Servlet25AsyncSupport();
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+    @Test
+    void isFirstRequest() {
+        assertTrue(unit.isFirstRequest(request));
+    }
+
+    @Test
+    void isLastRequest() {
+        assertTrue(unit.isLastRequest(request));
+    }
+
+}

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/Servlet25AsyncSupportTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/Servlet25AsyncSupportTest.java
@@ -1,11 +1,10 @@
 package org.zalando.logbook.servlet;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class Servlet25AsyncSupportTest {


### PR DESCRIPTION
Fixes #172 
Replaces #174 

@hanfak I made your tests pass and changed the implementation from being reflection-based to two distinct implementations. Code is 100% covered, but I can't verify it reliably against servlet api 2.5 since that would require to rewrite almost all tests from the logbook-servlet module.