### PR TITLE
fix the RestTemplate interceptor & confirm with wiremock

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,8 +632,11 @@ The `logbook-spring` module contains a `ClientHttpRequestInterceptor` to use wit
 ```java
     LogbookClientHttpRequestInterceptor interceptor = new LogbookClientHttpRequestInterceptor(logbook);
     RestTemplate restTemplate = new RestTemplate();
+    restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
     restTemplate.getInterceptors().add(interceptor);
 ```
+
+**note** if you use the `spring-boot-starter` then you can enable this with spring properties `logbook.write.interceptors-enabled=true`
 
 ### Spring Boot Starter
 
@@ -705,21 +708,22 @@ MyClient(RestTemplateBuilder builder, LogbookClientHttpRequestInterceptor interc
 
 The following tables show the available configuration:
 
-| Configuration                      | Description                                                                                          | Default                       |
-|------------------------------------|------------------------------------------------------------------------------------------------------|-------------------------------|
-| `logbook.include`                  | Include only certain URLs (if defined)                                                               | `[]`                          |
-| `logbook.exclude`                  | Exclude certain URLs (overrides `logbook.include`)                                                   | `[]`                          |
-| `logbook.filter.enabled`           | Enable the [`LogbookFilter`](#servlet)                                                               | `true`                        |
-| `logbook.filter.form-request-mode` | Determines how [form requests](#form-requests) are handled                                           | `body`                        |
-| `logbook.secure-filter.enabled`    | Enable the [`SecureLogbookFilter`](#servlet)                                                         | `true`                        |
-| `logbook.format.style`             | [Formatting style](#formatting) (`http`, `json`, `curl` or `splunk`)                                 | `json`                        |
-| `logbook.strategy`                 | [Strategy](#strategy) (`default`, `status-at-least`, `body-only-if-status-at-least`, `without-body`) | `default`                     |
-| `logbook.minimum-status`           | Minimum status to enable logging (`status-at-least` and `body-only-if-status-at-least`)              | `400`                         |
-| `logbook.obfuscate.headers`        | List of header names that need obfuscation                                                           | `[Authorization]`             |
-| `logbook.obfuscate.paths`          | List of paths that need obfuscation. Check [Filtering](#filtering) for syntax.                       | `[]`                          |
-| `logbook.obfuscate.parameters`     | List of parameter names that need obfuscation                                                        | `[access_token]`              |
-| `logbook.write.chunk-size`         | Splits log lines into smaller chunks of size up-to `chunk-size`.                                     | `0` (disabled)                |
-| `logbook.write.max-body-size`      | Truncates the body up to `max-body-size` and appends `...`.                                          | `-1` (disabled)               |
+| Configuration                       | Description                                                                                          | Default                       |
+|-------------------------------------|------------------------------------------------------------------------------------------------------|-------------------------------|
+| `logbook.include`                   | Include only certain URLs (if defined)                                                               | `[]`                          |
+| `logbook.exclude`                   | Exclude certain URLs (overrides `logbook.include`)                                                   | `[]`                          |
+| `logbook.filter.enabled`            | Enable the [`LogbookFilter`](#servlet)                                                               | `true`                        |
+| `logbook.filter.form-request-mode`  | Determines how [form requests](#form-requests) are handled                                           | `body`                        |
+| `logbook.secure-filter.enabled`     | Enable the [`SecureLogbookFilter`](#servlet)                                                         | `true`                        |
+| `logbook.format.style`              | [Formatting style](#formatting) (`http`, `json`, `curl` or `splunk`)                                 | `json`                        |
+| `logbook.strategy`                  | [Strategy](#strategy) (`default`, `status-at-least`, `body-only-if-status-at-least`, `without-body`) | `default`                     |
+| `logbook.minimum-status`            | Minimum status to enable logging (`status-at-least` and `body-only-if-status-at-least`)              | `400`                         |
+| `logbook.obfuscate.headers`         | List of header names that need obfuscation                                                           | `[Authorization]`             |
+| `logbook.obfuscate.paths`           | List of paths that need obfuscation. Check [Filtering](#filtering) for syntax.                       | `[]`                          |
+| `logbook.obfuscate.parameters`      | List of parameter names that need obfuscation                                                        | `[access_token]`              |
+| `logbook.write.chunk-size`          | Splits log lines into smaller chunks of size up-to `chunk-size`.                                     | `0` (disabled)                |
+| `logbook.write.max-body-size`       | Truncates the body up to `max-body-size` and appends `...`.                                          | `-1` (disabled)               |
+| `logbook.write.interceptors-enabled`| Enables `LogbookClientHttpInterceptor`                                                               | `false`                       |
 
 ##### Example configuration
 

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -310,6 +310,13 @@ public class LogbookAutoConfiguration {
         return new LogbookClientHttpRequestInterceptor(logbook);
     }
 
+    @Bean
+    @ConditionalOnMissingBean(LogbookRestTemplateCustomizer.class)
+    @ConditionalOnProperty(name = "logbook.write.interceptors-enabled", havingValue = "true")
+    public LogbookRestTemplateCustomizer logbookRestTemplateCustomizer(LogbookClientHttpRequestInterceptor logbookClientHttpRequestInterceptor){
+        return new LogbookRestTemplateCustomizer(logbookClientHttpRequestInterceptor);
+    }
+
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
             HttpClient.class,

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
@@ -34,6 +34,7 @@ public final class LogbookProperties {
     public static class Write {
         private int chunkSize;
         private int maxBodySize = -1;
+        private boolean interceptorsEnabled = false;
     }
 
     @Getter
@@ -41,5 +42,4 @@ public final class LogbookProperties {
     public static class Filter {
         private FormRequestMode formRequestMode = FormRequestMode.fromProperties();
     }
-
 }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookRestTemplateCustomizer.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookRestTemplateCustomizer.java
@@ -1,0 +1,19 @@
+package org.zalando.logbook.autoconfigure;
+
+import lombok.AllArgsConstructor;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
+
+@AllArgsConstructor
+public class LogbookRestTemplateCustomizer implements RestTemplateCustomizer {
+
+    private final LogbookClientHttpRequestInterceptor logbookClientHttpRequestInterceptor;
+
+    @Override
+    public void customize(RestTemplate restTemplate) {
+        restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
+        restTemplate.getInterceptors().add(logbookClientHttpRequestInterceptor);
+    }
+}

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/LogbookRestTemplateCustomizerTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/LogbookRestTemplateCustomizerTest.java
@@ -1,0 +1,57 @@
+package org.zalando.logbook.autoconfigure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogbookRestTemplateCustomizerTest {
+
+    @LogbookTest(properties = "logbook.write.interceptors-enabled=true")
+    @Nested
+    class Enabled {
+        @Autowired
+        private RestTemplateBuilder builder;
+
+        private RestTemplate restTemplate;
+
+        @BeforeEach
+        void setup(){
+            restTemplate = builder
+                    .build();
+        }
+
+        @Test
+        void hasInterceptor(){
+            assertThat(restTemplate.getInterceptors())
+                    .anyMatch(in -> in instanceof LogbookClientHttpRequestInterceptor);
+        }
+    }
+
+    @LogbookTest(properties = "logbook.write.interceptors-enabled=false")
+    @Nested
+    class Disabled {
+        @Autowired
+        private RestTemplateBuilder builder;
+
+        private RestTemplate restTemplate;
+
+        @BeforeEach
+        void setup(){
+            restTemplate = builder
+                    .build();
+        }
+
+        @Test
+        void noInterceptor(){
+            assertThat(restTemplate.getInterceptors())
+                    .noneMatch(in -> in instanceof LogbookClientHttpRequestInterceptor);
+        }
+    }
+}

--- a/logbook-spring/pom.xml
+++ b/logbook-spring/pom.xml
@@ -68,5 +68,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ru.lanwen.wiremock</groupId>
+            <artifactId>wiremock-junit5</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
@@ -63,7 +63,6 @@ final class RemoteResponse implements HttpResponse {
         public State buffer(final ClientHttpResponse response) throws IOException {
             InputStream responseBodyStream = response.getBody();
             byte[] data = ByteStreams.toByteArray(responseBodyStream);
-            responseBodyStream.reset();
             return new Buffering(data);
         }
 

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
@@ -9,6 +9,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -67,8 +68,11 @@ class LogbookClientHttpRequestInterceptorTest {
                 .build();
         interceptor = new LogbookClientHttpRequestInterceptor(logbook);
         restTemplate = new RestTemplate();
-        restTemplate.getInterceptors().add(interceptor);
+
+        // order matters because MockRestServiceServer modifies the requestFactory underneath
         serviceServer = MockRestServiceServer.createServer(restTemplate);
+        restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
+        restTemplate.getInterceptors().add(interceptor);
     }
 
     @AfterEach

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorWiremockTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorWiremockTest.java
@@ -1,0 +1,81 @@
+package org.zalando.logbook.spring;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.logbook.*;
+import ru.lanwen.wiremock.config.WiremockCustomizer;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({
+        WiremockResolver.class,
+        WiremockUriResolver.class,
+        MockitoExtension.class
+})
+public class LogbookClientHttpRequestInterceptorWiremockTest {
+
+    @Mock
+    private HttpLogWriter writer;
+    @Captor
+    private ArgumentCaptor<Correlation> correlationCaptor;
+    @Captor
+    private ArgumentCaptor<String> responseCaptor;
+
+    private Logbook logbook;
+    private LogbookClientHttpRequestInterceptor interceptor;
+
+    public static class Endpoint implements WiremockCustomizer {
+
+        static String URI = "/ping";
+
+        @Override
+        public void customize(com.github.tomakehurst.wiremock.WireMockServer server) throws Exception {
+            server.stubFor(WireMock.get(urlEqualTo(URI))
+                    .willReturn(aResponse()
+                            .withBody("pong"))
+            );
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        when(writer.isActive()).thenReturn(true);
+        logbook = Logbook.builder()
+                .strategy(new TestStrategy())
+                .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+                .build();
+        interceptor = new LogbookClientHttpRequestInterceptor(logbook);
+    }
+
+    @Test
+    void ping(@WiremockResolver.Wiremock(customizer = Endpoint.class) WireMockServer server,
+              @WiremockUriResolver.WiremockUri String uri) throws IOException {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
+        restTemplate.getInterceptors().add(interceptor);
+
+        String out = restTemplate.getForObject(uri + Endpoint.URI, String.class);
+
+        verify(writer).write(correlationCaptor.capture(), responseCaptor.capture());
+        assertThat(out).isEqualTo("pong");
+        assertThat(responseCaptor.getValue()).contains("pong");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,8 @@
         <spring-boot.version>2.4.4</spring-boot.version>
         <spring-security.version>5.4.5</spring-security.version>
 
+        <wiremock.version>2.16.0</wiremock.version>
+        <wiremock.junit5.version>1.3.0</wiremock.junit5.version>
         <junit.version>5.7.1</junit.version>
         <mockito.version>3.8.0</mockito.version>
         <jmh.version>1.29</jmh.version>
@@ -334,6 +336,18 @@
                         <artifactId>hamcrest-library</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${wiremock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>ru.lanwen.wiremock</groupId>
+                <artifactId>wiremock-junit5</artifactId>
+                <version>${wiremock.junit5.version}</version>
+                <scope>test</scope>
             </dependency>
             <!-- Needed by json-path-assert and rest-client-driver... -->
             <dependency>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Want to help resolve: https://github.com/zalando/logbook/issues/963
- Seems like the `MockRestServiceServer` isn't verifying enough

## Description
<!--- Describe your changes in detail -->
The previous attempt to fix was calling `.reset()` which seems dangerous since not every child class impls this method. On my [repro](https://github.com/nhomble/logbook-resttemplate-error-repro), I had `EofSensorInputStream`. 

Instead of trying to reset the response body directly, we can leverage spring's wrappers. This requires no changes to logbook and just an update to documentation. The new test with `wiremock` confirms this behavior. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/zalando/logbook/issues/963
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
