### PR TITLE
Fix ClassNotFoundException when LogbookAutoConfiguration is processed

### DIFF
--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -345,11 +345,20 @@ public class LogbookAutoConfiguration {
                     .withFormRequestMode(properties.getFilter().getFormRequestMode());
             return newFilter(filter, FILTER_NAME, Ordered.LOWEST_PRECEDENCE);
         }
+        
+        private static FilterRegistrationBean newFilter(final Filter filter, final String filterName, final int order) {
+            @SuppressWarnings("unchecked") // as of Spring Boot 2.x
+            final FilterRegistrationBean registration = new FilterRegistrationBean(filter);
+            registration.setName(filterName);
+            registration.setDispatcherTypes(REQUEST, ASYNC);
+            registration.setOrder(order);
+            return registration;
+        }
 
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(SecurityFilterChain.class)
+    @ConditionalOnClass({ SecurityFilterChain.class, Filter.class })
     @ConditionalOnWebApplication
     @AutoConfigureAfter(name = {
             "org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration", // Spring Boot 1.x
@@ -363,18 +372,9 @@ public class LogbookAutoConfiguration {
         @ConditionalOnProperty(name = "logbook.secure-filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
         public FilterRegistrationBean secureLogbookFilter(final Logbook logbook) {
-            return newFilter(new SecureLogbookFilter(logbook), FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
+            return ServletFilterConfiguration.newFilter(new SecureLogbookFilter(logbook), FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
         }
 
-    }
-
-    private static FilterRegistrationBean newFilter(final Filter filter, final String filterName, final int order) {
-        @SuppressWarnings("unchecked") // as of Spring Boot 2.x
-        final FilterRegistrationBean registration = new FilterRegistrationBean(filter);
-        registration.setName(filterName);
-        registration.setDispatcherTypes(REQUEST, ASYNC);
-        registration.setOrder(order);
-        return registration;
     }
 
 }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -67,6 +67,7 @@ import static javax.servlet.DispatcherType.ASYNC;
 import static javax.servlet.DispatcherType.REQUEST;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
+import static org.zalando.logbook.autoconfigure.LogbookAutoConfiguration.ServletFilterConfiguration.newFilter;
 import static org.zalando.logbook.BodyFilters.defaultValue;
 import static org.zalando.logbook.BodyFilters.truncate;
 import static org.zalando.logbook.HeaderFilters.replaceHeaders;
@@ -346,7 +347,7 @@ public class LogbookAutoConfiguration {
             return newFilter(filter, FILTER_NAME, Ordered.LOWEST_PRECEDENCE);
         }
         
-        private static FilterRegistrationBean newFilter(final Filter filter, final String filterName, final int order) {
+        static FilterRegistrationBean newFilter(final Filter filter, final String filterName, final int order) {
             @SuppressWarnings("unchecked") // as of Spring Boot 2.x
             final FilterRegistrationBean registration = new FilterRegistrationBean(filter);
             registration.setName(filterName);
@@ -358,7 +359,7 @@ public class LogbookAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass({ SecurityFilterChain.class })
+    @ConditionalOnClass(SecurityFilterChain.class)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
             "org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration", // Spring Boot 1.x
@@ -372,7 +373,7 @@ public class LogbookAutoConfiguration {
         @ConditionalOnProperty(name = "logbook.secure-filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
         public FilterRegistrationBean secureLogbookFilter(final Logbook logbook) {
-            return ServletFilterConfiguration.newFilter(new SecureLogbookFilter(logbook), FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
+            return newFilter(new SecureLogbookFilter(logbook), FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
         }
     }
 }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -324,7 +325,7 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(Filter.class)
-    @ConditionalOnWebApplication
+    @ConditionalOnWebApplication(type = Type.SERVLET)
     static class ServletFilterConfiguration {
 
         private static final String FILTER_NAME = "logbookFilter";
@@ -359,7 +360,7 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({ SecurityFilterChain.class, Filter.class })
-    @ConditionalOnWebApplication
+    @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
             "org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration", // Spring Boot 1.x
             "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
@@ -374,7 +375,5 @@ public class LogbookAutoConfiguration {
         public FilterRegistrationBean secureLogbookFilter(final Logbook logbook) {
             return ServletFilterConfiguration.newFilter(new SecureLogbookFilter(logbook), FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
         }
-
     }
-
 }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -324,7 +324,6 @@ public class LogbookAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(Filter.class)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     static class ServletFilterConfiguration {
 
@@ -359,7 +358,7 @@ public class LogbookAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass({ SecurityFilterChain.class, Filter.class })
+    @ConditionalOnClass({ SecurityFilterChain.class })
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
             "org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration", // Spring Boot 1.x


### PR DESCRIPTION
To avoid `ClassNotFoundException: javax.servlet.Filter` a code referencing the `Filter` is moved to a static inner class which is processed only conditionally when `javax.servlet.Filter` is on the classpath.

## Description
<!--- Describe your changes in detail -->
Factory method for creating `FilterRegistrationBean` moved from `LogbookAutoConfiguration` to conditionally processed class `ServletFilterConfiguration`.

## Motivation and Context
Fixes issue https://github.com/zalando/logbook/issues/881

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
