### PR TITLE
add a body max size config for Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ The following tables show the available configuration:
 | `logbook.write.category`       | Changes the category of the [`DefaultHttpLogWriter`](#logger)    | `org.zalando.logbook.Logbook` |
 | `logbook.write.level`          | Changes the level of the [`DefaultHttpLogWriter`](#logger)       | `TRACE`                       |
 | `logbook.write.chunk-size`     | Splits log lines into smaller chunks of size up-to `chunk-size`. | `0` (disabled)                |
+| `logbook.write.body-max-size`  | Truncates the body up to `body-max-size` and appends `...`.      | `null` (disabled)             |
 
 ##### Example configuration
 

--- a/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.joining;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
@@ -59,6 +60,11 @@ public final class BodyFilters {
 
         return (contentType, body) -> json.test(contentType) ?
                 pattern.matcher(body).replaceAll("$1\"" + replacement + "\"") : body;
+    }
+
+    @API(status = EXPERIMENTAL)
+    public static BodyFilter truncatedBody(int maxSize) {
+        return ((contentType, body) -> body.length() <= maxSize ? body : body.substring(0, maxSize) + "...");
     }
 
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/BodyFiltersTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/BodyFiltersTest.java
@@ -36,4 +36,22 @@ public final class BodyFiltersTest {
         assertThat(actual, is("{\"foo\":\"XXX\"}"));
     }
 
+    @Test
+    void shouldTruncateBodyIfTooLong() {
+        final BodyFilter unit = BodyFilters.truncatedBody(5);
+
+        final String actual = unit.filter("application/json", "{\"foo\":\"secret\"}");
+
+        assertThat(actual, is("{\"foo..."));
+    }
+
+    @Test
+    void shouldNotTruncateBodyIfTooShort() {
+        final BodyFilter unit = BodyFilters.truncatedBody(50);
+
+        final String actual = unit.filter("application/json", "{\"foo\":\"secret\"}");
+
+        assertThat(actual, is("{\"foo\":\"secret\"}"));
+    }
+
 }

--- a/logbook-spring-boot-starter/src/main/java/org/zalando/logbook/spring/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-starter/src/main/java/org/zalando/logbook/spring/LogbookAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.zalando.logbook.servlet.Strategy;
 
 import javax.servlet.Filter;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toList;
@@ -164,7 +165,12 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(BodyFilter.class)
     public BodyFilter bodyFilter() {
-        return BodyFilters.defaultValue();
+        final LogbookProperties.Write write = properties.getWrite();
+        final Optional<Integer> bodyMaxSize = write.getBodyMaxSize();
+
+        return bodyMaxSize
+                .map(integer -> BodyFilter.merge(BodyFilters.truncatedBody(integer), BodyFilters.defaultValue()))
+                .orElseGet(BodyFilters::defaultValue);
     }
 
     @API(status = INTERNAL)

--- a/logbook-spring-boot-starter/src/main/java/org/zalando/logbook/spring/LogbookProperties.java
+++ b/logbook-spring-boot-starter/src/main/java/org/zalando/logbook/spring/LogbookProperties.java
@@ -7,6 +7,7 @@ import org.zalando.logbook.Logbook;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
@@ -49,6 +50,7 @@ public final class LogbookProperties {
 
         private String category = Logbook.class.getName();
         private Level level = Level.TRACE;
+        private Integer bodyMaxSize = null;
         private int chunkSize = 0;
 
         public String getCategory() {
@@ -73,6 +75,14 @@ public final class LogbookProperties {
 
         public void setChunkSize(final int chunkSize) {
             this.chunkSize = chunkSize;
+        }
+
+        public Optional<Integer> getBodyMaxSize() {
+            return Optional.ofNullable(bodyMaxSize);
+        }
+
+        public void setBodyMaxSize(final int bodyMaxSize) {
+            this.bodyMaxSize = bodyMaxSize;
         }
 
     }

--- a/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteBodyMaxSizeTest.java
+++ b/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteBodyMaxSizeTest.java
@@ -1,0 +1,33 @@
+package org.zalando.logbook.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.zalando.logbook.BodyFilter;
+import org.zalando.logbook.ChunkingHttpLogWriter;
+import org.zalando.logbook.HttpLogWriter;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@TestPropertySource(properties = "logbook.write.body-max-size = 20")
+public final class WriteBodyMaxSizeTest extends AbstractTest {
+
+    @Autowired
+    private BodyFilter bodyFilter;
+
+    @Test
+    void shouldUseBodyMaxSizeFilter() {
+        assertThat(bodyFilter.filter("application/json", "{\"foo\":\"someLongMessage\"}"),
+                is("{\"foo\":\"someLongMess..."));
+    }
+
+    @Test
+    void shouldUseBodyMaxSizeOverDefaultFilter() {
+        assertThat(bodyFilter.filter("application/json", "{\"open_id\":\"someLongSecret\",\"foo\":\"bar\"}"),
+                is("{\"open_id\":\"XXX\",\"fo..."));
+    }
+}

--- a/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteBodyMaxSizeTest.java
+++ b/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteBodyMaxSizeTest.java
@@ -4,13 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 import org.zalando.logbook.BodyFilter;
-import org.zalando.logbook.ChunkingHttpLogWriter;
-import org.zalando.logbook.HttpLogWriter;
-
-import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 @TestPropertySource(properties = "logbook.write.body-max-size = 20")

--- a/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteNoBodyMaxSizeTest.java
+++ b/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteNoBodyMaxSizeTest.java
@@ -2,7 +2,6 @@ package org.zalando.logbook.spring;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.TestPropertySource;
 import org.zalando.logbook.BodyFilter;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteNoBodyMaxSizeTest.java
+++ b/logbook-spring-boot-starter/src/test/java/org/zalando/logbook/spring/WriteNoBodyMaxSizeTest.java
@@ -1,0 +1,21 @@
+package org.zalando.logbook.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.zalando.logbook.BodyFilter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public final class WriteNoBodyMaxSizeTest extends AbstractTest {
+
+    @Autowired
+    private BodyFilter bodyFilter;
+
+    @Test
+    void shouldNotUseBodyMaxSizeFilter() {
+        assertThat(bodyFilter.filter("application/json", "{\"open_id\":\"someLongSecret\",\"foo\":\"bar\"}"),
+                is("{\"open_id\":\"XXX\",\"foo\":\"bar\"}"));
+    }
+}


### PR DESCRIPTION
This PR aims at adding a Spring configuration field to limit the size of the body of logged requests/responses.

Solves #267

## Description
This PR adds a field `logbook.write.body-max-size` to the Spring configuration with the following behavior:
- if field absent or null, use the default BodyFilter (which hides some fields)
- if n>=0, use a merge of the default filter (applied first), truncates the body up to n-th character and then appends '...'. If n=0, the entire body will be printed as '...'.

## Motivation and Context
This PR aims at giving control over how much of the request/response body should be printed, especially if it is expected to contain a large number of characters.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
