### PR TITLE
1360-NPE-at-FeignLogbookLogger

### DIFF
--- a/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/FeignLogbookLogger.java
+++ b/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/FeignLogbookLogger.java
@@ -67,7 +67,7 @@ public final class FeignLogbookLogger extends feign.Logger {
         try {
             // Logbook will consume body stream, making it impossible to read it again
             // read body here and create new response based on byte array instead
-            byte[] body = ByteStreams.toByteArray(response.body().asInputStream());
+            byte[] body = response.body() != null ? ByteStreams.toByteArray(response.body().asInputStream()) : null;
 
             final HttpResponse httpResponse = RemoteResponse.create(response, body);
             stage.get().process(httpResponse).write();

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignClient.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignClient.java
@@ -6,7 +6,7 @@ public interface FeignClient {
     @RequestLine("GET /get/string")
     String getString();
 
-    @RequestLine("GET /get/string")
+    @RequestLine("GET /get/void")
     void getVoid();
 
     @RequestLine("POST /post/bad-request")

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignHttpServerRunner.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignHttpServerRunner.java
@@ -30,6 +30,9 @@ public abstract class FeignHttpServerRunner {
                     }
                 }
         );
+        server.createContext("/get/void", exchange -> {
+            exchange.sendResponseHeaders(401, -1);
+        });
         server.setExecutor(null);
         server.start();
     }

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignLogbookLoggerTest.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignLogbookLoggerTest.java
@@ -72,9 +72,10 @@ class FeignLogbookLoggerTest extends FeignHttpServerRunner {
     }
 
     @Test
-    void get200WithEmptyResponseBody() {
-        client.getVoid();
+    void get401WithEmptyResponseBody() {
+        assertThrows(FeignException.Unauthorized.class, () -> client.getVoid());
     }
+
 
     @Test
     void get200WithNonEmptyResponseBody() {


### PR DESCRIPTION
1360-NPE-at-FeignLogbookLogger: if response body is empty then don't throw NPE, tests are fixed.

## Description
#1360 

## Motivation and Context
So if a response from a server comes without body then FeignLogbookLogger throws an NPE, instead of logging the correct response, like in my example 401 Unauthorized. With my fix we avoid NPE in such cases. The empty body related test was wrong I fixed it as well to test this new bugfix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have added tests to cover my changes.
