### PR TITLE
Add feature in JsonBodyFilters to replace value by custom function.

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonBodyFilters.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonBodyFilters.java
@@ -6,7 +6,7 @@ import org.zalando.logbook.BodyFilter;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 import java.util.function.Predicate;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
@@ -83,7 +83,7 @@ public final class JsonBodyFilters {
     @API(status = API.Status.EXPERIMENTAL)
     public static BodyFilter replacePrimitiveJsonProperty(
             final Predicate<String> predicate,
-            final BiFunction<String, String, String> replacement) {
+            final BinaryOperator<String> replacement) {
         return replacePrimitiveFunction(predicate, replacement);
     }
 }

--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonBodyFilters.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonBodyFilters.java
@@ -6,12 +6,14 @@ import org.zalando.logbook.BodyFilter;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.replaceNumber;
 import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.replacePrimitive;
+import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.replacePrimitiveFunction;
 import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.replaceString;
 
 public final class JsonBodyFilters {
@@ -78,4 +80,10 @@ public final class JsonBodyFilters {
         return replacePrimitive(predicate, replacement);
     }
 
+    @API(status = API.Status.EXPERIMENTAL)
+    public static BodyFilter replacePrimitiveJsonProperty(
+            final Predicate<String> predicate,
+            final BiFunction<String, String, String> replacement) {
+        return replacePrimitiveFunction(predicate, replacement);
+    }
 }

