### PR TITLE
Logbook-json: Remove json-smart dependency.

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
@@ -9,6 +9,8 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -81,6 +83,7 @@ public final class JsonPathBodyFilters {
         private static final ParseContext CONTEXT = JsonPath.using(
                 Configuration.builder()
                         .jsonProvider(new JacksonJsonNodeJsonProvider())
+                        .mappingProvider(new JacksonMappingProvider())
                         .build());
 
         private final Operation operation;

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
@@ -2,6 +2,8 @@ package org.zalando.logbook.json;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.zalando.logbook.Correlation;
@@ -13,12 +15,22 @@ import org.zalando.logbook.MockHttpRequest;
 import org.zalando.logbook.MockHttpResponse;
 import org.zalando.logbook.Precorrelation;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.time.Clock.systemUTC;
@@ -33,6 +45,27 @@ import static org.zalando.logbook.Origin.LOCAL;
 import static org.zalando.logbook.Origin.REMOTE;
 
 final class JsonHttpLogFormatterTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        Configuration.setDefaults(new Defaults() {
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return new JacksonMappingProvider();
+            }
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return new JacksonJsonProvider();
+            }
+        });
+    }
 
     @MethodSource
     static Iterable<HttpLogFormatter> units() {
@@ -154,7 +187,7 @@ final class JsonHttpLogFormatterTest {
     void shouldNotEmbedReplacedJsonRequestBody(final HttpLogFormatter unit) throws IOException {
         final HttpRequest request = MockHttpRequest.create()
                 .withContentType("application/json")
-                .withBodyAsString("<skipped>");
+                .withBodyAsString("\"<skipped>\"");
 
         final String json = unit.format(new SimplePrecorrelation("", systemUTC()), request);
 

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
@@ -2,10 +2,21 @@ package org.zalando.logbook.json;
 
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.google.common.io.Resources;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.zalando.logbook.BodyFilter;
 
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static com.google.common.io.Resources.getResource;
 import static com.jayway.jsonassert.JsonAssert.with;
@@ -25,6 +36,27 @@ class JsonPathBodyFiltersTest {
     @SuppressWarnings("UnstableApiUsage")
     JsonPathBodyFiltersTest() throws IOException {
         this.student = Resources.toString(getResource("student.json"), UTF_8);
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        Configuration.setDefaults(new Defaults() {
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return new JacksonMappingProvider();
+            }
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return new JacksonJsonProvider();
+            }
+        });
     }
 
     @Test

--- a/logbook-logstash/src/test/java/org/zalando/logbook/logstash/LogbackLogstashSinkTest.java
+++ b/logbook-logstash/src/test/java/org/zalando/logbook/logstash/LogbackLogstashSinkTest.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.logstash;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.zalando.logbook.Correlation;
 import org.zalando.logbook.HttpHeaders;
@@ -12,8 +13,18 @@ import org.zalando.logbook.MockHttpResponse;
 import org.zalando.logbook.Precorrelation;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
 import java.io.IOException;
 import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.util.Collections.singletonList;
@@ -32,6 +43,27 @@ import static org.zalando.logbook.Origin.REMOTE;
  */
 
 class LogbackLogstashSinkTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        Configuration.setDefaults(new Defaults() {
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return new JacksonMappingProvider();
+            }
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return new JacksonJsonProvider();
+            }
+        });
+    }
 
     @AfterAll
     static void tearDown() {

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/FormattingTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/FormattingTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.servlet;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -16,7 +17,17 @@ import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.TestStrategy;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.util.Collections.singletonList;
@@ -49,6 +60,27 @@ final class FormattingTest {
                     .sink(new DefaultSink(formatter, writer))
                     .build()))
             .build();
+
+    @BeforeAll
+    static void beforeAll() {
+        Configuration.setDefaults(new Defaults() {
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return new JacksonMappingProvider();
+            }
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return new JacksonJsonProvider();
+            }
+        });
+    }
 
     @BeforeEach
     void setUp() {

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/TeeTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/TeeTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.servlet;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -11,6 +12,14 @@ import org.zalando.logbook.HttpLogFormatter;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -21,6 +30,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Verifies that {@link LogbookFilter} handles the copying of streams in {@link RemoteRequest} and {@link LocalResponse}
@@ -37,6 +49,27 @@ final class TeeTest {
                     .sink(new DefaultSink(formatter, writer))
                     .build()))
             .build();
+
+    @BeforeAll
+    static void beforeAll() {
+        Configuration.setDefaults(new Defaults() {
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return new JacksonMappingProvider();
+            }
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return new JacksonJsonProvider();
+            }
+        });
+    }
 
     @BeforeEach
     void setUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,13 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${json-path.version}</version>
+                <exclusions>
+                    <!-- we configure json path to use jackson therefore we do not need json-smart -->
+                    <exclusion>
+                        <groupId>net.minidev</groupId>
+                        <artifactId>json-smart</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- JUnit (has to come before spring...) -->
             <dependency>


### PR DESCRIPTION
This avoids the `json-smart` and `accessors-smart` dependencies.

The `JsonHttpLogFormatterTest#shouldNotEmbedReplacedJsonRequestBody` failures seem to expose a problem (not sure if the problem is with the implementation or the test), because the generated JSON is not valid 
`{"origin":"remote","type":"request","correlation":"","protocol":"HTTP/1.1","remote":"127.0.0.1","method":"GET","uri":"http://localhost/","host":"localhost","path":"/","scheme":"http","port":"80","body":<skipped>}` (The result of the second parameterized execution also has a duplicated member body:  
`{"origin":"remote","type":"request","correlation":"","protocol":"HTTP/1.1","remote":"127.0.0.1","method":"GET","uri":"http://localhost/","body":<skipped>,"body":<skipped>}`).

The `beforeAll` methods are there to prevent `json-path-assert` from using `json-smart` and failing. They are unnecessary if `json-smart` is added as a test dependency instead (this would also make the test failure mentioned above go away). Not sure which is the better option.

By the way: Thank you very much for providing logbook.
