### PR TITLE
Handle illegal characters in URL

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
@@ -42,7 +42,16 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
             final ChannelHandlerContext context,
             final Origin origin,
             final HttpRequest request) throws UnsupportedEncodingException {
-        this(context, origin, request, URI.create(URLEncoder.encode(request.uri(), "UTF-8")));
+        this(context, origin, request, createURI(request.uri()));
+    }
+
+    private static URI createURI(String uriString) throws UnsupportedEncodingException {
+        try {
+            return URI.create(uriString);
+        } catch(IllegalArgumentException e) {
+            // If it is an invalid URI, encode to avoid exception
+            return URI.create(URLEncoder.encode(uriString, "UTF-8"));
+        }
     }
 
     @Override

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
@@ -7,9 +7,11 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.ssl.SslHandler;
 
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,8 +41,8 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
     public Request(
             final ChannelHandlerContext context,
             final Origin origin,
-            final HttpRequest request) {
-        this(context, origin, request, URI.create(request.uri()));
+            final HttpRequest request) throws UnsupportedEncodingException {
+        this(context, origin, request, URI.create(URLEncoder.encode(request.uri(), "UTF-8")));
     }
 
     @Override

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
@@ -11,6 +11,8 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslHandler;
 import org.junit.jupiter.api.Test;
 
+import java.io.UnsupportedEncodingException;
+
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -26,7 +28,7 @@ import static org.zalando.logbook.Origin.REMOTE;
 public class RequestUnitTest {
 
     @Test
-    void shouldBeDefaultRequest() {
+    void shouldBeDefaultRequest() throws UnsupportedEncodingException {
         HttpRequest req = mock(HttpRequest.class);
         when(req.uri()).thenReturn("/test");
         when(req.headers()).thenReturn(new DefaultHttpHeaders().add(CONTENT_TYPE, "text/plain"));
@@ -53,6 +55,44 @@ public class RequestUnitTest {
         assertThat(remoteRequest.getOrigin()).isEqualTo(REMOTE);
         assertThat(remoteRequest.getMethod()).isEqualTo("GET");
         assertThat(remoteRequest.getPath()).isEqualTo("/test");
+        assertThat(remoteRequest.getProtocolVersion()).isEqualTo("HTTP/1.1");
+
+
+        when(req.headers()).thenReturn(new DefaultHttpHeaders().add(HOST, "localhost"));
+        Request localRequest = new Request(context, LOCAL, req);
+
+        assertThat(localRequest.getHost()).isEqualTo("localhost");
+    }
+
+
+    @Test
+    void shouldNotFailWithIllegalCharacterInPath() throws UnsupportedEncodingException {
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/v1/test[?a=2");
+        when(req.headers()).thenReturn(new DefaultHttpHeaders().add(CONTENT_TYPE, "text/plain"));
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+
+        when(context.channel()).thenReturn(mock(Channel.class));
+        when(context.channel().pipeline()).thenReturn(mock(ChannelPipeline.class));
+        when(context.channel().pipeline().get(SslHandler.class)).thenReturn(mock(SslHandler.class));
+
+        when(context.channel().remoteAddress()).thenReturn(LocalAddress.ANY);
+
+        Request remoteRequest = new Request(context, REMOTE, req);
+
+        assertThat(remoteRequest.getScheme()).isEqualTo("https");
+        assertThat(remoteRequest.getHost()).isEqualTo("unknown");
+        assertThat(remoteRequest.getPort()).isEmpty();
+        assertThat(remoteRequest.getContentType()).isEqualTo("text/plain");
+        assertThat(remoteRequest.getCharset()).isEqualTo(UTF_8);
+        assertThat(remoteRequest.getRemote()).isEqualTo("local:any");
+        assertThat(remoteRequest.getRequestUri()).isEqualTo("https://unknown/v1/test[?a=2");
+        assertThat(remoteRequest.getOrigin()).isEqualTo(REMOTE);
+        assertThat(remoteRequest.getMethod()).isEqualTo("GET");
+        assertThat(remoteRequest.getPath()).isEqualTo("/v1/test[?a=2");
         assertThat(remoteRequest.getProtocolVersion()).isEqualTo("HTTP/1.1");
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Encode `request.uri()` before calling `URI.create()` with it so illegal character does not cause an exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/zalando/logbook/issues/1303
`URI.create(request.uri())` throws an exception when `request.uri()` contains invalid characters.
Encode it so it does not fail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
