### PR TITLE
Adjustment for openfeign 10 suport

### DIFF
--- a/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/RemoteResponse.java
+++ b/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/RemoteResponse.java
@@ -7,8 +7,12 @@ import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Origin;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Optional;
+
+import static java.util.Objects.isNull;
 
 @RequiredArgsConstructor
 final class RemoteResponse implements HttpResponse {
@@ -18,13 +22,32 @@ final class RemoteResponse implements HttpResponse {
     private final Charset charset;
     private boolean withBody = false;
 
+    private static final String CHARSET_FLAG = "charset";
+
     public static RemoteResponse create(Response response, byte[] body) {
         return new RemoteResponse(
                 response.status(),
                 HeaderUtils.toLogbookHeaders(response.headers()),
                 body,
-                response.charset()
+                getCharsetByFeignVersion(response)
         );
+    }
+
+    private static Charset getCharsetByFeignVersion(Response response) {
+        Field charsetField = Arrays.stream(response.getClass().getDeclaredFields())
+                .filter(fieldName -> fieldName.getName()
+                        .equalsIgnoreCase(CHARSET_FLAG)).findFirst().orElse(null);
+        if(isNull(charsetField)) {
+            //openFeign 10
+            return Charset.defaultCharset();
+        } else {
+            //openFeign 11
+            try {
+                return (Charset) charsetField.get(response);
+            } catch (Exception e) {
+                return Charset.defaultCharset();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This change is important for the logbook be able to get the log when using openfeign 10 and not only version 11.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I work in a company. We use springboot with openfeign 10 and we did like to use logbook, but logbook is ready for openfeign 11 only. With this feature, openfeign10 and 11 can work together.

I have tested the flow and the log is working fine. Could please give a look at my feature please?

Obs.: sorry for my english.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [`x` ] New feature (non-breaking change which adds functionality)
- [`x` ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
