### PR TITLE
Bump Hamcrest version from 2.0.0.0 to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,8 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>java-hamcrest</artifactId>
-                <version>2.0.0.0</version>
+                <artifactId>hamcrest</artifactId>
+                <version>2.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -363,7 +363,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hobsoft.hamcrest</groupId>


### PR DESCRIPTION
Release notes: https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1
