### PR TITLE
Check that all filter parts have been used when running out of input string

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/DefaultPathFilter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/DefaultPathFilter.java
@@ -63,18 +63,27 @@ final class DefaultPathFilter implements PathFilter {
                     return path;
                 }
                 previousIndex += filter[filterIndex].length();
+
+                filterIndex++;
             } else {
+                // skip to next filter part
+                filterIndex++;
+
                 // locate next slash
                 final int nextIndex = path.indexOf('/', previousIndex);
                 if (nextIndex != -1) {
                     previousIndex = nextIndex;
                 } else {
+                    // out of string, did we match against all the filter elements already?
+                    if(filterIndex < filter.length) {
+                        return path;
+                    }
+
                     previousIndex = path.length();
 
                     break;
                 }
             }
-            filterIndex++;
         } while (filterIndex < filter.length);
 
         if (previousIndex == path.length()) {

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultPathFilterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultPathFilterTest.java
@@ -128,4 +128,15 @@ public class DefaultPathFilterTest {
         assertThat(path).isSameAs(result);
     }
 
+    @Test
+    public void testPathEndsAtSubstitute() {
+        final String path = "/profile/123456789";
+        final String expr = "/profile/{id}/info";
+
+        final PathFilter regexpPathUriFilter = new DefaultPathFilter("XXX", expr);
+
+        final String result = regexpPathUriFilter.filter(path);
+        assertThat(result).isEqualTo(path);
+    }
+
 }


### PR DESCRIPTION
## Description
See issue https://github.com/zalando/logbook/issues/1140 and PR https://github.com/zalando/logbook/pull/1139

## Motivation and Context
When input runs out of path segments, check that all filter segments have been matched.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
