### PR TITLE
response.body() is nullable

### DIFF
--- a/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/FeignLogbookLogger.java
+++ b/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/FeignLogbookLogger.java
@@ -67,7 +67,9 @@ public final class FeignLogbookLogger extends feign.Logger {
         try {
             // Logbook will consume body stream, making it impossible to read it again
             // read body here and create new response based on byte array instead
-            byte[] body = ByteStreams.toByteArray(response.body().asInputStream());
+            byte[] body = response.body() == null
+                ? null
+                : ByteStreams.toByteArray(response.body().asInputStream());
 
             final HttpResponse httpResponse = RemoteResponse.create(response, body);
             stage.get().process(httpResponse).write();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
OpenFeign's response object is nullable.  All that is required here is to propagate the null where appropriate.

## Motivation and Context

Notably a 404 with an empty response body trigger an NPE causing the library to blow up in ways that are unexpected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
