### PR TITLE
Improve performance of JsonHttpLogFormatter: StringBuilder

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonHttpLogFormatter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonHttpLogFormatter.java
@@ -1,89 +1,205 @@
 package org.zalando.logbook.json;
 
-import com.fasterxml.jackson.annotation.JsonRawValue;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
-import org.apiguardian.api.API;
-import org.zalando.logbook.HttpLogFormatter;
-import org.zalando.logbook.HttpMessage;
-import org.zalando.logbook.StructuredHttpLogFormatter;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
-
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Map.Entry;
+
+import org.apiguardian.api.API;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpLogFormatter;
+import org.zalando.logbook.HttpMessage;
+import org.zalando.logbook.HttpRequest;
+import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.Origin;
+import org.zalando.logbook.Precorrelation;
+
 /**
- * A custom {@link HttpLogFormatter} that produces JSON objects. It can be augmented with composition:
- *
- * <pre>
- * {@code
- *
- * public class CustomsFormatter implements HttpLogFormatter {
- *
- *     private final JsonHttpLogFormatter delegate;
- *
- *     public CustomsFormatter(final ObjectMapper mapper) {
- *         this.delegate = new JsonHttpLogFormatter(mapper);
- *     }
- *
- *     public String format(final Precorrelation<HttpRequest> precorrelation) throws IOException {
- *         Map<String, Object> request = delegate.prepare(precorrelation);
- *         // modify request here
- *         return delegate.format(request);
- *     }
- *
- *     public String format(final Correlation<HttpRequest, HttpResponse> correlation) throws IOException {
- *         Map<String, Object> response = delegate.prepare(correlation);
- *         // modify response here
- *         return delegate.format(response);
- *      }
- *
- * }
- * }
- * </pre>
+ * A custom {@link HttpLogFormatter} that produces JSON objects. 
  */
 @API(status = STABLE)
