### PR TITLE
Fix JsonPathBodyFilterBuilder NP exception when the element value is …

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
@@ -3,6 +3,7 @@ package org.zalando.logbook.json;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
@@ -56,7 +57,7 @@ public final class JsonPathBodyFilters {
         }
 
         public BodyFilter replace(final UnaryOperator<String> replacementFunction) {
-            return filter(context -> context.map(path, (node, config) -> new TextNode(replacementFunction.apply(node.toString()))));
+            return filter(context -> context.map(path, (node, config) -> node == null ? NullNode.getInstance() : new TextNode(replacementFunction.apply(node.toString()))));
         }
 
         public BodyFilter replace(

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
@@ -178,6 +178,14 @@ class JsonPathBodyFiltersTest {
     }
 
     @Test
+    void replacesValuesDynamicallyWithNullValue() {
+        final BodyFilter unit = jsonPath("$.nickname").replace(String::toUpperCase);
+
+        with(unit.filter(type, student))
+                .assertEquals("nickname", null);
+    }
+
+    @Test
     void replacesArrayValuesDynamically() {
         final BodyFilter unit = jsonPath("$.friends.*.name").replace(String::toUpperCase);
 

--- a/logbook-json/src/test/resources/student.json
+++ b/logbook-json/src/test/resources/student.json
@@ -19,5 +19,6 @@
     "English": 2.2,
     "Science": 1.9,
     "PE": 4.0
-  }
+  },
+  "nickname": null
 }


### PR DESCRIPTION
Fix JsonPathBodyFilterBuilder NP exception when the element value is null

## Description
We got  NullPointerException when use JsonPath dynamic value replacement, but when any JSON element has a null value.
This RP ﬁxes this issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
