### PR TITLE
fix: README PathFilter based on property name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ or the following table to see a list of possible integration points:
 | `Logbook`                |                       | Based on condition, filters, formatter and writer                         |
 | `Predicate<HttpRequest>` | `requestCondition`    | No filter; is later combined with `logbook.exclude` and `logbook.exclude` |
 | `HeaderFilter`           |                       | Based on `logbook.obfuscate.headers`                                      |
-| `PathFilter`             |                       | Based on `logbook.obfuscate.parameters`                                   |
+| `PathFilter`             |                       | Based on `logbook.obfuscate.paths`                                   |
 | `QueryFilter`            |                       | Based on `logbook.obfuscate.parameters`                                   |
 | `BodyFilter`             |                       | `BodyFilters.defaultValue()`, see [filtering](#filtering)                 |
 | `RequestFilter`          |                       | `RequestFilters.defaultValue()`, see [filtering](#filtering)              |

--- a/logbook-api/src/main/java/org/zalando/logbook/PathFilter.java
+++ b/logbook-api/src/main/java/org/zalando/logbook/PathFilter.java
@@ -15,7 +15,7 @@ public interface PathFilter {
     }
 
     static PathFilter merge(final PathFilter left, final PathFilter right) {
-        return headers ->
-                left.filter(right.filter(headers));
+        return path ->
+                left.filter(right.filter(path));
     }
 }


### PR DESCRIPTION
Only a small typo fix for PathFilter description in the LogbookAutoconfig section