### PR TITLE
[fix] Java URI cannot handle netty URIs

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
@@ -5,11 +5,11 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.ssl.SslHandler;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.Optional;
@@ -34,13 +34,13 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
     private final ChannelHandlerContext context;
     private final Origin origin;
     private final HttpRequest request;
-    private final URI uri;
+    private final QueryStringDecoder uriDecoder;
 
     public Request(
-            final ChannelHandlerContext context,
-            final Origin origin,
-            final HttpRequest request) {
-        this(context, origin, request, URI.create(request.uri()));
+        final ChannelHandlerContext context,
+        final Origin origin,
+        final HttpRequest request) {
+        this(context, origin, request, new QueryStringDecoder(request.uri()));
     }
 
     @Override
@@ -97,12 +97,12 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
 
     @Override
     public String getPath() {
-        return uri.getPath();
+        return uriDecoder.path();
     }
 
     @Override
     public String getQuery() {
-        return Optional.ofNullable(uri.getQuery()).orElse("");
+        return uriDecoder.rawQuery();
     }
 
     @Override

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import static org.zalando.logbook.Origin.LOCAL;
 import static org.zalando.logbook.Origin.REMOTE;
 
+
 /**
  * @author sokomishalov
  */
@@ -27,19 +28,14 @@ public class RequestUnitTest {
 
     @Test
     void shouldBeDefaultRequest() {
+
         HttpRequest req = mock(HttpRequest.class);
-        when(req.uri()).thenReturn("/test");
+        when(req.uri()).thenReturn("/test?a=b");
         when(req.headers()).thenReturn(new DefaultHttpHeaders().add(CONTENT_TYPE, "text/plain"));
         when(req.method()).thenReturn(HttpMethod.GET);
         when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
 
-        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
-
-        when(context.channel()).thenReturn(mock(Channel.class));
-        when(context.channel().pipeline()).thenReturn(mock(ChannelPipeline.class));
-        when(context.channel().pipeline().get(SslHandler.class)).thenReturn(mock(SslHandler.class));
-
-        when(context.channel().remoteAddress()).thenReturn(LocalAddress.ANY);
+        ChannelHandlerContext context = mockChannelHandlerContext();
 
         Request remoteRequest = new Request(context, REMOTE, req);
 
@@ -49,10 +45,11 @@ public class RequestUnitTest {
         assertThat(remoteRequest.getContentType()).isEqualTo("text/plain");
         assertThat(remoteRequest.getCharset()).isEqualTo(UTF_8);
         assertThat(remoteRequest.getRemote()).isEqualTo("local:any");
-        assertThat(remoteRequest.getRequestUri()).isEqualTo("https://unknown/test");
+        assertThat(remoteRequest.getRequestUri()).isEqualTo("https://unknown/test?a=b");
         assertThat(remoteRequest.getOrigin()).isEqualTo(REMOTE);
         assertThat(remoteRequest.getMethod()).isEqualTo("GET");
         assertThat(remoteRequest.getPath()).isEqualTo("/test");
+        assertThat(remoteRequest.getQuery()).isEqualTo("a=b");
         assertThat(remoteRequest.getProtocolVersion()).isEqualTo("HTTP/1.1");
 
 
@@ -60,5 +57,55 @@ public class RequestUnitTest {
         Request localRequest = new Request(context, LOCAL, req);
 
         assertThat(localRequest.getHost()).isEqualTo("localhost");
+    }
+
+    @Test
+    void shouldHandleUriWithoutQuery() {
+
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/test");
+        when(req.headers()).thenReturn(new DefaultHttpHeaders().add(CONTENT_TYPE, "text/plain"));
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        ChannelHandlerContext context = mockChannelHandlerContext();
+
+        Request remoteRequest = new Request(context, REMOTE, req);
+
+        assertThat(remoteRequest.getRequestUri()).isEqualTo("https://unknown/test");
+        assertThat(remoteRequest.getPath()).isEqualTo("/test");
+        assertThat(remoteRequest.getQuery()).isEqualTo("");
+    }
+
+    @Test
+    void shouldHandleMaliciousRequests() {
+
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/libs/dam/merge/metadata.json;%0A.json?path=<h1>Rhack&;%0A.inc.js");
+        when(req.headers()).thenReturn(new DefaultHttpHeaders().add(CONTENT_TYPE, "text/plain"));
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        ChannelHandlerContext context = mockChannelHandlerContext();
+
+        Request remoteRequest = new Request(context, REMOTE, req);
+
+        assertThat(remoteRequest.getRequestUri()).isEqualTo("https://unknown/libs/dam/merge/metadata.json;\n" +
+                                                                ".json?path=<h1>Rhack&;%0A.inc.js");
+        assertThat(remoteRequest.getPath()).isEqualTo("/libs/dam/merge/metadata.json;\n" +
+                                                          ".json");
+        assertThat(remoteRequest.getQuery()).isEqualTo("path=<h1>Rhack&;%0A.inc.js");
+    }
+
+    private ChannelHandlerContext mockChannelHandlerContext() {
+
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+
+        when(context.channel()).thenReturn(mock(Channel.class));
+        when(context.channel().pipeline()).thenReturn(mock(ChannelPipeline.class));
+        when(context.channel().pipeline().get(SslHandler.class)).thenReturn(mock(SslHandler.class));
+
+        when(context.channel().remoteAddress()).thenReturn(LocalAddress.ANY);
+        return context;
     }
 }

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.3</jackson.version>
         <json-path.version>2.7.0</json-path.version>
         <kotlin.version>1.6.10</kotlin.version>
         <ktor.version>1.6.7</ktor.version>


### PR DESCRIPTION
## Description
The log files are filled with this:

```
java.lang.IllegalArgumentException: Illegal character in query at index 44: /libs/dam/merge/metadata.json;%0A.json?path=<h1>Rhack&;%0A.inc.js
	at java.base/java.net.URI.create(Unknown Source)
	at org.zalando.logbook.netty.Request.<init>(Request.java:43)
	at org.zalando.logbook.netty.LogbookServerHandler.lambda$channelRead$0(LogbookServerHandler.java:45)
	at org.zalando.fauxpas.ThrowingConsumer.accept(ThrowingConsumer.java:19)
	at org.zalando.logbook.netty.Conditionals.runIf(Conditionals.java:17)
	at org.zalando.logbook.netty.LogbookServerHandler.channelRead(LogbookServerHandler.java:44)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:
```

For a lot of malicous URLs this is logged as an error.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
