### PR TITLE
Made JsonPathBodyFilter mergeable

### DIFF
--- a/logbook-jmh/src/main/java/org/zalando/logbook/json/JsonPathBodyFilterBenchmark.java
+++ b/logbook-jmh/src/main/java/org/zalando/logbook/json/JsonPathBodyFilterBenchmark.java
@@ -7,6 +7,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import static org.zalando.logbook.json.JsonPathBodyFilters.jsonPath;
 
@@ -21,7 +22,7 @@ public class JsonPathBodyFilterBenchmark {
 
     @Benchmark
     public void replaceStringDynamicallyBenchmark() {
-        jsonPath("$.test").replace("(\\d{6})\\d+(\\d{4})", "$1********$2")
+        jsonPath("$.test").replace(Pattern.compile("(\\d{6})\\d+(\\d{4})"), "$1********$2")
                 .filter(CONTENT_TYPE, BODY);
     }
 

--- a/logbook-json/src/test/resources/student.json
+++ b/logbook-json/src/test/resources/student.json
@@ -1,0 +1,23 @@
+{
+  "id": 1,
+  "name": "Alice",
+  "password": "s3cr3t",
+  "active": true,
+  "address": "Anhalter Straße 17 13, 67278 Bockenheim an der Weinstraße",
+  "friends": [
+    {
+      "id": 2,
+      "name": "Bob"
+    },
+    {
+      "id": 3,
+      "name": "Charlie"
+    }
+  ],
+  "grades": {
+    "Math": 1.0,
+    "English": 2.2,
+    "Science": 1.9,
+    "PE": 4.0
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,12 @@
             </dependency>
             <!-- testing: common -->
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>30.1.1-jre</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.version}</version>
@@ -393,6 +399,10 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <!-- testing -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made JsonPathBodyFilter mergeable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users will typically have many JsonPath filters and each instance would parse the body and produce a new one.
By merging them we can save performance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
