### PR TITLE
LogbookFilter: do not fail filter chain on I/O error from resp flushing

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -83,7 +83,13 @@ public final class LogbookFilter implements HttpFilter {
     private void write(RemoteRequest request, LocalResponse response, ResponseWritingStage writing) throws IOException {
         final AtomicBoolean attribute = (AtomicBoolean) request.getAttribute(responseWritingStageSynchronizationName);
         if (!attribute.getAndSet(true)) {
-            response.flushBuffer();
+            try {
+                response.flushBuffer();
+            } catch (IOException ignored) {
+                // Ignore various I/O errors like "Broken Pipe" as they might occur in
+                // real world situations. We do not want to them to fail the whole
+                // filter chain
+            }
             writing.write();
         }
     }


### PR DESCRIPTION
## Description

Ignore various I/O errors like "Broken Pipe" from `response.flushBuffer()` which is done before HTTP log writing as these might occur in real world situations. We do not want to them to fail the whole filter chain.

## Motivation and Context

E.g. in case of async, this should minimize stuff like "java.io.IOException: Broken pipe" bubbling up to AsynxContext.onComplete() call which makes some servlet containers complain about it quite loudly about it. E.g. on Tomcat:

```
WARN org.apache.catalina.core.AsyncContextImp: onComplete() call failed for listener of type [org.apache.catalina.core.AsyncListenerWrapper]
org.apache.catalina.connector.ClientAbortException: java.io.IOException: Broken pipe
...
  at javax.servlet.ServletResponseWrapper.flushBuffer(ServletResponseWrapper.java:181)
  at org.zalando.logbook.servlet.LocalResponse.flushBuffer(LocalResponse.java:215)
  at org.zalando.logbook.servlet.LogbookFilter.write(LogbookFilter.java:86)
  at org.zalando.logbook.servlet.LogbookFilter.lambda$doFilter$0(LogbookFilter.java:71)
  at org.zalando.logbook.servlet.LogbookAsyncListener.onComplete(LogbookAsyncListener.java:17)
  at org.apache.catalina.core.AsyncListenerWrapper.fireOnComplete(AsyncListenerWrapper.java:39)
...
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
