### PR TITLE
Update bill of materials (BOM) to define version for each dependency

### DIFF
--- a/logbook-bom/pom.xml
+++ b/logbook-bom/pom.xml
@@ -20,30 +20,37 @@
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-api</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-core</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-httpclient</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-servlet</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-spring-boot-starter</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-jaxrs</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-test</artifactId>
+                <version>1.12.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To omit the versions in `pom.xml` the dependencies in `org.zalando:logbook-bom` must define `<version>${logbook.version}</version>`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We still have to define the dependency version due to following error

`[ERROR] 'dependencies.dependency.version' for org.zalando:logbook-servlet:jar is missing. @ com.inventage.demo:backend-war:[unknown-version]
`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