-public final class JsonHttpLogFormatter implements StructuredHttpLogFormatter {
+public final class JsonHttpLogFormatter implements HttpLogFormatter {
 
-    private final ObjectMapper mapper;
-
-    public JsonHttpLogFormatter() {
-        this(new ObjectMapper());
-    }
-
-    public JsonHttpLogFormatter(final ObjectMapper mapper) {
-        this.mapper = mapper;
-    }
-
+    private static final String[] REPLACEMENT_CHARS;
+    
+    static {
+            REPLACEMENT_CHARS = new String[128];
+            for (int i = 0; i <= 0x1f; i++) {
+                REPLACEMENT_CHARS[i] = String.format("\\u%04x", (int) i);
+            }
+            REPLACEMENT_CHARS['"'] = "\\\"";
+            REPLACEMENT_CHARS['\\'] = "\\\\";
+            REPLACEMENT_CHARS['\t'] = "\\t";
+            REPLACEMENT_CHARS['\b'] = "\\b";
+            REPLACEMENT_CHARS['\r'] = "\\r";
+            REPLACEMENT_CHARS['\f'] = "\\f";
+      }
+    
     @Override
-    public Optional<Object> prepareBody(final HttpMessage message) throws IOException {
-        final String contentType = message.getContentType();
-        final String body = message.getBodyAsString();
+    public String format(Precorrelation precorrelation, HttpRequest request) throws IOException {
+        final String correlationId = precorrelation.getId();
+        
+        String body = request.getBodyAsString();
 
-        if (JsonMediaType.JSON.test(contentType)) {
-            return Optional.of(new JsonBody(body));
+        StringBuilder builder = new StringBuilder(body.length() + 2048);
+
+        builder.append("{\"origin\":\"");
+        if(request.getOrigin() == Origin.LOCAL) {
+            builder.append("local");
         } else {
-            return Optional.ofNullable(body.isEmpty() ? null : body);
+            builder.append("remote");
+        }
+        builder.append("\",\"type\":\"request\",\"correlation\":\"");
+        builder.append(correlationId); 
+        builder.append("\",\"protocol\":\"");
+        encode(request.getProtocolVersion(), builder);
+        builder.append("\",\"remote\":\"");
+        encode(request.getRemote(), builder);
+        builder.append("\",\"method\":\"");
+        encode(request.getMethod(), builder);
+        builder.append("\",\"uri\":\"");
+        reconstruct(request, builder);
+        builder.append('"');
+
+        writeHeaders(builder, request);
+
+        writeBody(request, body, builder);
+
+        builder.append('}');
+
+        return builder.toString();
+    }
+
+    private void writeBody(HttpMessage message, String body, StringBuilder builder) {
+        if(!body.isEmpty()) {
+            builder.append(",\"body\":");
+
+            final String contentType = message.getContentType();
+
+            if (JsonMediaType.JSON.test(contentType)) {
+                builder.append(body);
+            } else {
+                builder.append('"');
+                encode(body, builder);
+                builder.append('"');
+            }
         }
     }
 
     @Override
-    public String format(final Map<String, Object> content) throws IOException {
-        return mapper.writeValueAsString(content);
+    public String format(Correlation correlation, HttpResponse response) throws IOException {
+        
+        final String correlationId = correlation.getId();
+        
+        String body = response.getBodyAsString();
+
+        StringBuilder builder = new StringBuilder(body.length() + 2048);
+
+        builder.append("{\"origin\":\"");
+        if(response.getOrigin() == Origin.LOCAL) {
+            builder.append("local");
+        } else {
+            builder.append("remote");
+        }
+        builder.append("\",\"type\":\"response\",\"correlation\":\"");
+        builder.append(correlationId); 
+        builder.append("\",\"protocol\":\"");
+        encode(response.getProtocolVersion(), builder);
+        builder.append("\",\"duration\":");
+        builder.append(correlation.getDuration().toMillis()); 
+        builder.append(",\"status\":");
+        builder.append(response.getStatus()); 
+
+        writeHeaders(builder, response);
+        writeBody(response, body, builder);
+        
+        builder.append('}');
+
+        return builder.toString();      
     }
 
-    @AllArgsConstructor
-    private static final class JsonBody {
-        String json;
-
-        @JsonRawValue
-        @JsonValue
-        public String getJson() {
-            return json;
+    private void writeHeaders(StringBuilder builder, HttpMessage httpMessage) {
+        Map<String, List<String>> headers = httpMessage.getHeaders();
+        
+        if(!headers.isEmpty()) {
+            builder.append(",\"headers\":{");
+            
+            for (Entry<String, List<String>> entry : headers.entrySet()) {
+                builder.append('"');
+                encode(entry.getKey(), builder); 
+                builder.append("\":[");
+                List<String> headerValues = entry.getValue();
+                if(!headerValues.isEmpty()) {
+                    builder.append('"');
+                    for(String value : entry.getValue()) {
+                        encode(value, builder); 
+                        builder.append("\",\"");
+                    }
+                    builder.setLength(builder.length() - 2); // discard last comma and quote
+                }
+                builder.append("],");
+            }
+            builder.setCharAt(builder.length() - 1, '}'); // discard last comma
         }
     }
 
+    private void encode(String value, StringBuilder builder) {
+        int last = 0;
+        int length = value.length();
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            if (c >= 128) {
+                continue;
+            }
+            if(REPLACEMENT_CHARS[c] == null) {
+                continue;
+            }
+            if (last < i) {
+                builder.append(value, last, i);
+            }
+            builder.append(REPLACEMENT_CHARS[c]);
+            last = i + 1;
+        }
+        if (last < length) {
+            builder.append(value, last, length);
+        }
+    }
+    
+    private void reconstruct(final HttpRequest request, StringBuilder url) {
+        final String scheme = request.getScheme();
+        final String host = request.getHost();
+        final Optional<Integer> port = request.getPort();
+        final String path = request.getPath();
+        final String query = request.getQuery();
+
+        encode(scheme, url);
+        url.append(':');
+
+        url.append("//");
+        encode(host, url);
+
+        port.ifPresent(p -> {
+            if (isNotStandardPort(scheme, p)) {
+                url.append(':').append(p);
+            }
+        });
+
+        encode(path, url);
+
+        if (!query.isEmpty()) {
+            url.append('?');
+            encode(query, url);
+        }
+    }
+
+    private static boolean isNotStandardPort(final String scheme, final int port) {
+        return ("http".equals(scheme) && port != 80) ||
+                ("https".equals(scheme) && port != 443);
+    }
+    
 }
+

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
@@ -15,6 +15,12 @@ import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
 
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.time.Clock.systemUTC;
@@ -26,6 +32,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.not;
 import static org.zalando.logbook.Origin.LOCAL;
 import static org.zalando.logbook.Origin.REMOTE;
@@ -225,7 +232,7 @@ final class JsonHttpLogFormatterTest {
 
         final String json = unit.format(new SimplePrecorrelation("", systemUTC()), request);
 
-        assertThat(json, containsString("\"body\":}"));
+        assertThat(json, not(containsString("\"body\":}")));
     }
 
     @Test
@@ -323,7 +330,7 @@ final class JsonHttpLogFormatterTest {
 
         final String json = unit.format(new SimpleCorrelation(correlationId, ZERO), response);
 
-        assertThat(json, containsString("\"body\":}"));
+        assertThat(json, not(containsString("\"body\":}")));
     }
 
     @Test
@@ -349,7 +356,136 @@ final class JsonHttpLogFormatterTest {
 
         assertThat(json, containsString("{\"name\":\"Bob\"\n;};"));
     }
+    
+    @Test
+    void shouldLogCorrectRequestOrigin() throws IOException {
+        final String correlationId = "53de2640-677d-11e5-bc84-10ddb1ee7671";
+        final HttpRequest local = MockHttpRequest.create().withOrigin(LOCAL);
+        final String localJson = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), local);
 
+        with(localJson)
+                .assertThat("$.origin", is("local"));
+        
+        final HttpRequest remote = MockHttpRequest.create().withOrigin(REMOTE);
+        final String remoteJson = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), remote);
+
+        with(remoteJson)
+                .assertThat("$.origin", is("remote"));
+        
+    }       
+    
+    @Test
+    void shouldLogCorrectResponseOrigin() throws IOException {
+        final String correlationId = "53de2640-677d-11e5-bc84-10ddb1ee7671";
+        final HttpResponse local = MockHttpResponse.create().withOrigin(LOCAL);
+        final String localJson = unit.format(new SimpleCorrelation(correlationId, ofMillis(125)), local);
+
+        with(localJson)
+                .assertThat("$.origin", is("local"));
+        
+        final HttpResponse remote = MockHttpResponse.create().withOrigin(REMOTE);
+        final String remoteJson = unit.format(new SimpleCorrelation(correlationId, ofMillis(125)), remote);
+
+        with(remoteJson)
+                .assertThat("$.origin", is("remote"));
+        
+    }
+    
+    @Test
+    void shouldWorkWithSpecialCharacters() throws IOException {
+        final String correlationId = "5478b8da-6d87-11e5-a80f-10ddb1ee7671";
+        final HttpResponse response = MockHttpResponse.create()
+                .withContentType("application/json")
+                .withHeaders(MockHeaders.of("X-Nordic-Text", "ØÆÅabc\\\""))
+                .withBodyAsString("{\"name\":\"Bob\"}");
+
+        final String json = unit.format(new SimpleCorrelation(correlationId, ZERO), response);
+
+        with(json)
+            .assertThat("$.headers['X-Nordic-Text']", is(singletonList("ØÆÅabc\\\"")));
+    }
+    
+    @Test
+    void shouldWorkLogEmptyHeaders() throws IOException {
+        final String correlationId = "5478b8da-6d87-11e5-a80f-10ddb1ee7671";
+        
+        Map<String, List<String>> headers = new TreeMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put("X-Empty-Header", Collections.emptyList());
+        
+        final HttpResponse response = MockHttpResponse.create()
+                .withContentType("application/json")
+                .withHeaders(headers)
+                .withBodyAsString("{\"name\":\"Bob\"}");
+
+        final String json = unit.format(new SimpleCorrelation(correlationId, ZERO), response);
+
+        with(json)
+            .assertThat("$.headers['X-Empty-Header']", is(emptyCollectionOf(List.class)));
+    }
+
+    @Test
+    void shouldLogNonstandardHttpPort() throws IOException {
+        final String correlationId = "3ce91230-677b-11e5-87b7-10ddb1ee7671";
+        final HttpRequest request = MockHttpRequest.create()
+                .withProtocolVersion("HTTP/1.0")
+                .withOrigin(REMOTE)
+                .withPort(Optional.of(123))
+                .withPath("/test");
+
+        final String json = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+
+        with(json)
+                .assertThat("$.uri", is("http://localhost:123/test"));
+    }
+    
+    @Test
+    void shouldLogNonstandardHttpsPort() throws IOException {
+        final String correlationId = "3ce91230-677b-11e5-87b7-10ddb1ee7671";
+        final HttpRequest request = MockHttpRequest.create()
+                .withProtocolVersion("HTTPS/1.0")
+                .withScheme("https")
+                .withOrigin(REMOTE)
+                .withPort(Optional.of(123))
+                .withPath("/test");
+
+        final String json = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+
+        with(json)
+                .assertThat("$.uri", is("https://localhost:123/test"));
+    }    
+
+    @Test
+    void shouldNotLogStandardHttpsPort() throws IOException {
+        final String correlationId = "3ce91230-677b-11e5-87b7-10ddb1ee7671";
+        final HttpRequest request = MockHttpRequest.create()
+                .withProtocolVersion("HTTPS/1.0")
+                .withScheme("https")
+                .withOrigin(REMOTE)
+                .withPort(Optional.of(443))
+                .withPath("/test");
+
+        final String json = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+
+        with(json)
+                .assertThat("$.uri", is("https://localhost/test"));
+    }    
+
+    @Test
+    void shouldNotLogStandardHttpPort() throws IOException {
+        final String correlationId = "3ce91230-677b-11e5-87b7-10ddb1ee7671";
+        final HttpRequest request = MockHttpRequest.create()
+                .withProtocolVersion("HTTP/1.0")
+                .withScheme("http")
+                .withOrigin(REMOTE)
+                .withPort(Optional.of(80))
+                .withPath("/test");
+
+        final String json = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+
+        with(json)
+                .assertThat("$.uri", is("http://localhost/test"));
+    }     
     static class SimplePrecorrelation implements Precorrelation {
 
         private final String id;

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -257,9 +257,8 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnBean(ObjectMapper.class)
     @ConditionalOnMissingBean(HttpLogFormatter.class)
-    public HttpLogFormatter jsonFormatter(
-            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final ObjectMapper mapper) {
-        return new JsonHttpLogFormatter(mapper);
+    public HttpLogFormatter jsonFormatter() {
+        return new JsonHttpLogFormatter();
     }
 
     @API(status = INTERNAL)


### PR DESCRIPTION
Full optimization of JsonHttpLogFormatter.

Original:
Benchmark                                Mode  Cnt       Score     Error  Units
HttpLogFormatterBenchmark.jsonRequest thrpt 5 **291434**,027 ± 614,715 ops/s
HttpLogFormatterBenchmark.jsonResponse thrpt 5 **324309**,826 ± 565,692 ops/s

Optimized:
Benchmark                                Mode  Cnt       Score      Error  Units
HttpLogFormatterBenchmark.jsonRequest   thrpt    5  **447403**,477 ±  521,810  ops/s
HttpLogFormatterBenchmark.jsonResponse  thrpt    5  **388240**,457 ± 1964,092  ops/s

So in other words approximately +54% for request and ~~+40%~~ +20% for response.

## Description
StringBuilder with various inlining, including JSON output. Improves performance at the cost of rougher code.

## Motivation and Context
Improve performance. Even if the code changes are considered a too high price for the performance benefit, at least it is now known how much there is to gain from the original implementation.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
