### PR TITLE
feat(logbook-core): correlationId supplier

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/DefaultLogbook.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/DefaultLogbook.java
@@ -64,6 +64,7 @@ final class DefaultLogbook implements Logbook {
     }
 
     private Precorrelation newPrecorrelation(final HttpRequest request) {
+        // delay evaluation of correlationId for later
         return new SimplePrecorrelation(() -> correlationId.generate(request), clock);
     }
 

--- a/logbook-core/src/test/java/org/zalando/logbook/ChunkingSinkTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/ChunkingSinkTest.java
@@ -14,6 +14,7 @@ import static java.time.Instant.MIN;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -63,7 +64,7 @@ final class ChunkingSinkTest {
     }
 
     private List<String> captureRequest(final String request) throws IOException {
-        unit.write(new SimplePrecorrelation("", Clock.systemUTC()), MockHttpRequest.create().withBodyAsString(request));
+        unit.write(new SimplePrecorrelation(() -> "", Clock.systemUTC()), MockHttpRequest.create().withBodyAsString(request));
 
         final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(writer, atLeastOnce()).write(any(Precorrelation.class), captor.capture());
@@ -99,7 +100,7 @@ final class ChunkingSinkTest {
 
     @Test
     void shouldCreateWithSizeOfOne() {
-        new ChunkingSink(delegate, 1);
+        assertDoesNotThrow(() -> new ChunkingSink(delegate, 1));
     }
 
     private List<String> captureResponse(final String response) throws IOException {

--- a/logbook-core/src/test/java/org/zalando/logbook/CommonsLogFormatSinkTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/CommonsLogFormatSinkTest.java
@@ -50,7 +50,7 @@ final class CommonsLogFormatSinkTest {
     @Test
     void shouldNotWriteRequestBeforeResponse() throws IOException {
         final Clock clock = fixed(Instant.parse("2019-08-02T08:04:27Z"), UTC);
-        final Precorrelation correlation = new SimplePrecorrelation("", clock);
+        final Precorrelation correlation = new SimplePrecorrelation(() -> "", clock);
 
         new CommonsLogFormatSink(writer)
                 .write(correlation, MockHttpRequest.create());

--- a/logbook-core/src/test/java/org/zalando/logbook/CurlHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/CurlHttpLogFormatterTest.java
@@ -28,7 +28,7 @@ final class CurlHttpLogFormatterTest {
                 .withBodyAsString("Hello, world!");
 
         final HttpLogFormatter unit = new CurlHttpLogFormatter();
-        final String curl = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+        final String curl = unit.format(new SimplePrecorrelation(() -> correlationId, systemUTC()), request);
 
         assertThat(curl)
                 .isEqualTo("c9408eaa-677d-11e5-9457-10ddb1ee7671 " +
@@ -46,7 +46,7 @@ final class CurlHttpLogFormatterTest {
                 .withHeaders(HttpHeaders.of("Accept", "application/json"));
 
         final HttpLogFormatter unit = new CurlHttpLogFormatter();
-        final String curl = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+        final String curl = unit.format(new SimplePrecorrelation(() -> correlationId, systemUTC()), request);
 
         assertThat(curl)
                 .isEqualTo("0eae9f6c-6824-11e5-8b0a-10ddb1ee7671 " +
@@ -65,7 +65,7 @@ final class CurlHttpLogFormatterTest {
                 .withBodyAsString("{\"message\":\"Hello, 'world'!\"}");
 
         final HttpLogFormatter unit = new CurlHttpLogFormatter();
-        final String curl = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+        final String curl = unit.format(new SimplePrecorrelation(() -> correlationId, systemUTC()), request);
 
         assertThat(curl)
                 .isEqualTo("c9408eaa-677d-11e5-9457-10ddb1ee7671 " +

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogFormatterTest.java
@@ -28,7 +28,7 @@ final class DefaultHttpLogFormatterTest {
                         .update("Content-Type", "text/plain"))
                 .withBodyAsString("Hello, world!");
 
-        final String http = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+        final String http = unit.format(new SimplePrecorrelation(() -> correlationId, systemUTC()), request);
 
         assertThat(http).isEqualTo("Incoming Request: c9408eaa-677d-11e5-9457-10ddb1ee7671\n" +
                 "Remote: 127.0.0.1\n" +
@@ -50,7 +50,7 @@ final class DefaultHttpLogFormatterTest {
                         .update("Content-Type", "text/plain"))
                 .withBodyAsString("Hello, world!");
 
-        final String http = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+        final String http = unit.format(new SimplePrecorrelation(() -> correlationId, systemUTC()), request);
 
         assertThat(http).isEqualTo("Outgoing Request: 2bd05240-6827-11e5-bbee-10ddb1ee7671\n" +
                 "Remote: 127.0.0.1\n" +
@@ -68,7 +68,7 @@ final class DefaultHttpLogFormatterTest {
                 .withPath("/test")
                 .withHeaders(HttpHeaders.of("Accept", "application/json"));
 
-        final String http = unit.format(new SimplePrecorrelation(correlationId, systemUTC()), request);
+        final String http = unit.format(new SimplePrecorrelation(() -> correlationId, systemUTC()), request);
 
         assertThat(http).isEqualTo("Incoming Request: 0eae9f6c-6824-11e5-8b0a-10ddb1ee7671\n" +
                 "Remote: 127.0.0.1\n" +

--- a/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogWriterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/DefaultHttpLogWriterTest.java
@@ -47,7 +47,7 @@ final class DefaultHttpLogWriterTest {
 
         logger.setEnabledLevels(TRACE);
 
-        unit.write(new SimplePrecorrelation("", Clock.systemUTC()), "foo");
+        unit.write(new SimplePrecorrelation(() -> "", Clock.systemUTC()), "foo");
 
         final LoggingEvent event = getOnlyElement(logger.getLoggingEvents());
 

--- a/logbook-core/src/test/java/org/zalando/logbook/SimplePrecorrelationTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/SimplePrecorrelationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class SimplePrecorrelationTest {
 
     private final Precorrelation unit = new SimplePrecorrelation(
-            "", Clock.systemUTC());
+        () -> "", Clock.systemUTC());
 
     @Test
     void getId() {

--- a/logbook-core/src/test/java/org/zalando/logbook/SplunkHttpLogFormatterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/SplunkHttpLogFormatterTest.java
@@ -149,7 +149,7 @@ class SplunkHttpLogFormatterTest {
     }
 
     private SimplePrecorrelation correlation(final String correlationId) {
-        return new SimplePrecorrelation(correlationId, Clock.systemUTC());
+        return new SimplePrecorrelation(() -> correlationId, Clock.systemUTC());
     }
 
     private SimpleCorrelation correlation(

--- a/logbook-core/src/test/java/org/zalando/logbook/StreamHttpLogWriterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/StreamHttpLogWriterTest.java
@@ -30,7 +30,7 @@ final class StreamHttpLogWriterTest {
         final PrintStream stream = mock(PrintStream.class);
         final HttpLogWriter unit = new StreamHttpLogWriter(stream);
 
-        unit.write(new SimplePrecorrelation("", Clock.systemUTC()), "foo");
+        unit.write(new SimplePrecorrelation(() -> "", Clock.systemUTC()), "foo");
 
         verify(stream).println("foo");
     }
@@ -54,7 +54,7 @@ final class StreamHttpLogWriterTest {
         try {
             final HttpLogWriter unit = new StreamHttpLogWriter();
 
-            unit.write(new SimplePrecorrelation("", Clock.systemUTC()), "foo");
+            unit.write(new SimplePrecorrelation(() -> "", Clock.systemUTC()), "foo");
 
             verify(stream).println("foo");
         } finally {


### PR DESCRIPTION
Use correlationId supplier to allow defered evaluation of correlationId


## Description
Precorrelation object is created at the very beginning of the process, in Netty pipeline body is not yet read. It's not used in pairing of request and response, and only used in writing stage. Writing stage is evaluated after request body is read from Netty channel. Currently Precorrelation contains direct string value for correlationId, which makes it impossible to use any information
from the request body in generation of correlationId.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
SOAP messages contains information essential for process correlation in <SOAP:HEADER/>, which is part of HTTP body. In Micronaut, HTTP request is read in several steps, and with current implementation HTTP request body is not yet retrieved from Netty channel. 
Proposed change is essential for SOAP processing and is transparent for other protocols. Correspond issue: https://github.com/zalando/logbook/issues/1274

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
