### PR TITLE
add okhttp and okhttp2 modules to the bom

### DIFF
--- a/logbook-bom/pom.xml
+++ b/logbook-bom/pom.xml
@@ -34,17 +34,27 @@
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
+                <artifactId>logbook-jaxrs</artifactId>
+                <version>1.13.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-okhttp</artifactId>
+                <version>1.13.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>logbook-okhttp2</artifactId>
+                <version>1.13.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
                 <artifactId>logbook-servlet</artifactId>
                 <version>1.13.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
                 <artifactId>logbook-spring-boot-starter</artifactId>
-                <version>1.13.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.zalando</groupId>
-                <artifactId>logbook-jaxrs</artifactId>
                 <version>1.13.0-SNAPSHOT</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I realized after the latest release that neither okhttp nor okhtttp2 were in the bom.

## Motivation and Context
Developers will expect the bom to be complete.

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
