### PR TITLE
Replace deprecated methods of Netty HttpClient and HttpServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,19 +663,21 @@ The `logbook-netty` module contains:
 A `LogbookClientHandler` to be used with an `HttpClient`:
 
 ```java
-HttpClient.create()
-    .tcpConfiguration(tcpClient ->
-        tcpClient.doOnConnected(connection ->
-            connection.addHandlerLast(new LogbookClientHandler(logbook))))
+HttpClient httpClient =
+        HttpClient.create()
+                .doOnConnected(
+                        (connection -> connection.addHandlerLast(new LogbookClientHandler(logbook)))
+                );
 ```
 
 A `LogbookServerHandler` for use used with an `HttpServer`:
 
 ```java
-HttpServer.create()
-    .tcpConfiguration(tcpServer ->
-        tcpServer.doOnConnection(connection ->
-            connection.addHandlerLast(new LogbookServerHandler(logbook))))
+HttpServer httpServer =
+        HttpServer.create()
+                .doOnConnection(
+                        connection -> connection.addHandlerLast(new LogbookServerHandler(logbook))
+                );
 ```
 
 #### Spring WebFlux


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `README.md` contains configuration examples for Netty HttpClient and HttpServer with deprecated methods.
I updated these examples.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
