### PR TITLE
Improve JsonMediaType performance

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonMediaType.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonMediaType.java
@@ -1,15 +1,36 @@
 package org.zalando.logbook.json;
 
-import org.zalando.logbook.common.MediaTypeQuery;
-
 import java.util.function.Predicate;
 
 final class JsonMediaType {
 
     private JsonMediaType() {
-
     }
 
-    static final Predicate<String> JSON = MediaTypeQuery.compile("application/json", "application/*+json");
-
+    static final Predicate<String> JSON = contentType -> {
+        if(contentType == null) {
+            return false;
+        }
+        // implementation note: manually coded for improved performance
+        if(contentType.startsWith("application/")) {
+            int index = contentType.indexOf(';', 12);
+            if(index != -1) {
+                if(index > 16) {
+                    // application/some+json;charset=utf-8
+                    return contentType.regionMatches(index - 5, "+json", 0, 5);
+                }
+                
+                // application/json;charset=utf-8
+                return contentType.regionMatches(index - 4, "json", 0, 4);
+            } else {
+                // application/json
+                if(contentType.length() == 16) {
+                    return contentType.endsWith("json");
+                }
+                // application/some+json
+                return contentType.endsWith("+json");
+            }
+        }
+        return false;
+    };
 }

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonMediaTypeTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonMediaTypeTest.java
@@ -1,28 +1,51 @@
 package org.zalando.logbook.json;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zalando.logbook.common.MediaTypeQuery;
 
 public class JsonMediaTypeTest {
 
-    @Test
-    public void testApplicationJson1() {
-        assertTrue(JsonMediaType.JSON.test("application/json"));
-    }
-    
-    @Test
-    public void testApplicationJson2() {
-        assertTrue(JsonMediaType.JSON.test("application/abc+json;charset=utf-8"));
+    static final Predicate<String> JSON = MediaTypeQuery.compile("application/json", "application/*+json");
+
+    @ParameterizedTest
+    @ValueSource(strings = { 
+            "application/json",
+            "application/abc+json;charset=utf-8",
+            "application/json;charset=utf-8",
+            "application/abc+json;charset=utf-8"
+            })
+    public void testJsonTypes(String mediaType) {
+        assertTrue(JsonMediaType.JSON.test(mediaType));
+        assertEquals(JsonMediaType.JSON.test(mediaType), JSON.test(mediaType));
     }
 
-    @Test
-    public void testApplicationJson1WithCharset() {
-        assertTrue(JsonMediaType.JSON.test("application/json;charset=utf-8"));
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application/notjson",
+            "application/abc+notjson;charset=utf-8",
+            "application/notjson;charset=utf-8",
+            "application/abc+notjson;charset=utf-8",
+            "text/json",
+            "text/abc+json;charset=utf-8",
+            "text/json;charset=utf-8",
+            "text/abc+json;charset=utf-8",
+            "image/json",
+            "image/abc+json;charset=utf-8",
+            "image/json;charset=utf-8",
+            "image/abc+json;charset=utf-8"
+            })
+    @NullSource
+    public void testNonJsonTypes(String mediaType) {
+        assertFalse(JsonMediaType.JSON.test(mediaType));
+        assertEquals(JsonMediaType.JSON.test(mediaType), JSON.test(mediaType));
     }
-    
-    @Test
-    public void testApplicationJson2WithCharset() {
-        assertTrue(JsonMediaType.JSON.test("application/abc+json;charset=utf-8"));
-    }
+
 }


### PR DESCRIPTION
Hard-code check for JSON media type for considerable (7x) speedup.

## Description
Hard-code check for JSON media type; avoid use of regexp. Apply previous implementation for unit tests.

Benchmarks run via IDE:
before
JsonMediaTypeBenchmark.contentType1  thrpt    5  10458210,505 ± 112443,545  ops/s
JsonMediaTypeBenchmark.contentType2  thrpt    5   7560926,574 ±  70957,434  ops/s
JsonMediaTypeBenchmark.contentType3  thrpt    5   5107299,369 ±  51905,145  ops/s
JsonMediaTypeBenchmark.contentType4  thrpt    5   3528531,278 ±  34853,242  ops/s
after
JsonMediaTypeBenchmark.contentType1  thrpt    5  78192119,714 ± 4628504,966  ops/s
JsonMediaTypeBenchmark.contentType2  thrpt    5  64037507,380 ± 3227112,459  ops/s
JsonMediaTypeBenchmark.contentType3  thrpt    5  68491591,930 ±  765070,096  ops/s
JsonMediaTypeBenchmark.contentType4  thrpt    5  58140675,375 ±  592186,800  ops/s

## Motivation and Context
JsonMediaType is usually called several times per request/response.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
