### PR TITLE
fix BodyFilter.replaceJsonStringProperty issue with empty values

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
@@ -50,13 +51,14 @@ public final class BodyFilters {
      * @return BodyFilter generated
      */
     @API(status = MAINTAINED)
-    public static BodyFilter replaceJsonStringProperty(final Set<String> properties, final String replacement) {
-        final String regex = properties.stream()
+    public static BodyFilter replaceJsonStringProperty(final Iterable<String> properties, final String replacement) {
+        final String regex = StreamSupport.stream(properties.spliterator(), false)
+                .distinct()
                 .map(Pattern::quote)
                 .collect(joining("|"));
 
         final Predicate<String> json = MediaTypeQuery.compile("application/json", "application/*+json");
-        final Pattern pattern = Pattern.compile("(\"(?:" + regex + ")\"\\s*:\\s*)\".+?\"");
+        final Pattern pattern = Pattern.compile("(\"(?:" + regex + ")\"\\s*:\\s*)\".*?\"");
 
         return (contentType, body) -> json.test(contentType) ?
                 pattern.matcher(body).replaceAll("$1\"" + replacement + "\"") : body;

--- a/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
@@ -51,9 +50,8 @@ public final class BodyFilters {
      * @return BodyFilter generated
      */
     @API(status = MAINTAINED)
-    public static BodyFilter replaceJsonStringProperty(final Iterable<String> properties, final String replacement) {
-        final String regex = StreamSupport.stream(properties.spliterator(), false)
-                .distinct()
+    public static BodyFilter replaceJsonStringProperty(final Set<String> properties, final String replacement) {
+        final String regex = properties.stream()
                 .map(Pattern::quote)
                 .collect(joining("|"));
 

--- a/logbook-core/src/test/java/org/zalando/logbook/BodyFiltersTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/BodyFiltersTest.java
@@ -28,12 +28,30 @@ public final class BodyFiltersTest {
     }
 
     @Test
-    void shouldFilterJSONProperty() {
+    void shouldFilterNotEmptyJSONProperty() {
         final BodyFilter unit = BodyFilters.replaceJsonStringProperty(Collections.singleton("foo"), "XXX");
 
-        final String actual = unit.filter("application/json", "{\"foo\":\"secret\"}");
+        final String actual = unit.filter("application/json", "{\"foo\":\"secret\",\"bar\":\"public\"}");
 
-        assertThat(actual, is("{\"foo\":\"XXX\"}"));
+        assertThat(actual, is("{\"foo\":\"XXX\",\"bar\":\"public\"}"));
+    }
+
+    @Test
+    void shouldFilterEmptyJSONProperty() {
+        final BodyFilter unit = BodyFilters.replaceJsonStringProperty(Collections.singleton("foo"), "XXX");
+
+        final String actual = unit.filter("application/json", "{\"foo\":\"\",\"bar\":\"public\"}");
+
+        assertThat(actual, is("{\"foo\":\"XXX\",\"bar\":\"public\"}"));
+    }
+
+    @Test
+    void shouldNotFilterNullJSONProperty() {
+        final BodyFilter unit = BodyFilters.replaceJsonStringProperty(Collections.singleton("foo"), "XXX");
+
+        final String actual = unit.filter("application/json", "{\"foo\":null,\"bar\":\"public\"}");
+
+        assertThat(actual, is("{\"foo\":null,\"bar\":\"public\"}"));
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
BodyFilter `BodyFilters#replaceJsonStringProperty` corrupts json.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `BodyFilters#replaceJsonStringProperty` filters json containing empty properties to replace it corrupt json. Example:

Filter: 
```java
final BodyFilter unit = BodyFilters.replaceJsonStringProperty(Collections.singleton("foo"), "XXX");
```

Input: 
```json
{"foo":"","bar":"public"}
```
Output: 
```json
{"foo":"XXX"bar":"public"}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
