### PR TITLE
SecurityStrategy supporting 403 (#219)

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecurityStrategy.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecurityStrategy.java
@@ -31,7 +31,7 @@ final class SecurityStrategy implements Strategy {
 
         chain.doFilter(request, response);
 
-        if (isUnauthorized(response)) {
+        if (isUnauthorizedOrForbibben(response)) {
             final Optional<Correlator> correlator;
 
             if (isFirstRequest(request)) {
@@ -46,7 +46,7 @@ final class SecurityStrategy implements Strategy {
         }
     }
 
-    private boolean isUnauthorized(final HttpServletResponse response) {
+    private boolean isUnauthorizedOrForbibben(final HttpServletResponse response) {
         final int status = response.getStatus();
         return status == 401 || status == 403;
     }

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecurityStrategy.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecurityStrategy.java
@@ -47,7 +47,8 @@ final class SecurityStrategy implements Strategy {
     }
 
     private boolean isUnauthorized(final HttpServletResponse response) {
-        return response.getStatus() == 401;
+        final int status = response.getStatus();
+        return status == 401 || status == 403;
     }
 
     private Optional<Correlator> readCorrelator(final RemoteRequest request) {

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/MultiFilterSecurityTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/MultiFilterSecurityTest.java
@@ -2,6 +2,8 @@ package org.zalando.logbook.servlet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -146,47 +148,52 @@ public final class MultiFilterSecurityTest {
         return captor.getValue();
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
     @SuppressWarnings("unchecked")
-    void shouldFormatUnauthorizedRequestOnce() throws Exception {
-        securityFilter.setStatus(401);
+    void shouldFormatUnauthorizedRequestOnce(final int status) throws Exception {
+        securityFilter.setStatus(status);
 
         mvc.perform(get("/api/sync"));
 
         verify(formatter).format(any(Precorrelation.class));
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
     @SuppressWarnings("unchecked")
-    void shouldFormatUnauthorizedResponseOnce() throws Exception {
-        securityFilter.setStatus(401);
+    void shouldFormatUnauthorizedResponseOnce(final int status) throws Exception {
+        securityFilter.setStatus(status);
 
         mvc.perform(get("/api/sync"));
 
         verify(formatter).format(any(Correlation.class));
     }
 
-    @Test
-    void shouldLogUnauthorizedRequestOnce() throws Exception {
-        securityFilter.setStatus(401);
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
+    void shouldLogUnauthorizedRequestOnce(final int status) throws Exception {
+        securityFilter.setStatus(status);
 
         mvc.perform(get("/api/sync"));
 
         verify(writer).writeRequest(any());
     }
 
-    @Test
-    void shouldLogUnauthorizedResponseOnce() throws Exception {
-        securityFilter.setStatus(401);
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
+    void shouldLogUnauthorizedResponseOnce(final int status) throws Exception {
+        securityFilter.setStatus(status);
 
         mvc.perform(get("/api/sync"));
 
         verify(writer).writeResponse(any());
     }
 
-    @Test
-    void shouldNotLogRequestBodyForUnauthorizedRequests() throws Exception {
-        securityFilter.setStatus(401);
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
+    void shouldNotLogRequestBodyForUnauthorizedRequests(final int status) throws Exception {
+        securityFilter.setStatus(status);
 
         mvc.perform(post("/api/sync")
                 .content("Hello, world!"));
@@ -199,10 +206,11 @@ public final class MultiFilterSecurityTest {
         assertThat(precorrelation.getRequest(), not(containsString("Hello, world")));
     }
 
-    @Test
-    void shouldNotLogUnauthorizedRequest() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
+    void shouldNotLogUnauthorizedRequest(final int status) throws Exception {
         when(writer.isActive(any())).thenReturn(false);
-        securityFilter.setStatus(401);
+        securityFilter.setStatus(status);
 
         mvc.perform(get("/api/sync"));
 


### PR DESCRIPTION
Proposed changes to add support for logging requests and responses with HTTP 403 status in the default SpringBoot setup, as discussed in  #219.