### PR TITLE
Adjust logging of empty or filtered body

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonHttpLogFormatter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonHttpLogFormatter.java
@@ -62,11 +62,14 @@ public final class JsonHttpLogFormatter implements StructuredHttpLogFormatter {
     public Optional<Object> prepareBody(final HttpMessage message) throws IOException {
         final String contentType = message.getContentType();
         final String body = message.getBodyAsString();
-
+        if(body.isEmpty()) {
+            return Optional.empty();
+        }
         if (JsonMediaType.JSON.test(contentType)) {
+        	// TODO has this JSON been validated? If not then this might result in invalid log statements
             return Optional.of(new JsonBody(body));
         } else {
-            return Optional.ofNullable(body.isEmpty() ? null : body);
+            return Optional.of(body);
         }
     }
 

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
@@ -225,7 +225,7 @@ final class JsonHttpLogFormatterTest {
 
         final String json = unit.format(new SimplePrecorrelation("", systemUTC()), request);
 
-        assertThat(json, containsString("\"body\":}"));
+        assertThat(json, not(containsString("\"body\"")));
     }
 
     @Test
@@ -316,14 +316,14 @@ final class JsonHttpLogFormatterTest {
     }
 
     @Test
-    void shouldEmbedJsonResponseBodyAsNullIfEmpty() throws IOException {
+    void shouldNotEmbedJsonResponseBodyIfEmpty() throws IOException {
         final String correlationId = "5478b8da-6d87-11e5-a80f-10ddb1ee7671";
         final HttpResponse response = MockHttpResponse.create()
                 .withContentType("application/json");
 
         final String json = unit.format(new SimpleCorrelation(correlationId, ZERO), response);
 
-        assertThat(json, containsString("\"body\":}"));
+        assertThat(json, not(containsString("\"body\"")));
     }
 
     @Test


### PR DESCRIPTION
Invalid body values are logged as raw valid JSON values. 

## Description
For the special case of an empty body, resulting from using a filter, log an empty body.

## Motivation and Context
Produces invalid log statements.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
