### PR TITLE
Add compacting body filters

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/BodyFilters.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apiguardian.api.API;
 
 import java.util.HashSet;
@@ -65,6 +66,16 @@ public final class BodyFilters {
     @API(status = EXPERIMENTAL)
     public static BodyFilter truncate(final int maxSize) {
         return (contentType, body) -> body.length() <= maxSize ? body : body.substring(0, maxSize) + "...";
+    }
+
+    @API(status = EXPERIMENTAL)
+    public static BodyFilter compactJson(final ObjectMapper objectMapper) {
+        return new JsonCompactingBodyFilter(objectMapper);
+    }
+
+    @API(status = EXPERIMENTAL)
+    public static BodyFilter compactXml() {
+        return new XmlCompactingBodyFilter();
     }
 
 }

--- a/logbook-core/src/main/java/org/zalando/logbook/JsonCompactingBodyFilter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/JsonCompactingBodyFilter.java
@@ -21,11 +21,11 @@ class JsonCompactingBodyFilter implements BodyFilter {
 
     @Override
     public String filter(@Nullable final String contentType, final String body) {
-        return shouldCompact(contentType, body) ? compact(body) : body;
+        return contentTypes.test(contentType) && shouldCompact(body) ? compact(body) : body;
     }
 
-    private boolean shouldCompact(@Nullable final String contentType, final String body) {
-        return contentTypes.test(contentType) && heuristic.isProbablyJson(body);
+    private boolean shouldCompact(final String body) {
+        return heuristic.isProbablyJson(body) && !jsonCompactor.isCompacted(body);
     }
 
     private String compact(final String body) {

--- a/logbook-core/src/main/java/org/zalando/logbook/JsonCompactingBodyFilter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/JsonCompactingBodyFilter.java
@@ -1,0 +1,39 @@
+package org.zalando.logbook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.function.Predicate;
+
+
+@Slf4j
+class JsonCompactingBodyFilter implements BodyFilter {
+
+    private final JsonCompactor jsonCompactor;
+    private final JsonHeuristic heuristic = new JsonHeuristic();
+    private final Predicate<String> contentTypes = MediaTypeQuery.compile("application/json", "application/*+json");
+
+    JsonCompactingBodyFilter(final ObjectMapper objectMapper) {
+        jsonCompactor = new JsonCompactor(objectMapper);
+    }
+
+    @Override
+    public String filter(@Nullable final String contentType, final String body) {
+        return shouldCompact(contentType, body) ? compact(body) : body;
+    }
+
+    private boolean shouldCompact(@Nullable final String contentType, final String body) {
+        return contentTypes.test(contentType) && heuristic.isProbablyJson(body);
+    }
+
+    private String compact(final String body) {
+        try {
+            return jsonCompactor.compact(body);
+        } catch (final IOException e) {
+            log.trace("Unable to compact body, is it a JSON?. Keep it as-is: `{}`", e.getMessage());
+            return body;
+        }
+    }
+}

--- a/logbook-core/src/main/java/org/zalando/logbook/XmlCompactingBodyFilter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/XmlCompactingBodyFilter.java
@@ -1,0 +1,74 @@
+package org.zalando.logbook;
+
+import lombok.extern.slf4j.Slf4j;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.annotation.Nullable;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.util.function.Predicate;
+
+import static javax.xml.transform.OutputKeys.INDENT;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+import static javax.xml.xpath.XPathConstants.NODESET;
+import static org.zalando.fauxpas.FauxPas.throwingSupplier;
+
+@Slf4j
+class XmlCompactingBodyFilter implements BodyFilter {
+
+    private final Predicate<String> contentTypes = MediaTypeQuery.compile("*/xml", "*/*+xml");
+    private final Transformer transformer = transformerFactory();
+
+    @Override
+    public String filter(@Nullable final String contentType, final String body) {
+        return contentTypes.test(contentType) ? compact(body) : body;
+    }
+
+    private String compact(final String body) {
+        if (body.trim().isEmpty()) return body;
+        try {
+            final StringWriter output = new StringWriter();
+            final Document document = documentWithoutTextNodes(body);
+            transformer.transform(new DOMSource(document), new StreamResult(output));
+            return output.toString();
+        } catch (Exception e) {
+            log.trace("Unable to compact body, is it a XML?. Keep it as-is: `{}`", e.getMessage());
+            return body;
+        }
+    }
+
+    private Document documentWithoutTextNodes(final String body) {
+        try {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            final Document document = factory.newDocumentBuilder().parse(new ByteArrayInputStream(body.getBytes()));
+
+            final XPathFactory xPathFactory = XPathFactory.newInstance();
+            final XPath xpath = xPathFactory.newXPath();
+            final NodeList empty = (NodeList) xpath.evaluate("//text()[normalize-space(.) = '']", document, NODESET);
+            for (int i = 0; i < empty.getLength(); i++) {
+                final Node node = empty.item(i);
+                node.getParentNode().removeChild(node);
+            }
+            return document;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Can not parse document", e);
+        }
+    }
+
+    private Transformer transformerFactory() {
+            final TransformerFactory factory = TransformerFactory.newInstance();
+            final Transformer transformer = throwingSupplier(factory::newTransformer).get();
+            transformer.setOutputProperty(INDENT, "no");
+            transformer.setOutputProperty(OMIT_XML_DECLARATION, "yes");
+            return transformer;
+    }
+}

--- a/logbook-core/src/main/java/org/zalando/logbook/XmlCompactingBodyFilter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/XmlCompactingBodyFilter.java
@@ -17,7 +17,6 @@ import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import static javax.xml.transform.OutputKeys.INDENT;
 import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
@@ -37,7 +36,7 @@ class XmlCompactingBodyFilter implements BodyFilter {
     }
 
     private boolean shouldCompact(final String body) {
-        return Stream.of("<?xml", "\n", "  ").anyMatch(body::contains);
+        return body.indexOf('\n') != -1;
     }
 
     private String compact(final String body) {

--- a/logbook-core/src/test/java/org/zalando/logbook/BodyFiltersTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/BodyFiltersTest.java
@@ -1,10 +1,12 @@
 package org.zalando.logbook;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public final class BodyFiltersTest {
@@ -72,4 +74,17 @@ public final class BodyFiltersTest {
         assertThat(actual, is("{\"foo\":\"secret\"}"));
     }
 
+    @Test
+    void shouldReturnJsonCompactingBodyFilter() {
+        final BodyFilter bodyFilter = BodyFilters.compactJson(new ObjectMapper());
+
+        assertThat(bodyFilter, instanceOf(JsonCompactingBodyFilter.class));
+    }
+
+    @Test
+    void shouldReturnXmlCompactingBodyFilter() {
+        final BodyFilter bodyFilter = BodyFilters.compactXml();
+
+        assertThat(bodyFilter, instanceOf(XmlCompactingBodyFilter.class));
+    }
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/JsonCompactingBodyFilterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/JsonCompactingBodyFilterTest.java
@@ -1,0 +1,68 @@
+package org.zalando.logbook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class JsonCompactingBodyFilterTest {
+
+    private JsonCompactingBodyFilter bodyFilter;
+
+    /*language=JSON*/
+    private final String prettifiedJson = "{\n" +
+            "  \"root\": {\n" +
+            "    \"child\": \"text\"\n" +
+            "  }\n" +
+            "}";
+
+    /*language=JSON*/
+    private final String minimisedJson = "{\"root\":{\"child\":\"text\"}}";
+
+    @BeforeEach
+    void setUp() {
+        bodyFilter = new JsonCompactingBodyFilter(new ObjectMapper());
+    }
+
+    @Test
+    void shouldIgnoreEmptyBody() {
+        final String filtered = bodyFilter.filter("application/json", "");
+        assertThat(filtered, is(""));
+    }
+
+    @Test
+    void shouldIgnoreInvalidContent() {
+        final String invalidBody = UUID.randomUUID().toString();
+        final String filtered = bodyFilter.filter("application/json", invalidBody);
+        assertThat(filtered, is(invalidBody));
+    }
+
+    @Test
+    void shouldIgnoreInvalidContentType() {
+        final String filtered = bodyFilter.filter("text/plain", prettifiedJson);
+        assertThat(filtered, is(prettifiedJson));
+    }
+
+    @Test
+    void shouldTransformValidJsonRequestWithSimpleContentType() {
+        final String filtered = bodyFilter.filter("application/json", prettifiedJson);
+        assertThat(filtered, is(minimisedJson));
+    }
+
+    @Test
+    void shouldTransformValidJsonRequestWithCompatibleContentType() {
+        final String filtered = bodyFilter.filter("application/custom+json", prettifiedJson);
+        assertThat(filtered, is(minimisedJson));
+    }
+
+    @Test
+    void shouldSkipInvalidJsonLookingLikeAValidOne() {
+        final String invalidJson = "{invalid}";
+        final String filtered = bodyFilter.filter("application/custom+json", invalidJson);
+        assertThat(filtered, is(invalidJson));
+    }
+}

--- a/logbook-core/src/test/java/org/zalando/logbook/JsonCompactingBodyFilterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/JsonCompactingBodyFilterTest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -36,7 +34,7 @@ class JsonCompactingBodyFilterTest {
 
     @Test
     void shouldIgnoreInvalidContent() {
-        final String invalidBody = UUID.randomUUID().toString();
+        final String invalidBody = "{\ninvalid}";
         final String filtered = bodyFilter.filter("application/json", invalidBody);
         assertThat(filtered, is(invalidBody));
     }

--- a/logbook-core/src/test/java/org/zalando/logbook/MediaTypeQueryTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/MediaTypeQueryTest.java
@@ -18,6 +18,7 @@ public final class MediaTypeQueryTest {
         deny("text/plain", "application/json");
         allow("*/*", "text/plain");
         allow("text/*", "text/plain");
+        allow("*/plain", "text/plain");
         allow("text/plain", "text/plain");
         allow("text/plain", "text/plain;charset=UTF-8");
         allow("text/plain;charset=UTF-8", "text/plain"); // TODO should deny

--- a/logbook-core/src/test/java/org/zalando/logbook/XmlCompactingBodyFilterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/XmlCompactingBodyFilterTest.java
@@ -1,0 +1,62 @@
+package org.zalando.logbook;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class XmlCompactingBodyFilterTest {
+
+    private XmlCompactingBodyFilter bodyFilter;
+
+    /*language=XML*/
+    private final String prettifiedXml = "" +
+            "<?xml version=\"1.0\"?>" +
+            "<root>\n\n" +
+            "    <child>text</child>\n" +
+            "</root>";
+
+    /*language=XML*/
+    private final String minimisedXml = "<root><child>text</child></root>";
+
+    @BeforeEach
+    void setUp() {
+        bodyFilter = new XmlCompactingBodyFilter();
+    }
+
+    @Test
+    void shouldIgnoreEmptyBody() {
+        final String filtered = bodyFilter.filter("application/xml", "");
+        assertThat(filtered, is(""));
+    }
+
+    @Test
+    void shouldIgnoreInvalidContent() {
+        final String invalidBody = UUID.randomUUID().toString();
+        final String filtered = bodyFilter.filter("application/xml", invalidBody);
+        assertThat(filtered, is(invalidBody));
+    }
+
+    @Test
+    void shouldIgnoreInvalidContentType() {
+        final String filtered = bodyFilter.filter("text/plain", prettifiedXml);
+        assertThat(filtered, is(prettifiedXml));
+    }
+
+    @Test
+    void shouldTransformValidXmlRequestWithSimpleContentType() {
+        final String filtered = bodyFilter.filter("application/xml", prettifiedXml);
+        assertThat(filtered, is(minimisedXml));
+    }
+
+    @Test
+    void shouldTransformValidXmlRequestWithCompatibleContentType() {
+        final String filtered = bodyFilter.filter("application/custom+xml", prettifiedXml);
+        assertThat(filtered, is(minimisedXml));
+    }
+
+}

--- a/logbook-core/src/test/java/org/zalando/logbook/XmlCompactingBodyFilterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/XmlCompactingBodyFilterTest.java
@@ -4,8 +4,6 @@ package org.zalando.logbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -36,7 +34,7 @@ class XmlCompactingBodyFilterTest {
 
     @Test
     void shouldIgnoreInvalidContent() {
-        final String invalidBody = UUID.randomUUID().toString();
+        final String invalidBody = "<?xml>\n<invalid>";
         final String filtered = bodyFilter.filter("application/xml", invalidBody);
         assertThat(filtered, is(invalidBody));
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add body filters to compact most common content types

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Custom `HttpLogForrmatter`s (different from `JsonHttpLogFormatter`) have also need to minify message body. To reduce code duplication from formatter to formatter, it could be extracted as delegating body filters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
