### PR TITLE
Changed default Servlet charset to ISO-8859-1

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static lombok.AccessLevel.PROTECTED;
 import static org.zalando.fauxpas.FauxPas.throwingUnaryOperator;
 
@@ -176,7 +176,15 @@ final class LocalResponse extends HttpServletResponseWrapper implements HttpResp
 
     @Override
     public Charset getCharset() {
-        return Optional.ofNullable(getCharacterEncoding()).map(Charset::forName).orElse(UTF_8);
+        return Optional.ofNullable(getCharacterEncoding())
+                .map(Charset::forName)
+                /*
+                 * Servlet Spec, 5.6 Internationalization
+                 *
+                 * If the servlet does not specify a character encoding before the getWriter method of the
+                 * ServletResponse interface is called or the response is committed, the default ISO-8859-1 is used.
+                 */
+                .orElse(ISO_8859_1);
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Logbook violates the servlet spec because we use UTF-8 as the default fallback charset, when in fact we should be using ISO-8859-1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #870 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
