### PR TITLE
append empty headers matching support - for example, if header is abs…

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/Conditions.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/Conditions.java
@@ -1,11 +1,14 @@
 package org.zalando.logbook;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apiguardian.api.API;
 import org.zalando.logbook.common.Glob;
 import org.zalando.logbook.common.MediaTypeQuery;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -62,13 +65,16 @@ public final class Conditions {
     }
 
     public static <T extends HttpMessage> Predicate<T> header(final String key, final String value) {
-        return message ->
-                message.getHeaders().getOrDefault(key, emptyList()).contains(value);
+        return message -> {
+            final List<String> headerValues = message.getHeaders().get(key);
+            if (StringUtils.isEmpty(value) && (headerValues == null || headerValues.isEmpty())) return true;
+            return message.getHeaders().getOrDefault(key, emptyList()).contains(value);
+        };
     }
 
     public static <T extends HttpMessage> Predicate<T> header(final String key, final Predicate<String> predicate) {
         return message ->
-                message.getHeaders().getOrDefault(key, emptyList()).stream().anyMatch(predicate);
+            message.getHeaders().getOrDefault(key, Collections.singletonList("")).stream().anyMatch(predicate);
     }
 
     public static <T extends HttpMessage> Predicate<T> header(final BiPredicate<String, String> predicate) {

--- a/logbook-core/src/test/java/org/zalando/logbook/ConditionsTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/ConditionsTest.java
@@ -150,9 +150,9 @@ final class ConditionsTest {
     }
 
     @Test
-    void headerShouldNotMatchPredicateWhenHeaderIsAbsent() {
-        final Predicate<HttpMessage> unit = header("X-Absent", v -> true);
+    void headerShouldMatchPredicateEvenIfItIsAbsentButItStillMatchesPredicate() {
+        final Predicate<HttpMessage> unit = header("X-Absent", v -> v.equals(""));
 
-        assertThat(unit.test(request)).isFalse();
+        assertThat(unit.test(request)).isTrue();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>


### PR DESCRIPTION
Append empty headers matching support 

## Description
In general, I have made it possible to apply predicate to header even if it is absent considering header as empty string. Below u can see my triuble with that

## Motivation and Context
II have faced an issue I want to exclude with logbook some requests, that has contain empty Authorization header or **does not contain it at all**. As u can understand header name here is unimportant, it could be easily some another header. Unfortunately, by default, if logbook see that header is absent it is not apply predicate to it at all. This it quite sadly, because what I really need to tell logbook is something like this : "Hey, if Authorization header is absent, or consists of an empty string, that you should not log request and corresponding response". 

## Types of changes

The changes I have made is quite simple:
1) Adjust 2 methods in **Conditions** - I think changes is self descriptive, I have made possible to compare header even if it is absent (in this case header is considered as empty string) with predicate  
2) I have obviously run unit tests and fix one that have failed because of my change. This test btw describes my idea - even if header is empty it possibly could satisfy predicate
3) Append apache commons dependency, to just simplify some ordinary stuff, hope we will make use of this latter also

## Checklist:
I think my changes should be somewhere documented. If you will procure me place where this change should be documented I will certainly supply you with one

Best regards,
Mikhail

