### PR TITLE
Reuse Jackson JsonFactory, as it is thread safe

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -2,5 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
         <cve>CVE-2018-1258</cve>
+        <cve>CVE-2019-12814</cve>
     </suppress>
 </suppressions>

--- a/logbook-json/src/main/java/org/zalando/logbook/json/CompactingJsonBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/CompactingJsonBodyFilter.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.json;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
@@ -23,8 +24,12 @@ public final class CompactingJsonBodyFilter implements BodyFilter {
         this(new ObjectMapper());
     }
 
+    public CompactingJsonBodyFilter(final JsonFactory factory) {
+        this.compactor = new ParsingJsonCompactor(factory);
+    }
+
     public CompactingJsonBodyFilter(final ObjectMapper mapper) {
-        this.compactor = new ParsingJsonCompactor(mapper);
+        this(mapper.getFactory());
     }
 
     @Override

--- a/logbook-json/src/main/java/org/zalando/logbook/json/JacksonJsonFieldBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JacksonJsonFieldBodyFilter.java
@@ -30,12 +30,12 @@ public class JacksonJsonFieldBodyFilter implements BodyFilter {
 
     private final String replacement;
     private final Set<String> fields;
-    private final ObjectMapper objectMapper;
-    
+    private final JsonFactory factory;
+
     public JacksonJsonFieldBodyFilter(Collection<String> fieldNames, String replacement, ObjectMapper objectMapper) {
         this.fields = new HashSet<>(fieldNames); // thread safe for reading
         this.replacement = replacement;
-        this.objectMapper = objectMapper;
+        this.factory = objectMapper.getFactory();
     }
 
     public JacksonJsonFieldBodyFilter(Collection<String> fieldNames, String replacement) {
@@ -49,7 +49,6 @@ public class JacksonJsonFieldBodyFilter implements BodyFilter {
 
     public String filter(final String body) {
         try {
-            JsonFactory factory = objectMapper.getFactory();
             final JsonParser parser = factory.createParser(body);
             
             StringWriter writer = new StringWriter(body.length() * 2); // rough estimate of final size

--- a/logbook-json/src/main/java/org/zalando/logbook/json/ParsingJsonCompactor.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/ParsingJsonCompactor.java
@@ -12,12 +12,11 @@ import java.io.StringWriter;
 @AllArgsConstructor
 final class ParsingJsonCompactor implements JsonCompactor {
 
-    private final ObjectMapper mapper;
+    private final JsonFactory factory;
 
     @Override
     public String compact(final String json) throws IOException {
         final StringWriter output = new StringWriter(json.length());
-        final JsonFactory factory = mapper.getFactory();
         final JsonParser parser = factory.createParser(json);
 
         final JsonGenerator generator = factory.createGenerator(output);

--- a/pom.xml
+++ b/pom.xml
@@ -244,19 +244,20 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- spring security -->
+            <!-- note: BOM order matters -->
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>${spring-security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- spring boot -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- spring security -->
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-bom</artifactId>
-                <version>${spring-security.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -651,7 +652,7 @@
             <properties>
                 <spring.version>4.3.24.RELEASE</spring.version>
                 <spring-boot.version>1.5.21.RELEASE</spring-boot.version>
-                <spring-security.version>4.2.12.RELEASE</spring-security.version>
+                <spring-security.version>4.2.13.RELEASE</spring-security.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Reuse Jackson JsonFactory.

## Description
From JsonFactory Javadoc:

 * Factory instances are thread-safe and reusable after configuration
 * (if any). Typically applications and services use only a single
 * globally shared factory instance, unless they need differently
 * configured factories. Factory reuse is important if efficiency matters;
 * most recycling of expensive construct is done on per-factory basis.

## Motivation and Context
Improve performance.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
