### PR TITLE
Filtering is now preserved when discarding body

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/FilteredHttpRequest.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/FilteredHttpRequest.java
@@ -1,21 +1,25 @@
 package org.zalando.logbook;
 
+import lombok.AllArgsConstructor;
 import org.apiguardian.api.API;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static lombok.AccessLevel.PRIVATE;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
-// TODO package private
 @API(status = INTERNAL)
-public final class FilteredHttpRequest implements ForwardingHttpRequest {
+@AllArgsConstructor(access = PRIVATE)
+final class FilteredHttpRequest implements ForwardingHttpRequest {
 
     private final HttpRequest request;
+
     private final String query;
     private final String path;
     private final BodyFilter bodyFilter;
+
     private final Map<String, List<String>> headers;
 
     FilteredHttpRequest(final HttpRequest request,
@@ -39,23 +43,37 @@ public final class FilteredHttpRequest implements ForwardingHttpRequest {
     }
 
     @Override
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    @Override
     public String getRequestUri() {
         return RequestURI.reconstruct(this);
+    }
+
+    @Override
+    public String getPath() {
+        return path;
     }
 
     @Override
     public String getQuery() {
         return query;
     }
-    
+
     @Override
-    public Map<String, List<String>> getHeaders() {
-        return headers;
+    public HttpRequest withBody() throws IOException {
+        return withRequest(request.withBody());
     }
-    
+
     @Override
-    public String getPath() {
-        return path;
+    public HttpRequest withoutBody() {
+        return withRequest(request.withoutBody());
+    }
+
+    private FilteredHttpRequest withRequest(final HttpRequest request) {
+        return new FilteredHttpRequest(request, query, path, bodyFilter, headers);
     }
 
     @Override

--- a/logbook-core/src/main/java/org/zalando/logbook/FilteredHttpResponse.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/FilteredHttpResponse.java
@@ -1,18 +1,21 @@
 package org.zalando.logbook;
 
+import lombok.AllArgsConstructor;
 import org.apiguardian.api.API;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static lombok.AccessLevel.PRIVATE;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
-// TODO package private
 @API(status = INTERNAL)
-public final class FilteredHttpResponse implements ForwardingHttpResponse {
+@AllArgsConstructor(access = PRIVATE)
+final class FilteredHttpResponse implements ForwardingHttpResponse {
 
     private final HttpResponse response;
+
     private final BodyFilter bodyFilter;
     private final Map<String, List<String>> headers;
 
@@ -31,6 +34,20 @@ public final class FilteredHttpResponse implements ForwardingHttpResponse {
     @Override
     public Map<String, List<String>> getHeaders() {
         return headers;
+    }
+
+    @Override
+    public HttpResponse withBody() throws IOException {
+        return withResponse(response.withBody());
+    }
+
+    @Override
+    public HttpResponse withoutBody() {
+        return withResponse(response.withoutBody());
+    }
+
+    private HttpResponse withResponse(final HttpResponse response) {
+        return new FilteredHttpResponse(response, bodyFilter, headers);
     }
 
     @Override

--- a/logbook-core/src/test/java/org/zalando/logbook/FilteredHttpRequestTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/FilteredHttpRequestTest.java
@@ -48,6 +48,16 @@ final class FilteredHttpRequestTest {
     }
 
     @Test
+    void shouldFilterAuthorizationHeaderWithBody() throws IOException {
+        assertThat(unit.withBody().getHeaders(), hasEntry(equalTo("Authorization"), contains("XXX")));
+    }
+
+    @Test
+    void shouldFilterAuthorizationHeaderWithoutBody() {
+        assertThat(unit.withoutBody().getHeaders(), hasEntry(equalTo("Authorization"), contains("XXX")));
+    }
+
+    @Test
     void shouldNotFilterAcceptHeader() {
         assertThat(unit.getHeaders(), hasEntry(equalTo("Accept"), contains("text/plain")));
     }

--- a/logbook-core/src/test/java/org/zalando/logbook/FilteredHttpResponseTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/FilteredHttpResponseTest.java
@@ -26,6 +26,16 @@ final class FilteredHttpResponseTest {
     }
 
     @Test
+    void shouldFilterAuthorizationHeaderWithBody() throws IOException {
+        assertThat(unit.withBody().getHeaders(), hasEntry(equalTo("Authorization"), contains("XXX")));
+    }
+
+    @Test
+    void shouldFilterAuthorizationHeaderWithoutBody() {
+        assertThat(unit.withoutBody().getHeaders(), hasEntry(equalTo("Authorization"), contains("XXX")));
+    }
+
+    @Test
     void shouldNotFilterAcceptHeader() {
         assertThat(unit.getHeaders(), hasEntry(equalTo("Accept"), contains("text/plain")));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Discarding body (or re-enabling it) caused filtered headers to not be used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #581

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
