### PR TITLE
Fixed missing flush for writer

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -107,6 +107,14 @@ final class LocalResponse extends HttpServletResponseWrapper implements HttpResp
     }
 
     @Override
+    public void flushBuffer() throws IOException {
+        if (buffer != null) {
+            buffer.flush();
+        }
+        super.flushBuffer();
+    }
+
+    @Override
     public byte[] getBody() {
         return body == null ? new byte[0] : body.getBytes();
     }
@@ -133,6 +141,14 @@ final class LocalResponse extends HttpServletResponseWrapper implements HttpResp
                 writer = new PrintWriter(new OutputStreamWriter(output, charset.get()));
             }
             return writer;
+        }
+
+        void flush() throws IOException {
+            if (writer == null) {
+                output.flush();
+            } else {
+                writer.flush();
+            }
         }
 
         byte[] getBytes() {

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -46,7 +46,7 @@ public final class LogbookFilter implements HttpFilter {
         final RemoteRequest request = new RemoteRequest(httpRequest);
         final LocalResponse response = new LocalResponse(httpResponse, request.getProtocolVersion());
 
-        final ResponseWritingStage stage = logRequest(request, request).process(response);
+        final ResponseWritingStage stage = logRequest(request).process(response);
 
         chain.doFilter(request, response);
 
@@ -58,14 +58,12 @@ public final class LogbookFilter implements HttpFilter {
         stage.write();
     }
 
-    private ResponseProcessingStage logRequest(final HttpServletRequest httpRequest,
-            final HttpRequest request) throws IOException {
-
-        if (httpRequest.getDispatcherType() == DispatcherType.ASYNC) {
-            return (ResponseProcessingStage) httpRequest.getAttribute(STAGE);
+    private ResponseProcessingStage logRequest(final RemoteRequest request) throws IOException {
+        if (request.getDispatcherType() == DispatcherType.ASYNC) {
+            return (ResponseProcessingStage) request.getAttribute(STAGE);
         } else {
             final ResponseProcessingStage stage = process(request).write();
-            httpRequest.setAttribute(STAGE, stage);
+            request.setAttribute(STAGE, stage);
             return stage;
         }
     }

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ExampleController.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ExampleController.java
@@ -13,7 +13,6 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.CharBuffer;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -95,9 +94,7 @@ public class ExampleController {
 
     @RequestMapping(path = "/reader", produces = TEXT_PLAIN_VALUE)
     public void reader(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        try (final PrintWriter writer = response.getWriter()) {
-            copy(request.getReader(), writer);
-        }
+        copy(request.getReader(), response.getWriter());
     }
 
     @RequestMapping(path = "/binary", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LocalResponseTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LocalResponseTest.java
@@ -95,6 +95,12 @@ class LocalResponseTest {
     }
 
     @Test
+    void shouldDelegateClose() throws IOException {
+        unit.withBody();
+        unit.getOutputStream().close();
+    }
+
+    @Test
     void shouldTeeGetWriter() throws IOException {
         unit.withBody();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Turns out that my fake controller in tests behaved too correctly. It always closed (and implicitly flushed) the writer it was using. But that is in fact not done by everyone out there in the wild. Ultimately the `flushBuffer` method is invoked on the response, but that wasn't intercepted and propagated properly. The noticable effect was that users which use `getWriter()` without an explicit `close` or `flush` would not see the body getting logged and even worse wouldn't see the body on the wire either.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #603

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
