### PR TITLE
Fix CommonsLogFormatSink class name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ a JSON response body will **not** be escaped and represented as a string:
 
 ##### Common Log Format
 
-The Common Log Format ([CLF](https://httpd.apache.org/docs/trunk/logs.html#common)) is a standardized text file format used by web servers when generating server log files. The format is supported via the `CommonLogFormatSink`:
+The Common Log Format ([CLF](https://httpd.apache.org/docs/trunk/logs.html#common)) is a standardized text file format used by web servers when generating server log files. The format is supported via the `CommonsLogFormatSink`:
 
 ```text
 185.85.220.253 - - [02/Aug/2019:08:16:41 0000] "GET /search?q=zalando HTTP/1.1" 200 -


### PR DESCRIPTION
Fix `CommonsLogFormatSink` class name

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix a typo referring to the wrong class name in the README.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Better documentation == 👯‍♀️ 🥳 ❤️

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
