### PR TITLE
Add logstash into spring autoconfiguration and provide logstash raw marker config possibility

### DIFF
--- a/logbook-logstash/src/main/java/org/zalando/logbook/logstash/LogstashLogbackSink.java
+++ b/logbook-logstash/src/main/java/org/zalando/logbook/logstash/LogstashLogbackSink.java
@@ -25,6 +25,12 @@ public final class LogstashLogbackSink implements Sink {
 
     private final HttpLogFormatter formatter;
 
+    private final String baseField;
+
+    public LogstashLogbackSink(final HttpLogFormatter formatter) {
+        this(formatter, "http");
+    }
+
     @Override
     public boolean isActive() {
         return log.isTraceEnabled();
@@ -32,7 +38,7 @@ public final class LogstashLogbackSink implements Sink {
 
     @Override
     public void write(final Precorrelation precorrelation, final HttpRequest request) throws IOException {
-        final Marker marker = new AutodetectPrettyPrintingMarker("http", formatter.format(precorrelation, request));
+        final Marker marker = new AutodetectPrettyPrintingMarker(baseField, formatter.format(precorrelation, request));
         log.trace(marker, requestMessage(request));
     }
 
@@ -43,7 +49,7 @@ public final class LogstashLogbackSink implements Sink {
     @Override
     public void write(final Correlation correlation, final HttpRequest request,
             final HttpResponse response) throws IOException {
-        final Marker marker = new AutodetectPrettyPrintingMarker("http", formatter.format(correlation, response));
+        final Marker marker = new AutodetectPrettyPrintingMarker(baseField, formatter.format(correlation, response));
 
         log.trace(marker, responseMessage(request, response));
     }


### PR DESCRIPTION
## Description
2 changes overall:
* Provide a possibility to change the logstash raw marker field name which contains all the information about the requests and responses
* Add a Spring configuration possibility to use the logstash sink and configure the raw marker field name

## Motivation and Context
The first change is motivated by an issue in our logging environment (ELK). As we use it for many applications, the http field name clashes with an already existing one which is indexed and defined as a different type. Because of this, we cannot even see the requests and responses logged by logbook. For this, I introduced a possibility to change this field name.
The second change is more of a convenient change for Spring autoconfiguration. Currently, we need to define an own Spring bean to be able to use this Logstash sink. I'm not sure if you have some requirements on if and how configuration changes should be for your framework, so feedback is pretty much appreciated (and if needed, I could roll back the second change if you don't feel this is a good way)
I added both changes in a way that the defaults are as before and no breaking changes are introduced.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