--- a/logbook-json/src/main/java/org/zalando/logbook/json/PrimitiveJsonPropertyBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/PrimitiveJsonPropertyBodyFilter.java
@@ -5,6 +5,8 @@ import lombok.With;
 import org.zalando.logbook.BodyFilter;
 
 import javax.annotation.Nullable;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -63,25 +65,31 @@ final class PrimitiveJsonPropertyBodyFilter implements BodyFilter {
     @With(PRIVATE)
     private final Predicate<String> predicate;
 
-    private final String replacement;
+    private final BinaryOperator<String> replacement;
 
     private static Pattern pattern(final String value) {
-        return compile("(?<key>\"(?<property>" + STRING_VALUE_PATTERN + ")\"\\s*:\\s*)(" + value + "|null)");
+        return compile("(?<key>\"(?<property>" + STRING_VALUE_PATTERN + ")\"\\s*:\\s*)(?<propertyValue>" + value + "|null)");
     }
 
     static BodyFilter replaceString(
             final Predicate<String> predicate, final String replacement) {
-        return create(STRING, predicate, quote(replacement));
+        return create(STRING, predicate, new StaticParameterReplacementOperator<>(replacement, true));
     }
 
     static BodyFilter replaceNumber(
             final Predicate<String> predicate, final Number replacement) {
-        return create(NUMBER, predicate, String.valueOf(replacement));
+        return create(NUMBER, predicate, new StaticParameterReplacementOperator<>(replacement, false));
     }
 
     static BodyFilter replacePrimitive(
             final Predicate<String> predicate, final String replacement) {
-        return create(PRIMITIVE, predicate, quote(replacement));
+        return create(PRIMITIVE, predicate, new StaticParameterReplacementOperator<>(replacement, true));
+    }
+
+    static BodyFilter replacePrimitiveFunction(
+            final Predicate<String> predicate,
+            final BiFunction<String, String, String> replacement) {
+        return create(PRIMITIVE, predicate, new StringFunctionReplacementOperator(replacement));
     }
 
     public static String quote(final String s) {
@@ -98,7 +106,8 @@ final class PrimitiveJsonPropertyBodyFilter implements BodyFilter {
                 if (predicate.test(matcher.group("property"))) {
                     // this preserves whitespaces around properties
                     matcher.appendReplacement(result, "${key}");
-                    result.append(replacement);
+                    result.append(this.replacement.apply(matcher.group("property"),
+                            matcher.group("propertyValue")));
                 } else {
                     matcher.appendReplacement(result, "$0");
                 }

--- a/logbook-json/src/main/java/org/zalando/logbook/json/PrimitiveJsonPropertyBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/PrimitiveJsonPropertyBodyFilter.java
@@ -73,17 +73,17 @@ final class PrimitiveJsonPropertyBodyFilter implements BodyFilter {
 
     static BodyFilter replaceString(
             final Predicate<String> predicate, final String replacement) {
-        return create(STRING, predicate, new StaticParameterReplacementOperator<>(replacement, true));
+        return create(STRING, predicate, new QuotedStringReplacementOperator<>(replacement));
     }
 
     static BodyFilter replaceNumber(
             final Predicate<String> predicate, final Number replacement) {
-        return create(NUMBER, predicate, new StaticParameterReplacementOperator<>(replacement, false));
+        return create(NUMBER, predicate, new StaticParameterReplacementOperator<>(replacement));
     }
 
     static BodyFilter replacePrimitive(
             final Predicate<String> predicate, final String replacement) {
-        return create(PRIMITIVE, predicate, new StaticParameterReplacementOperator<>(replacement, true));
+        return create(PRIMITIVE, predicate, new QuotedStringReplacementOperator<>(replacement));
     }
 
     static BodyFilter replacePrimitiveFunction(
@@ -106,7 +106,7 @@ final class PrimitiveJsonPropertyBodyFilter implements BodyFilter {
                 if (predicate.test(matcher.group("property"))) {
                     // this preserves whitespaces around properties
                     matcher.appendReplacement(result, "${key}");
-                    result.append(this.replacement.apply(matcher.group("property"),
+                    result.append(replacement.apply(matcher.group("property"),
                             matcher.group("propertyValue")));
                 } else {
                     matcher.appendReplacement(result, "$0");

--- a/logbook-json/src/main/java/org/zalando/logbook/json/QuotedStringReplacementOperator.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/QuotedStringReplacementOperator.java
@@ -1,17 +1,17 @@
 package org.zalando.logbook.json;
 
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 
 import java.util.function.BinaryOperator;
 
+import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.quote;
+
 @AllArgsConstructor
-@EqualsAndHashCode
-final class StaticParameterReplacementOperator<T> implements BinaryOperator<String> {
+final class QuotedStringReplacementOperator<T> implements BinaryOperator<String> {
     private final T replacement;
 
     @Override
     public String apply(String s, String s2) {
-        return replacement.toString();
+        return quote(replacement.toString());
     }
 }

--- a/logbook-json/src/main/java/org/zalando/logbook/json/QuotedStringReplacementOperator.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/QuotedStringReplacementOperator.java
@@ -1,12 +1,14 @@
 package org.zalando.logbook.json;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 
 import java.util.function.BinaryOperator;
 
 import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.quote;
 
 @AllArgsConstructor
+@EqualsAndHashCode
 final class QuotedStringReplacementOperator<T> implements BinaryOperator<String> {
     private final T replacement;
 

--- a/logbook-json/src/main/java/org/zalando/logbook/json/StaticParameterReplacementOperator.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/StaticParameterReplacementOperator.java
@@ -1,0 +1,21 @@
+package org.zalando.logbook.json;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+import java.util.function.BinaryOperator;
+
+import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.quote;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+public class StaticParameterReplacementOperator<T> implements BinaryOperator<String> {
+    private final T replacement;
+
+    private final boolean addQuotation;
+
+    @Override
+    public String apply(String s, String s2) {
+        return addQuotation ? quote(replacement.toString()) : replacement.toString();
+    }
+}

--- a/logbook-json/src/main/java/org/zalando/logbook/json/StringFunctionReplacementOperator.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/StringFunctionReplacementOperator.java
@@ -10,8 +10,8 @@ import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.quote;
 
 @AllArgsConstructor
 @EqualsAndHashCode
-public class StringFunctionReplacementOperator implements BinaryOperator<String> {
-    private BiFunction<String, String, String> stringReplacementFunction;
+final class StringFunctionReplacementOperator implements BinaryOperator<String> {
+    private final BiFunction<String, String, String> stringReplacementFunction;
 
     @Override
     public String apply(String s, String s2) {

--- a/logbook-json/src/main/java/org/zalando/logbook/json/StringFunctionReplacementOperator.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/StringFunctionReplacementOperator.java
@@ -1,0 +1,20 @@
+package org.zalando.logbook.json;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+
+import static org.zalando.logbook.json.PrimitiveJsonPropertyBodyFilter.quote;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+public class StringFunctionReplacementOperator implements BinaryOperator<String> {
+    private BiFunction<String, String, String> stringReplacementFunction;
+
+    @Override
+    public String apply(String s, String s2) {
+        return quote(stringReplacementFunction.apply(s, s2));
+    }
+}

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonBodyFiltersTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonBodyFiltersTest.java
@@ -227,4 +227,17 @@ class JsonBodyFiltersTest {
         assertThat(actual, is(original));
     }
 
+    @Test
+    void shouldFilterPrimitivesWithFunction() {
+        final BodyFilter unit = replacePrimitiveJsonProperty(
+                asList("foo", "bar", "baz")::contains, (s, s2) -> s + "XXX" + s2);
+
+        final String actual = unit.filter(
+                contentType,
+                "{\"foo\":1.0,\"bar\":false,\"baz\":\"secret\"}");
+
+        assertThat(actual,
+                is("{\"foo\":\"fooXXX1.0\",\"bar\":\"barXXXfalse\",\"baz\":\"bazXXX\"secret\"\"}"));
+    }
+
 }


### PR DESCRIPTION
Summary:
Currently Json Body filters obfusicate the property values with a replacement string. eg. "XXX". However, users may want to do a custom obfusication of these values for eg. Hash of the given value. In order to make it extensible, add a function in JSonBodyFilter to convert a primitive JSON using a custom function provided by the user.

 Description:
The following changes are made:

- Make PrimitiveJsonPropertyBodyFilter as abstract class, where child class will provide replacement function.
- Change Pattern regular expression to add groupname "propertyValue" for grouping the value.
- Add two subclass for string replacement and function replacement.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds extension to help users create a custom filter function.
Fixes #851
https://github.com/zalando/logbook/issues/755

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation. (Not sure about this)
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
