### PR TITLE
1268 fix json duplicated keys

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonFieldWriter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonFieldWriter.java
@@ -1,18 +1,13 @@
 package org.zalando.logbook.json;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-import static org.zalando.logbook.Origin.LOCAL;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apiguardian.api.API;
+import org.zalando.logbook.*;
 
 import java.io.IOException;
 
-import org.apiguardian.api.API;
-import org.zalando.logbook.Correlation;
-import org.zalando.logbook.HttpMessage;
-import org.zalando.logbook.HttpRequest;
-import org.zalando.logbook.HttpResponse;
-import org.zalando.logbook.Precorrelation;
-
-import com.fasterxml.jackson.core.JsonGenerator;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.zalando.logbook.Origin.LOCAL;
 
 public interface JsonFieldWriter {
 
@@ -27,8 +22,6 @@ public interface JsonFieldWriter {
         generator.writeStringField("remote", request.getRemote());
         generator.writeStringField("method", request.getMethod());
         generator.writeStringField("uri", request.getRequestUri());
-        
-        write(request, generator);
 	}
 
 	@API(status = EXPERIMENTAL)
@@ -39,8 +32,6 @@ public interface JsonFieldWriter {
         generator.writeStringField("protocol", response.getProtocolVersion());
         generator.writeNumberField("duration", correlation.getDuration().toMillis());
         generator.writeNumberField("status", response.getStatus());
-        
-        write(response, generator);
 	}
 
 	static String getOrigin(HttpMessage message) {

--- a/logbook-json/src/test/java/org/zalando/logbook/json/FastJsonHttpLogFormatterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/FastJsonHttpLogFormatterTest.java
@@ -1,0 +1,42 @@
+package org.zalando.logbook.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.HttpRequest;
+import org.zalando.logbook.MockHttpRequest;
+import org.zalando.logbook.json.JsonHttpLogFormatterTest.SimplePrecorrelation;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY;
+import static java.time.Clock.systemUTC;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.zalando.logbook.Origin.REMOTE;
+
+public class FastJsonHttpLogFormatterTest {
+    private final ObjectMapper objectMapper;
+    private final FastJsonHttpLogFormatter formatter;
+
+    public FastJsonHttpLogFormatterTest() {
+        objectMapper = new ObjectMapper();
+        objectMapper.enable(FAIL_ON_READING_DUP_TREE_KEY);
+        formatter = new FastJsonHttpLogFormatter(objectMapper);
+    }
+
+    @Test
+    public void shouldNotContainDuplicatedKeys() throws IOException {
+        final HttpRequest request = MockHttpRequest.create()
+                .withProtocolVersion("HTTP/1.0")
+                .withOrigin(REMOTE)
+                .withPath("/test")
+                .withHeaders(HttpHeaders.empty().update("Accept", "application/json"))
+                .withContentType("application/json")
+                .withBodyAsString("{\"action\": \"test\"}");
+
+        String json = formatter.format(new SimplePrecorrelation(UUID.randomUUID().toString(), systemUTC()), request);
+
+        assertDoesNotThrow(() -> objectMapper.readTree(json));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
These changes remove the duplicated calls to `write` that were being done on `JsonFieldWriter` and that caused duplicated entries for `headers` and `body` on the resulting JSON.

## Motivation and Context
This change is required to avoid the duplicated entries for `headers` and `body` on the resulting JSON, generated by `FastJsonHttpLogFormatter`.
[<!--- If it fixes an open issue, please link to the issue here. -->](https://github.com/zalando/logbook/issues/1268)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
