### PR TITLE
log response body when netty passes in a ByteBuf instead of a HttpContent

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Buffering.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Buffering.java
@@ -2,7 +2,6 @@ package org.zalando.logbook.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 
 final class Buffering implements State {
@@ -19,12 +18,11 @@ final class Buffering implements State {
     }
 
     @Override
-    public State buffer(final HttpMessage message, final HttpContent content) {
-        final ByteBuf source = content.content();
-        final int index = source.readerIndex();
-        buffer.ensureWritable(source.readableBytes());
-        source.readBytes(buffer, source.readableBytes());
-        source.readerIndex(index);
+    public State buffer(final HttpMessage message, final ByteBuf content) {
+        final int index = content.readerIndex();
+        buffer.ensureWritable(content.readableBytes());
+        content.readBytes(buffer, content.readableBytes());
+        content.readerIndex(index);
         return this;
     }
 

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Ignoring.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Ignoring.java
@@ -1,6 +1,6 @@
 package org.zalando.logbook.netty;
 
-import io.netty.handler.codec.http.HttpContent;
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMessage;
 import lombok.AllArgsConstructor;
 
@@ -15,7 +15,7 @@ final class Ignoring implements State {
     }
 
     @Override
-    public State buffer(final HttpMessage message, final HttpContent content) {
+    public State buffer(final HttpMessage message, final ByteBuf content) {
         buffering.buffer(message, content);
         return this;
     }

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Offering.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Offering.java
@@ -1,10 +1,9 @@
 package org.zalando.logbook.netty;
 
-import io.netty.handler.codec.http.HttpContent;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpMessage;
-
 import static io.netty.handler.codec.http.HttpUtil.getContentLength;
-import static io.netty.handler.codec.http.LastHttpContent.EMPTY_LAST_CONTENT;
 
 final class Offering implements State {
 
@@ -14,8 +13,8 @@ final class Offering implements State {
     }
 
     @Override
-    public State buffer(final HttpMessage message, final HttpContent content) {
-        if (content.equals(EMPTY_LAST_CONTENT)) {
+    public State buffer(final HttpMessage message, final ByteBuf content) {
+        if (content.equals(Unpooled.EMPTY_BUFFER)) {
             // saves us from allocating an unnecessary buffer
             return this;
         }

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
@@ -1,19 +1,17 @@
 package org.zalando.logbook.netty;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
-import lombok.AllArgsConstructor;
-import org.zalando.logbook.HttpHeaders;
-import org.zalando.logbook.Origin;
-
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.Origin;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static lombok.AccessLevel.PRIVATE;
@@ -112,7 +110,7 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
         return this;
     }
 
-    void buffer(final HttpContent content) {
+    void buffer(final ByteBuf content) {
         state.updateAndGet(state -> state.buffer(request, content));
     }
 

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Response.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Response.java
@@ -1,16 +1,14 @@
 package org.zalando.logbook.netty;
 
-import io.netty.handler.codec.http.HttpContent;
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponse;
-import lombok.AllArgsConstructor;
-import org.zalando.logbook.HttpHeaders;
-import org.zalando.logbook.Origin;
-
-import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
-
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.Origin;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 
 @AllArgsConstructor
@@ -67,7 +65,7 @@ final class Response
         return this;
     }
 
-    void buffer(final HttpContent content) {
+    void buffer(final ByteBuf content) {
         state.updateAndGet(state -> state.buffer(response, content));
     }
 

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/State.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/State.java
@@ -1,6 +1,6 @@
 package org.zalando.logbook.netty;
 
-import io.netty.handler.codec.http.HttpContent;
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMessage;
 
 interface State {
@@ -14,7 +14,7 @@ interface State {
     }
 
     default State buffer(
-            final HttpMessage message, final HttpContent content) {
+            final HttpMessage message, final ByteBuf content) {
         return this;
     }
 

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/IgnoringTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/IgnoringTest.java
@@ -1,13 +1,11 @@
 package org.zalando.logbook.netty;
 
-import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.atomic.AtomicReference;
-
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -34,8 +32,8 @@ final class IgnoringTest {
         Assertions.assertEquals("foobar", body);
     }
 
-    private DefaultHttpContent content(final String s) {
-        return new DefaultHttpContent(wrappedBuffer(s.getBytes(UTF_8)));
+    private ByteBuf content(final String s) {
+        return wrappedBuffer(s.getBytes(UTF_8));
     }
 
 }


### PR DESCRIPTION
## Description
Handle case where netty passes in a `ByteBuf` instead of an `HttpContent`. I've changed `State#buffer` to accept a `ByteBuf` directly instead of a `HttpContent` to avoid having to wrap the `ByteBuf` only to unwrap it again shortly after. I've unfortunately not found a good way to test this, i.e. a test is missing at this time.

## Motivation and Context
Fixes #977

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
