### PR TITLE
Fixed typo (I guess :))

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ Logbook comes with a convenient auto configuration for Spring Boot users. It set
 - HTTP-/JSON-style formatter
 - Logging writer
 
-Instead of declaring a dependency to `logback-core` declare one to the Spring Boot Starter:
+Instead of declaring a dependency to `logbook-core` declare one to the Spring Boot Starter:
 
 ```xml
 <dependency>


### PR DESCRIPTION
## Description
I think there is a small typo in the README you probably wanted to put logbook-core but instead wrote logback-core.

## Motivation and Context
Only a small typo I noticed by accident.

## Types of changes
-  [x] Typo
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
