### PR TITLE
fixing the NPE in FeignLogbookLogger

### DIFF
--- a/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/FeignLogbookLogger.java
+++ b/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/FeignLogbookLogger.java
@@ -12,6 +12,7 @@ import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 
 /**
  * Example usage:
@@ -67,7 +68,13 @@ public final class FeignLogbookLogger extends feign.Logger {
         try {
             // Logbook will consume body stream, making it impossible to read it again
             // read body here and create new response based on byte array instead
-            byte[] body = ByteStreams.toByteArray(response.body().asInputStream());
+
+            byte[] body;
+            if (Objects.nonNull(response.body())) {
+                body = ByteStreams.toByteArray(response.body().asInputStream());
+            } else {
+                body = null;
+            }
 
             final HttpResponse httpResponse = RemoteResponse.create(response, body);
             stage.get().process(httpResponse).write();

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignClient.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignClient.java
@@ -9,6 +9,9 @@ public interface FeignClient {
     @RequestLine("GET /get/string")
     void getVoid();
 
+    @RequestLine("GET /get/empty")
+    void getEmptyBody();
+
     @RequestLine("POST /post/bad-request")
     String postBadRequest(String request);
 }

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignHttpServerRunner.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignHttpServerRunner.java
@@ -30,6 +30,11 @@ public abstract class FeignHttpServerRunner {
                     }
                 }
         );
+        server.createContext("/get/empty", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.getResponseBody().close();
+            exchange.close();
+        });
         server.setExecutor(null);
         server.start();
     }

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignLogbookLoggerTest.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignLogbookLoggerTest.java
@@ -102,4 +102,21 @@ class FeignLogbookLoggerTest extends FeignHttpServerRunner {
         assertTrue(responseCaptor.getValue().contains("400 Bad Request"));
         assertTrue(responseCaptor.getValue().contains("response"));
     }
+
+    @Test
+    void get404WithEmptyResponseBody() throws IOException {
+        assertThrows(FeignException.NotFound.class, () -> client.getEmptyBody());
+
+        verify(writer).write(precorrelationCaptor.capture(), requestCaptor.capture());
+        verify(writer).write(correlationCaptor.capture(), responseCaptor.capture());
+
+        assertTrue(requestCaptor.getValue().contains("/get/empty"));
+        assertTrue(requestCaptor.getValue().contains("GET"));
+        assertTrue(requestCaptor.getValue().contains("Remote: localhost"));
+        assertTrue(requestCaptor.getValue().contains(precorrelationCaptor.getValue().getId()));
+
+        assertEquals(precorrelationCaptor.getValue().getId(), correlationCaptor.getValue().getId());
+        assertTrue(responseCaptor.getValue().contains(precorrelationCaptor.getValue().getId()));
+        assertTrue(responseCaptor.getValue().contains("404 Not Found"));
+    }
 }


### PR DESCRIPTION
 fixing the NPE in FeignLogbookLogger when the incoming body of an unsuccessful response is null

<!--- Provide a general summary of your changes in the Title above -->

## Description
When an unsuccessful response comes in feign.Client on line 131 we get InputStream == null (which is the body of the response). After that, in FeignLogbookLogger, we try to copy the response body, from which we call the asInputStream method.

## Motivation and Context
Solves the problem of log drop with an empty body in an unsuccessful response

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
