### PR TITLE
Close original entity stream in order to avoid connection leak

### DIFF
--- a/logbook-jaxrs/pom.xml
+++ b/logbook-jaxrs/pom.xml
@@ -90,5 +90,20 @@
             <artifactId>jersey-media-multipart</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.ws.rs</groupId>
+                    <artifactId>jakarta.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/logbook-jaxrs/src/main/java/org/zalando/logbook/jaxrs/RemoteResponse.java
+++ b/logbook-jaxrs/src/main/java/org/zalando/logbook/jaxrs/RemoteResponse.java
@@ -8,6 +8,7 @@ import org.zalando.logbook.Origin;
 import javax.annotation.Nullable;
 import javax.ws.rs.client.ClientResponseContext;
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -63,9 +64,11 @@ final class RemoteResponse implements HttpResponse {
         public State buffer(
                 final ClientResponseContext context) throws IOException {
 
-            final byte[] body = toByteArray(context.getEntityStream());
-            context.setEntityStream(new ByteArrayInputStream(body));
-            return new Buffering(body);
+            try (InputStream entityStream = context.getEntityStream()) {
+                final byte[] body = toByteArray(entityStream);
+                context.setEntityStream(new ByteArrayInputStream(body));
+                return new Buffering(body);
+            }
         }
 
     }

--- a/logbook-jaxrs/src/test/java/org/zalando/logbook/jaxrs/ClientWithApacheConnectorTest.java
+++ b/logbook-jaxrs/src/test/java/org/zalando/logbook/jaxrs/ClientWithApacheConnectorTest.java
@@ -1,0 +1,76 @@
+package org.zalando.logbook.jaxrs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.glassfish.jersey.apache.connector.ApacheClientProperties;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.message.GZipEncoder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.filter.EncodingFilter;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Sink;
+import org.zalando.logbook.jaxrs.testing.support.TestModel;
+import org.zalando.logbook.jaxrs.testing.support.TestWebService;
+
+final class ClientWithApacheConnectorTest extends JerseyTest {
+
+    ClientWithApacheConnectorTest() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+    }
+
+    private PoolingHttpClientConnectionManager connectionManager;
+
+    @Override
+    protected Application configure() {
+        ResourceConfig resourceConfig = new ResourceConfig(TestWebService.class)
+            .register(MultiPartFeature.class);
+        EncodingFilter.enableFor(resourceConfig, GZipEncoder.class);
+        return resourceConfig;
+    }
+
+    @Override
+    protected void configureClient(final ClientConfig config) {
+        Sink sink = mock(Sink.class);
+        when(sink.isActive()).thenReturn(true);
+
+        connectionManager = new PoolingHttpClientConnectionManager();
+
+        config.property(ApacheClientProperties.CONNECTION_MANAGER, connectionManager)
+            .register(new LogbookClientFilter(
+                Logbook.builder().sink(sink).build()
+            ))
+            .connectorProvider(new ApacheConnectorProvider());
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        super.setUp();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        super.tearDown();
+        connectionManager.shutdown();
+    }
+
+    @Test
+    void shouldCloseOriginalEntityStreamAndReleaseConnection() {
+        target("testws/testGetJson")
+            .request(MediaType.APPLICATION_JSON)
+            .get(TestModel.class);
+
+        assertEquals(0, connectionManager.getTotalStats().getLeased());
+    }
+}

--- a/logbook-jaxrs/src/test/java/org/zalando/logbook/jaxrs/RemoteResponseTest.java
+++ b/logbook-jaxrs/src/test/java/org/zalando/logbook/jaxrs/RemoteResponseTest.java
@@ -1,0 +1,36 @@
+package org.zalando.logbook.jaxrs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.ws.rs.client.ClientResponseContext;
+import org.junit.jupiter.api.Test;
+
+class RemoteResponseTest {
+
+    @Test
+    void shouldCloseOriginalResponseContext() {
+        ClientResponseContext context = mock(ClientResponseContext.class);
+        final AtomicBoolean isStreamClosed = new AtomicBoolean();
+        InputStream entityStream = new ByteArrayInputStream("response-body".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public void close() throws IOException {
+                super.close();
+                isStreamClosed.getAndSet(true);
+            }
+        };
+        when(context.getEntityStream()).thenReturn(entityStream);
+
+        RemoteResponse remoteResponse = new RemoteResponse(context);
+        ((RemoteResponse) remoteResponse.withBody()).expose();
+
+        assertTrue(isStreamClosed.get());
+    }
+
+}

--- a/logbook-jaxrs/src/test/java/org/zalando/logbook/jaxrs/testing/support/TestWebService.java
+++ b/logbook-jaxrs/src/test/java/org/zalando/logbook/jaxrs/testing/support/TestWebService.java
@@ -42,4 +42,11 @@ public class TestWebService {
         // we need to test a response without a body
     }
 
+    @GET
+    @Path("testGetJson")
+    @Produces(APPLICATION_JSON)
+    public TestModel getJson() {
+        return new TestModel().setProperty1("1").setProperty2("2");
+    }
+
 }


### PR DESCRIPTION
## Description
Leased connections were not released when using the Apache Connector and the server returned a compressed response.

## Motivation and Context
Added logging of requests/responses with the help of Logbook but found out that the apache http connections were not released back to the connection pool. Old behaviour can be verified if you remove the new `try` clause in `RemoteResponse` and run the test `ClientWithApacheConnectorTest`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
