### PR TITLE
Add note about Spring Boot Starter dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,16 @@ Logbook comes with a convenient auto configuration for Spring Boot users. It set
 - HTTP-/JSON-style formatter
 - Logging writer
 
+Instead of declaring a dependency to `logback-core` declare one to the Spring Boot Starter:
+
+```xml
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>logbook-spring-boot-starter</artifactId>
+    <version>${logbook.version}</version>
+</dependency>
+```
+
 Every bean can be overridden and customized if needed, e.g. like this:
 
 ```java


### PR DESCRIPTION
## Description
The README should mention to use the Spring Boot Starter dependency instead of the core dependency when working with Spring Boot.

## Motivation and Context
To combat issues like this one https://github.com/zalando/logbook/issues/218#issuecomment-506634294

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
