### PR TITLE
Improve performance of DefaultHttpLogFormatter

### DIFF
--- a/logbook-api/src/main/java/org/zalando/logbook/RequestURI.java
+++ b/logbook-api/src/main/java/org/zalando/logbook/RequestURI.java
@@ -10,33 +10,33 @@ import static org.zalando.logbook.RequestURI.Component.PATH;
 import static org.zalando.logbook.RequestURI.Component.QUERY;
 import static org.zalando.logbook.RequestURI.Component.SCHEME;
 
-public final class RequestURI {
+final class RequestURI {
 
     private RequestURI() {
 
     }
 
-    public static enum Component {
+    enum Component {
         SCHEME, AUTHORITY, PATH, QUERY
     }
 
-    public static String reconstruct(final HttpRequest request) {
+    static String reconstruct(final HttpRequest request) {
         final StringBuilder url = new StringBuilder();
         reconstruct(request, url);
         return url.toString();
     }
 
-    public static void reconstruct(final HttpRequest request, StringBuilder output) {
+    static void reconstruct(final HttpRequest request, StringBuilder output) {
         reconstruct(request, EnumSet.allOf(Component.class), output);
     }
 
-    public static String reconstruct(final HttpRequest request, final Component... components) {
+    static String reconstruct(final HttpRequest request, final Component... components) {
         final StringBuilder url = new StringBuilder();
         reconstruct(request, EnumSet.copyOf(asList(components)), url);
         return url.toString();
     }
 
-    public static String reconstruct(final HttpRequest request, final Set<Component> components) {
+    static String reconstruct(final HttpRequest request, final Set<Component> components) {
         final StringBuilder url = new StringBuilder();
         reconstruct(request, components, url);
         return url.toString();

--- a/logbook-api/src/main/java/org/zalando/logbook/RequestURI.java
+++ b/logbook-api/src/main/java/org/zalando/logbook/RequestURI.java
@@ -10,35 +10,47 @@ import static org.zalando.logbook.RequestURI.Component.PATH;
 import static org.zalando.logbook.RequestURI.Component.QUERY;
 import static org.zalando.logbook.RequestURI.Component.SCHEME;
 
-final class RequestURI {
+public final class RequestURI {
 
     private RequestURI() {
 
     }
 
-    enum Component {
+    public static enum Component {
         SCHEME, AUTHORITY, PATH, QUERY
     }
 
-    static String reconstruct(final HttpRequest request) {
-        return reconstruct(request, EnumSet.allOf(Component.class));
+    public static String reconstruct(final HttpRequest request) {
+        final StringBuilder url = new StringBuilder();
+        reconstruct(request, url);
+        return url.toString();
     }
 
-    static String reconstruct(final HttpRequest request, final Component... components) {
-        return reconstruct(request, EnumSet.copyOf(asList(components)));
+    public static void reconstruct(final HttpRequest request, StringBuilder output) {
+        reconstruct(request, EnumSet.allOf(Component.class), output);
     }
 
-    private static String reconstruct(final HttpRequest request, final Set<Component> components) {
+    public static String reconstruct(final HttpRequest request, final Component... components) {
+        final StringBuilder url = new StringBuilder();
+        reconstruct(request, EnumSet.copyOf(asList(components)), url);
+        return url.toString();
+    }
+
+    public static String reconstruct(final HttpRequest request, final Set<Component> components) {
+        final StringBuilder url = new StringBuilder();
+        reconstruct(request, components, url);
+        return url.toString();
+    }
+
+    private static void reconstruct(final HttpRequest request, final Set<Component> components, StringBuilder url) {
         final String scheme = request.getScheme();
         final String host = request.getHost();
         final Optional<Integer> port = request.getPort();
         final String path = request.getPath();
         final String query = request.getQuery();
 
-        final StringBuilder url = new StringBuilder();
-
         if (components.contains(SCHEME)) {
-            url.append(scheme).append(":");
+            url.append(scheme).append(':');
         }
 
         if (components.contains(AUTHORITY)) {
@@ -63,13 +75,11 @@ final class RequestURI {
         if (components.contains(QUERY) && !query.isEmpty()) {
             url.append('?').append(query);
         }
-
-        return url.toString();
     }
 
     private static boolean isNotStandardPort(final String scheme, final int port) {
-        return "http".equals(scheme) && port != 80 ||
-                "https".equals(scheme) && port != 443;
+        return ("http".equals(scheme) && port != 80) ||
+                ("https".equals(scheme) && port != 443);
     }
 
 }

--- a/logbook-api/src/test/java/org/zalando/logbook/RequestURITest.java
+++ b/logbook-api/src/test/java/org/zalando/logbook/RequestURITest.java
@@ -3,6 +3,7 @@ package org.zalando.logbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.EnumSet;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -109,5 +110,16 @@ final class RequestURITest {
         Origin.valueOf("LOCAL");
     }
 
-
+    @Test
+    void shouldReconstructUsingBuilder() {
+        StringBuilder builder = new StringBuilder();
+        RequestURI.reconstruct(request, builder);
+        assertThat(builder.toString(), is("http://localhost/admin?limit=1"));
+    }
+    
+    @Test
+    void shouldReconstructSpecificComponents() {
+        String r = RequestURI.reconstruct(request, EnumSet.of(RequestURI.Component.SCHEME, RequestURI.Component.AUTHORITY, RequestURI.Component.PATH));
+        assertThat(r, is("http://localhost/admin"));
+    }
 }

--- a/logbook-core/src/main/java/org/zalando/logbook/DefaultHttpLogFormatter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/DefaultHttpLogFormatter.java
@@ -1,25 +1,56 @@
 package org.zalando.logbook;
 
-import org.apiguardian.api.API;
+import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-import static org.apiguardian.api.API.Status.STABLE;
-import static org.zalando.logbook.Origin.REMOTE;
+import org.apiguardian.api.API;
 
 @API(status = STABLE)
 public final class DefaultHttpLogFormatter implements HttpLogFormatter {
 
+    /**
+     * Produces an HTTP-like request in individual lines.
+     *
+     * @param precorrelation the request correlation
+     * @param request the HTTP request 
+     * @return a line-separated HTTP request
+     * @throws IOException if reading body fails
+     */
+    
     @Override
-    public String format(final Precorrelation precorrelation, final HttpRequest request) throws IOException {
-        return format(prepare(precorrelation, request));
+    public String format(Precorrelation precorrelation, HttpRequest request) throws IOException {
+        final String correlationId = precorrelation.getId();
+        
+        String body = request.getBodyAsString();
+
+        StringBuilder builder = new StringBuilder(body.length() + 2048);
+
+        builder.append(direction(request));
+        builder.append(" Request: ");
+        builder.append(correlationId);
+        builder.append('\n');
+        
+        builder.append(request.getMethod());
+        builder.append(' ');
+        RequestURI.reconstruct(request, builder);
+        builder.append(' ');
+        builder.append(request.getProtocolVersion());
+        builder.append('\n');
+        
+        writeHeaders(builder, request);
+
+        if (!body.isEmpty()) {
+            builder.append('\n');
+            builder.append(body);
+        } else {
+            builder.setLength(builder.length() - 1); // discard last newline
+        }
+        
+        return builder.toString();
     }
 
     /**
@@ -32,95 +63,66 @@ public final class DefaultHttpLogFormatter implements HttpLogFormatter {
      * @see #format(List)
      * @see StructuredHttpLogFormatter#prepare(Precorrelation, HttpRequest)
      */
-    @API(status = EXPERIMENTAL)
-    public List<String> prepare(final Precorrelation precorrelation, final HttpRequest request) throws IOException {
-        final String requestLine = String.format("%s %s %s", request.getMethod(), request.getRequestUri(),
-                request.getProtocolVersion());
-        return prepare(request, "Request", precorrelation.getId(), requestLine);
-    }
 
     @Override
     public String format(final Correlation correlation, final HttpResponse response) throws IOException {
-        return format(prepare(correlation, response));
-    }
+        final String correlationId = correlation.getId();
+        
+        String body = response.getBodyAsString();
 
-    /**
-     * Produces an HTTP-like response in individual lines.
-     * <p>
-     * Pr@param correlation the response correlation
-     *
-     * @param correlation the correlated request and response pair
-     * @return a line-separated HTTP response
-     * @throws IOException if reading body fails
-     * @see #prepare(Precorrelation, HttpRequest)
-     * @see #format(List)
-     * @see StructuredHttpLogFormatter#prepare(Correlation, HttpResponse)
-     */
-    @API(status = EXPERIMENTAL)
-    public List<String> prepare(final Correlation correlation, final HttpResponse response) throws IOException {
-        final StringBuilder statusLineBuilder = new StringBuilder(64);
-        statusLineBuilder.append(response.getProtocolVersion());
-        statusLineBuilder.append(' ');
-        statusLineBuilder.append(response.getStatus());
+        StringBuilder builder = new StringBuilder(body.length() + 2048);
+
+        builder.append(direction(response));
+        builder.append(" Response: ");
+        builder.append(correlationId);
+        builder.append("\nDuration: ");
+        builder.append(correlation.getDuration().toMillis());
+        builder.append(" ms\n");
+        
+        builder.append(response.getProtocolVersion());
+        builder.append(' ');
+        builder.append(response.getStatus());
         final String reasonPhrase = response.getReasonPhrase();
         if(reasonPhrase != null) {
-            statusLineBuilder.append(' ');
-            statusLineBuilder.append(reasonPhrase);
+            builder.append(' ');
+            builder.append(reasonPhrase);
         }
-        return prepare(response, "Response", correlation.getId(),
-                "Duration: " + correlation.getDuration().toMillis() + " ms", statusLineBuilder.toString());
-    }
+        
+        builder.append('\n');
 
-    private <H extends HttpMessage> List<String> prepare(final H message, final String type,
-            final String correlationId, final String... prefixes) throws IOException {
-        final List<String> lines = new ArrayList<>();
-
-        lines.add(direction(message) + " " + type + ": " + correlationId);
-        Collections.addAll(lines, prefixes);
-        lines.addAll(formatHeaders(message));
-
-        final String body = message.getBodyAsString();
+        writeHeaders(builder, response);
 
         if (!body.isEmpty()) {
-            lines.add("");
-            lines.add(body);
+            builder.append('\n');
+            builder.append(body);
+        } else {
+            builder.setLength(builder.length() - 1); // discard last newline
         }
+        
+        return builder.toString();        
+    }
 
-        return lines;
+    private void writeHeaders(StringBuilder builder, HttpMessage httpMessage) {
+        Map<String, List<String>> headers = httpMessage.getHeaders();
+        
+        if(!headers.isEmpty()) {
+            for (Entry<String, List<String>> entry : headers.entrySet()) {
+                builder.append(entry.getKey()); 
+                builder.append(": ");
+                List<String> headerValues = entry.getValue();
+                if(!headerValues.isEmpty()) {
+                    for(String value : entry.getValue()) {
+                        builder.append(value); 
+                        builder.append(", ");
+                    }
+                    builder.setLength(builder.length() - 2); // discard last comma
+                }
+                builder.append('\n');
+            }
+        }
     }
 
     private String direction(final HttpMessage request) {
-        return request.getOrigin() == REMOTE ? "Incoming" : "Outgoing";
+        return request.getOrigin() == Origin.REMOTE ? "Incoming" : "Outgoing";
     }
-
-    private List<String> formatHeaders(final HttpMessage message) {
-        return message.getHeaders().entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, this::formatHeaderValues))
-                .entrySet().stream()
-                .map(this::formatHeader)
-                .collect(toList());
-    }
-
-    private String formatHeaderValues(final Map.Entry<String, List<String>> entry) {
-        return String.join(", ", entry.getValue());
-    }
-
-    private String formatHeader(final Map.Entry<String, String> entry) {
-        return String.format("%s: %s", entry.getKey(), entry.getValue());
-    }
-
-    /**
-     * Renders an HTTP-like message into a printable string.
-     *
-     * @param lines lines of an HTTP message
-     * @return the whole message as a single string, separated by new lines
-     * @see #prepare(Precorrelation, HttpRequest)
-     * @see #prepare(Correlation, HttpResponse)
-     * @see StructuredHttpLogFormatter#format(Map)
-     */
-    @API(status = EXPERIMENTAL)
-    public String format(final List<String> lines) {
-        return String.join("\n", lines);
-    }
-
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
@@ -5,6 +5,12 @@ import org.zalando.logbook.DefaultLogbook.SimpleCorrelation;
 import org.zalando.logbook.DefaultLogbook.SimplePrecorrelation;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import static java.time.Clock.systemUTC;
 import static java.time.Duration.ofMillis;
@@ -131,5 +137,30 @@ final class DefaultHttpLogFormatterTest {
                 "\n" +
                 "{\"success\":true}"));
     }
-   
+
+    @Test
+    void shouldLogResponseForEmptyHeader() throws IOException {
+        final String correlationId = "2d51bc02-677e-11e5-8b9b-10ddb1ee7671";
+        
+        Map<String, List<String>> headers = new TreeMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put("X-Empty-Header", Collections.emptyList());
+        
+        final HttpResponse response = MockHttpResponse.create()
+                .withProtocolVersion("HTTP/1.0")
+                .withOrigin(Origin.REMOTE)
+                .withStatus(201)
+                .withHeaders(headers)
+                .withBodyAsString("{\"success\":true}");
+
+        final String http = unit.format(new SimpleCorrelation(correlationId, ofMillis(125)), response);
+
+        assertThat(http, is("Incoming Response: 2d51bc02-677e-11e5-8b9b-10ddb1ee7671\n" +
+                "Duration: 125 ms\n" +
+                "HTTP/1.0 201 Created\n" +
+                "Content-Type: application/json\n" +
+                "X-Empty-Header: \n" +
+                "\n" +
+                "{\"success\":true}"));
+    }
 }

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/WritingTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/WritingTest.java
@@ -91,8 +91,8 @@ final class WritingTest {
         assertThat(request, endsWith(
                 "GET http://localhost/api/sync HTTP/1.1\n" +
                         "Accept: application/json\n" +
-                        "Host: localhost\n" +
                         "Content-Type: " + contentType + "\n" +
+                        "Host: localhost\n" +
                         "\n" +
                         content));
     }
@@ -116,8 +116,8 @@ final class WritingTest {
         assertThat(request, endsWith(
                 "GET http://localhost/api/sync HTTP/1.1\n" +
                         "Accept: application/json\n" +
-                        "Host: localhost\n" +
-                        "Content-Type: application/x-www-form-urlencoded"));
+                        "Content-Type: application/x-www-form-urlencoded\n" +
+                        "Host: localhost"));
     }
 
     @Test


### PR DESCRIPTION
Improve performance of DefaultHttpLogFormatter.

## Description
Construct log statement in a single 'streaming' fasion.

## Motivation and Context
The previous implementation used a two-step approach via StructuredHttpLogFormatters format + prepare. Switching to a single step approach improves performance considerably, run HttpLogFormatterBenchmark for comparisons.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
