### PR TITLE
Made JSON heuristic handle whitespace around structural characters correctly

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/JsonHeuristic.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/JsonHeuristic.java
@@ -9,36 +9,40 @@ final class JsonHeuristic {
     private final Pattern number = compile("^-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?$");
 
     boolean isProbablyJson(final String body) {
-        return isNull(body)
-                || isBoolean(body)
-                || isNumber(body)
+        // Insignificant whitespace is allowed before or after any of the six structural characters.
+        // https://tools.ietf.org/html/rfc4627#section-2
+        final String trimmed = body.trim();
+
+        return isProbablyObject(trimmed)
+                || isProbablyArray(trimmed)
                 || isProbablyString(body)
-                || isProbablyArray(body)
-                || isProbablyObject(body);
+                || isNumber(body)
+                || isBoolean(body)
+                || isNull(body);
     }
 
-    private boolean isNull(final String body) {
-        return "null".equals(body);
-    }
-
-    private boolean isBoolean(final String body) {
-        return "true".equals(body) || "false".equals(body);
-    }
-
-    private boolean isNumber(final String body) {
-        return number.matcher(body).matches();
-    }
-
-    private boolean isProbablyString(final String body) {
-        return body.startsWith("\"") && body.endsWith("\"") && body.length() > 1;
+    private boolean isProbablyObject(final String body) {
+        return body.startsWith("{") && body.endsWith("}");
     }
 
     private boolean isProbablyArray(final String body) {
         return body.startsWith("[") && body.endsWith("]");
     }
 
-    private boolean isProbablyObject(final String body) {
-        return body.startsWith("{") && body.endsWith("}");
+    private boolean isProbablyString(final String body) {
+        return body.startsWith("\"") && body.endsWith("\"") && body.length() > 1;
+    }
+
+    private boolean isNumber(final String body) {
+        return number.matcher(body).matches();
+    }
+
+    private boolean isBoolean(final String body) {
+        return "true".equals(body) || "false".equals(body);
+    }
+
+    private boolean isNull(final String body) {
+        return "null".equals(body);
     }
 
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/JsonHeuristicTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/JsonHeuristicTest.java
@@ -23,7 +23,13 @@ class JsonHeuristicTest {
             "\"missing end quote",
             "123.4.5",
             "{},",
-            "[],"
+            "[],",
+            "null\n",
+            "true\n",
+            "false\n",
+            "\"string\"\n",
+            "123\n",
+            "123.45\n",
     })
     void notJson(final String value) {
         assertFalse(unit.isProbablyJson(value));
@@ -39,10 +45,14 @@ class JsonHeuristicTest {
             "123",
             "123.45",
             "{}",
+            "{}\n",
+            "\n{}",
             "{\"key\",\"value\"}",
             "{key:value}", // acceptable false positive
             "{\"key\",{}", // acceptable false positive
             "[]",
+            "[]\n",
+            "\n[]",
             "[\"value\"]",
             "[]]", // acceptable false positive
             "[value]", // acceptable false positive


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The JSON heuristic doesn't recognize `{}\n` as valid JSON.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JSON generators that produce formatted JSON will most likely append a trailing new line. The inlining of JSON bodies doesn't work for those.

> Insignificant whitespace is allowed before or after any of the six
   structural characters.
>
> https://tools.ietf.org/html/rfc4627#section-2 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
