### PR TITLE
Fix empty response body when using Spring RestTemplate with LogbookClientHttpRequestInterceptor

### DIFF
--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
@@ -9,6 +9,7 @@ import org.zalando.logbook.Origin;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -60,8 +61,9 @@ final class RemoteResponse implements HttpResponse {
 
         @Override
         public State buffer(final ClientHttpResponse response) throws IOException {
-            response.getBody();
-            byte[] data = ByteStreams.toByteArray(response.getBody());
+            InputStream responseBodyStream = response.getBody();
+            byte[] data = ByteStreams.toByteArray(responseBodyStream);
+            responseBodyStream.reset();
             return new Buffering(data);
         }
 

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
@@ -80,7 +80,7 @@ class LogbookClientHttpRequestInterceptorTest {
     void get200() throws IOException {
         serviceServer.expect(once(), requestTo("/test/get")).andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess().body("response"));
-        restTemplate.getForObject("/test/get", Void.class);
+        restTemplate.getForObject("/test/get", String.class);
 
         verify(writer).write(precorrelationCaptor.capture(), requestCaptor.capture());
         verify(writer).write(correlationCaptor.capture(), responseCaptor.capture());
@@ -94,6 +94,14 @@ class LogbookClientHttpRequestInterceptorTest {
         assertTrue(responseCaptor.getValue().contains(precorrelationCaptor.getValue().getId()));
         assertTrue(responseCaptor.getValue().contains("200 OK"));
         assertTrue(responseCaptor.getValue().contains("response"));
+    }
+
+    @Test
+    void get200WithEmptyResponseBody(){
+        serviceServer.expect(once(), requestTo("/test/get")).andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess());
+
+        restTemplate.getForObject("/test/get", Void.class);
     }
 
     @Test

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.ExpectedCount.once;
@@ -93,6 +94,18 @@ class LogbookClientHttpRequestInterceptorTest {
         assertTrue(responseCaptor.getValue().contains(precorrelationCaptor.getValue().getId()));
         assertTrue(responseCaptor.getValue().contains("200 OK"));
         assertTrue(responseCaptor.getValue().contains("response"));
+    }
+
+    @Test
+    void get200WithNonEmptyResponseBody() {
+        String expectedResponseBody = "response";
+        serviceServer.expect(once(), requestTo("/test/get")).andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess().body(expectedResponseBody));
+
+        String actualResponseBody = restTemplate.getForObject("/test/get", String.class);
+
+        assertNotNull(actualResponseBody);
+        assertEquals(expectedResponseBody, actualResponseBody);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes that null response bodies are returned for non-empty responses when using the new LogbookClientHttpRequestInterceptor with a Spring RestTemplate.

## Description
The response extractor of the Spring RestTemplate considers the position of the response body stream.
This leads to a null response body, since the buffered RemoteResponse was not resetting the streams position after copying the response body bytes.

## Motivation and Context
Currently RestTemplates without any special configuration are returning null response entities when using the new LogbookClientHttpRequestInterceptor.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
