### PR TITLE
Adding Remote in HTTP Incoming Request log

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/DefaultHttpLogFormatter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/DefaultHttpLogFormatter.java
@@ -32,6 +32,10 @@ public final class DefaultHttpLogFormatter implements HttpLogFormatter {
         builder.append(correlationId);
         builder.append('\n');
 
+        builder.append("Remote: ");
+        builder.append(request.getRemote());
+        builder.append('\n');
+
         builder.append(request.getMethod());
         builder.append(' ');
         RequestURI.reconstruct(request, builder);

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
@@ -35,6 +35,7 @@ final class DefaultHttpLogFormatterTest {
         final String http = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
 
         assertThat(http, is("Incoming Request: c9408eaa-677d-11e5-9457-10ddb1ee7671\n" +
+                "Remote: 127.0.0.1\n" +
                 "GET http://localhost/test?limit=1 HTTP/1.0\n" +
                 "Accept: application/json\n" +
                 "Content-Type: text/plain\n" +
@@ -56,6 +57,7 @@ final class DefaultHttpLogFormatterTest {
         final String http = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
 
         assertThat(http, is("Outgoing Request: 2bd05240-6827-11e5-bbee-10ddb1ee7671\n" +
+                "Remote: 127.0.0.1\n" +
                 "GET http://localhost/test HTTP/1.1\n" +
                 "Accept: application/json\n" +
                 "Content-Type: text/plain\n" +
@@ -73,6 +75,7 @@ final class DefaultHttpLogFormatterTest {
         final String http = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
 
         assertThat(http, is("Incoming Request: 0eae9f6c-6824-11e5-8b0a-10ddb1ee7671\n" +
+                "Remote: 127.0.0.1\n" +
                 "GET http://localhost/test HTTP/1.1\n" +
                 "Accept: application/json"));
     }
@@ -140,11 +143,11 @@ final class DefaultHttpLogFormatterTest {
     @Test
     void shouldLogResponseForEmptyHeader() throws IOException {
         final String correlationId = "2d51bc02-677e-11e5-8b9b-10ddb1ee7671";
-        
+
         final Map<String, List<String>> headers = new TreeMap<>();
         headers.put("Content-Type", Collections.singletonList("application/json"));
         headers.put("X-Empty-Header", Collections.emptyList());
-        
+
         final HttpResponse response = MockHttpResponse.create()
                 .withProtocolVersion("HTTP/1.0")
                 .withOrigin(Origin.REMOTE)


### PR DESCRIPTION
## Description
This would add Remote to incoming request log for format style http.

## Motivation and Context
https://github.com/zalando/logbook/issues/598

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

It seems getting proper remote is missing for jax-rs
https://github.com/zalando/logbook/blob/master/logbook-jaxrs/src/main/java/org/zalando/logbook/jaxrs/RemoteRequest.java#L40 
