### PR TITLE
create support for absent header condition

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/Conditions.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/Conditions.java
@@ -78,4 +78,8 @@ public final class Conditions {
                                 e.getValue().stream().anyMatch(v -> predicate.test(e.getKey(), v)));
     }
 
+    public static <T extends HttpMessage> Predicate<T> withoutHeader(String headerName) {
+        return message -> !message.getHeaders().containsKey(headerName);
+    }
+
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/ConditionsTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/ConditionsTest.java
@@ -11,6 +11,7 @@ import static org.zalando.logbook.Conditions.exclude;
 import static org.zalando.logbook.Conditions.header;
 import static org.zalando.logbook.Conditions.requestTo;
 import static org.zalando.logbook.Conditions.withoutContentType;
+import static org.zalando.logbook.Conditions.withoutHeader;
 
 final class ConditionsTest {
 
@@ -154,5 +155,23 @@ final class ConditionsTest {
         final Predicate<HttpMessage> unit = header("X-Absent", v -> true);
 
         assertThat(unit.test(request)).isFalse();
+    }
+
+    @Test
+    void withoutHeader() {
+        final Predicate<HttpMessage> unit = Conditions.withoutHeader("Authorization");
+
+        assertThat(unit.test(request)).isTrue();
+    }
+
+    @Test
+    void withEmptyHeader() {
+        final MockHttpRequest requestWithEmptyAuthorizationHeader = MockHttpRequest.create()
+                                                                                   .withHeaders(HttpHeaders.of("Authorization", ""))
+                                                                                   .withContentType("application/json");
+
+        final Predicate<HttpMessage> unit = Conditions.withoutHeader("Authorization");
+
+        assertThat(unit.test(requestWithEmptyAuthorizationHeader)).isFalse();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create additional condition in order to support condition - "header is absent in http request" 

## Motivation and Context
Encounter in our project. Requirement was to disable logging for requests (and corresponding responses) without certain headers 

## Types of changes
New feature (and corresponding tests for it also goes along)

## Checklist:
Required tests have been already created. Consider to doc this change somewhere. If you will provide me with the link I can supply with one :)  