### PR TITLE
Added bill of materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Logbook is ready to use out of the box for most common setups. Even for uncommon
 
 ## Installation
 
-Selectively add the following dependencies to your project:
+Add the following dependency to your project:
 
 ```xml
 <dependency>
@@ -47,25 +47,48 @@ Selectively add the following dependencies to your project:
     <artifactId>logbook-core</artifactId>
     <version>${logbook.version}</version>
 </dependency>
+```
+
+Additional modules/artifacts of Logbook always share the same version number.
+
+Alternatively, you can import our *bill of materials*...
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>logbook-bom</artifactId>
+      <version>${logbook.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+... which allows you to omit versions:
+
+```xml
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>logbook-core</artifactId>
+</dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>logbook-servlet</artifactId>
-    <version>${logbook.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>logbook-httpclient</artifactId>
-    <version>${logbook.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>logbook-okhttp</artifactId>
-    <version>${logbook.version}</version>
 </dependency>
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>logbook-spring-boot-starter</artifactId>
-    <version>${logbook.version}</version>
 </dependency>
 ```
 

--- a/logbook-bom/pom.xml
+++ b/logbook-bom/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.zalando</groupId>
+        <artifactId>logbook-parent</artifactId>
+        <version>1.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>logbook-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Logbook: Bill of Materials</name>
+    <description>HTTP request and response logging</description>
+
+    <scm>
+        <url>https://github.com/zalando/logbook</url>
+        <connection>scm:git:git@github.com:zalando//logbook.git</connection>
+        <developerConnection>scm:git:git@github.com:zalando//logbook.git</developerConnection>
+    </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-api</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-core</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-httpclient</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-servlet</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-spring-boot-starter</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-test</artifactId>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 
     <modules>
         <module>logbook-api</module>
+        <module>logbook-bom</module>
         <module>logbook-core</module>
         <module>logbook-httpclient</module>
         <module>logbook-okhttp</module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Logbook has already 5+ modules that produce individual artifacts. Users that depend on them will usually list them all as dependencies in their POMs. Right now we guarantee that version numbers across modules are always the same, i.e. a new release will release each module, even if it wasn't change.
That allows users right now already to use a single maven property `logbook.version` that is used for each dependency. 

This pull requests introduces a BOM (bill of material) as an alternative. The BOM can be imported in the `dependencyManagement` section of a POM. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The BOM removes the need to specify any version on individual logbook artifacts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
