### PR TITLE
capture response where servlet code programmatically starts async dispatch

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListener.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListener.java
@@ -1,0 +1,9 @@
+package org.zalando.logbook.servlet;
+
+import java.io.IOException;
+import javax.servlet.AsyncEvent;
+
+@FunctionalInterface
+interface AsyncOnCompleteListener {
+    void onComplete(AsyncEvent event) throws IOException;
+}

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookAsyncListener.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookAsyncListener.java
@@ -1,0 +1,31 @@
+package org.zalando.logbook.servlet;
+
+import java.io.IOException;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+
+class LogbookAsyncListener implements AsyncListener {
+
+    private final AsyncOnCompleteListener onCompleteListener;
+
+    public LogbookAsyncListener(AsyncOnCompleteListener onCompleteListener) {
+        this.onCompleteListener = onCompleteListener;
+    }
+
+    @Override
+    public void onComplete(AsyncEvent event) throws IOException {
+        onCompleteListener.onComplete(event);
+    }
+
+    @Override
+    public void onTimeout(AsyncEvent event) {
+    }
+
+    @Override
+    public void onError(AsyncEvent event) {
+    }
+
+    @Override
+    public void onStartAsync(AsyncEvent event) {
+    }
+}

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
@@ -1,5 +1,12 @@
 package org.zalando.logbook.servlet;
 
+import java.io.IOException;
+import java.time.Duration;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +16,7 @@ import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConf
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -19,11 +27,6 @@ import org.zalando.logbook.DefaultSink;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
-
-import javax.servlet.DispatcherType;
-import java.io.IOException;
-import java.time.Duration;
-
 import static javax.servlet.DispatcherType.ASYNC;
 import static javax.servlet.DispatcherType.REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,9 +45,44 @@ final class AsyncDispatchTest {
     @MockBean
     private HttpLogWriter writer;
 
+    static class AsyncHttpServlet extends HttpServlet{
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+            asyncResponse(req.startAsync(req, resp));
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp)  {
+            asyncResponse(req.startAsync());
+        }
+
+        private void asyncResponse(AsyncContext asyncContext) {
+            new Thread(() -> {
+                try {
+                    Thread.sleep(100);
+                    final HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
+                    response.setStatus(200);
+                    response.addHeader("Content-Type", "text/plain");
+                    response.getWriter().println("Hello Async");
+                    asyncContext.complete();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }).start();
+        }
+    }
+
     @Configuration
     @Import(ExampleController.class)
     static class TestConfiguration {
+
+        @Bean
+        public ServletRegistrationBean<AsyncHttpServlet> asyncHttpServlet() {
+            ServletRegistrationBean<AsyncHttpServlet> bean = new ServletRegistrationBean<>(new AsyncHttpServlet(), "/servlet/*");
+            bean.setLoadOnStartup(1);
+            return bean;
+        }
 
         @Bean
         public Logbook logbook(final HttpLogWriter writer) {
@@ -95,6 +133,34 @@ final class AsyncDispatchTest {
 
         assertThat(response)
                 .contains("200 OK", "text/plain", "Hello, world!");
+    }
+
+    @Test
+    void shouldFormatAsyncServletResponseGet() throws Exception {
+        final RestTemplate template = new RestTemplate();
+        template.getForObject("http://localhost:8080/servlet/async", String.class);
+
+        waitFor(Duration.ofSeconds(1));
+
+        interceptRequest();
+        final String response = interceptResponse();
+
+        assertThat(response)
+                .contains("200 OK", "text/plain", "Hello Async");
+    }
+
+    @Test
+    void shouldFormatAsyncServletResponsePost() throws Exception {
+        final RestTemplate template = new RestTemplate();
+        template.postForObject("http://localhost:8080/servlet/async", "Hello Servlet", String.class);
+
+        waitFor(Duration.ofSeconds(1));
+
+        interceptRequest();
+        final String response = interceptResponse();
+
+        assertThat(response)
+                .contains("200 OK", "text/plain", "Hello Async");
     }
 
     @SneakyThrows

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookAsyncListenerTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookAsyncListenerTest.java
@@ -1,0 +1,37 @@
+package org.zalando.logbook.servlet;
+
+import java.io.IOException;
+import javax.servlet.AsyncEvent;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LogbookAsyncListenerTest {
+
+    private final AsyncOnCompleteListener asyncOnCompleteListener = mock(AsyncOnCompleteListener.class);
+    private final AsyncEvent asyncEvent = mock(AsyncEvent.class);
+
+    private final LogbookAsyncListener logbookAsyncListener = new LogbookAsyncListener(asyncOnCompleteListener);
+
+    @Test
+    void onComplete() throws IOException {
+        logbookAsyncListener.onComplete(asyncEvent);
+
+        verify(asyncOnCompleteListener).onComplete(asyncEvent);
+    }
+
+    @Test
+    void onTimeout() {
+        logbookAsyncListener.onTimeout(asyncEvent);
+    }
+
+    @Test
+    void onError() {
+        logbookAsyncListener.onError(asyncEvent);
+    }
+
+    @Test
+    void onStartAsync() {
+        logbookAsyncListener.onStartAsync(asyncEvent);
+    }
+}

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/RemoteRequestTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/RemoteRequestTest.java
@@ -1,12 +1,50 @@
 package org.zalando.logbook.servlet;
 
+import java.util.Optional;
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RemoteRequestTest {
+
+    private final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    private final HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    private final AsyncContext asyncContext = mock(AsyncContext.class);
+    private final AsyncListener asyncListener = mock(AsyncListener.class);
+
+    private final RemoteRequest remoteRequest = new RemoteRequest(httpServletRequest, FormRequestMode.OFF);
+
+    @BeforeEach
+    void setUp() {
+        remoteRequest.setAsyncListener(Optional.of(asyncListener));
+    }
+
+    @Test
+    void startAsync_noargs() {
+        when(httpServletRequest.startAsync()).thenReturn(asyncContext);
+
+        assertEquals(asyncContext, remoteRequest.startAsync());
+        verify(asyncContext).addListener(asyncListener);
+    }
+
+    @Test
+    void startAsync_twoargs() {
+        when(httpServletRequest.startAsync(httpServletRequest, httpServletResponse)).thenReturn(asyncContext);
+
+        assertEquals(asyncContext, remoteRequest.startAsync(httpServletRequest, httpServletResponse));
+        verify(asyncContext).addListener(asyncListener);
+    }
 
     @Test
     void shouldThrow() {


### PR DESCRIPTION
## Description
The GraphQL servlet from https://github.com/graphql-java-kickstart/graphql-java-servlet programmatically starts an async request by calling `startAsync` on the `HttpServletRequest`. In this case, logbook misses the reply because the logbook filter checks `request.isAsyncStarted()` before logging. In order to fix this issue, an `AsyncListener` is being registered whenever `startAsync` is being called.

Regarding `LogbookAsyncListener`, would it make sense to also implement the other methods besides `onComplete`? If yes, how?

## Motivation and Context
Fix for issue #954

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
