### PR TITLE
Fix issue 1112: apache http-client5 decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,15 @@ client.execute(producer, new LogbookHttpAsyncResponseConsumer<>(consumer), callb
 
 ### HTTP Client 5
 
-The `logbook-httpclient5` module contains both an `HttpRequestInterceptor` and an `HttpResponseInterceptor` to use with the `HttpClient`:
+The `logbook-httpclient5` module contains an `ExecHandler` to use with the `HttpClient`:
+```java
+CloseableHttpClient client = HttpClientBuilder.create()
+        .addExecInterceptorFirst("Logbook", new LogbookHttpExecHandler(logbook))
+        .build();
+```
+The Handler should be added first, such that a compression is performed after logging and decompression is performed before logging.
+
+To avoid a breaking change, there is also an `HttpRequestInterceptor` and an `HttpResponseInterceptor` to use with the `HttpClient`, which works fine as long as compression (or other ExecHandlers) is not used:
 
 ```java
 CloseableHttpClient client = HttpClientBuilder.create()

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
@@ -18,11 +18,11 @@ public class LogbookHttpExecHandler implements ExecChainHandler {
     }
 
     @Override
-    public ClassicHttpResponse execute(ClassicHttpRequest request, ExecChain.Scope scope, ExecChain execChain) throws IOException, HttpException {
-        LocalRequest localRequest = new LocalRequest(request, request.getEntity());
-        Logbook.ResponseProcessingStage stage = logbook.process(localRequest).write();
+    public ClassicHttpResponse execute(final ClassicHttpRequest request, final ExecChain.Scope scope, final ExecChain execChain) throws IOException, HttpException {
+        final LocalRequest localRequest = new LocalRequest(request, request.getEntity());
+        final Logbook.ResponseProcessingStage stage = logbook.process(localRequest).write();
 
-        ClassicHttpResponse response = execChain.proceed(request, scope);
+        final ClassicHttpResponse response = execChain.proceed(request, scope);
 
         stage.process(new RemoteResponse(response)).write();
 

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
@@ -1,0 +1,31 @@
+package org.zalando.logbook.httpclient5;
+
+import org.apache.hc.client5.http.classic.ExecChain;
+import org.apache.hc.client5.http.classic.ExecChainHandler;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.zalando.logbook.Logbook;
+
+import java.io.IOException;
+
+public class LogbookHttpExecHandler implements ExecChainHandler {
+
+    private final Logbook logbook;
+
+    public LogbookHttpExecHandler(Logbook logbook) {
+        this.logbook = logbook;
+    }
+
+    @Override
+    public ClassicHttpResponse execute(ClassicHttpRequest request, ExecChain.Scope scope, ExecChain execChain) throws IOException, HttpException {
+        LocalRequest localRequest = new LocalRequest(request, request.getEntity());
+        Logbook.ResponseProcessingStage stage = logbook.process(localRequest).write();
+
+        ClassicHttpResponse response = execChain.proceed(request, scope);
+
+        stage.process(new RemoteResponse(response)).write();
+
+        return response;
+    }
+}

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
@@ -1,0 +1,46 @@
+package org.zalando.logbook.httpclient5;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
+import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogbookHttpExecHandlerTest extends AbstractHttpTest {
+    private final CloseableHttpClient client = HttpClientBuilder.create()
+            .addExecInterceptorFirst("Logbook", new LogbookHttpExecHandler(logbook))
+            .build();
+
+    @AfterEach
+    void stop() throws IOException {
+        client.close();
+    }
+
+    @Override
+    protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws IOException {
+        driver.addExpectation(onRequestTo("/"),
+                giveResponse("Hello, world!", "text/plain"));
+
+        if (body == null) {
+            return client.execute(new HttpGet(driver.getBaseUrl()));
+        } else {
+            final HttpPost post = new HttpPost(driver.getBaseUrl());
+            post.setEntity(new StringEntity(body));
+            post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
+            return client.execute(post);
+        }
+    }
+}

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
@@ -3,21 +3,30 @@ package org.zalando.logbook.httpclient5;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zalando.logbook.Correlation;
 
 import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
+import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.POST;
 import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponseAsBytes;
 import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 class LogbookHttpExecHandlerTest extends AbstractHttpTest {
     private final CloseableHttpClient client = HttpClientBuilder.create()
@@ -42,5 +51,31 @@ class LogbookHttpExecHandlerTest extends AbstractHttpTest {
             post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
             return client.execute(post);
         }
+    }
+
+    @Test
+    void shouldLogCompressedResponseWithBody() throws IOException, ParseException {
+        byte[] compressedResponse = new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, -1, -13, 72, -51, -55, -55, -41, 81,
+                72, -50, -49, 45, 40, 74, 45, 46, 78, 77, 81, 40, -49, 47, -54, 73, 81, 4, 0, 5, -67, 83, 110, 24, 0, 0, 0};
+        driver.addExpectation(onRequestTo("/").withMethod(POST),
+                giveResponseAsBytes(new ByteArrayInputStream(compressedResponse), "text/plain")
+                        .withHeader("Content-Encoding", "gzip"));
+
+        final HttpPost post = new HttpPost(driver.getBaseUrl());
+        post.setEntity(new StringEntity("Hello, world!"));
+        post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
+        final CloseableHttpResponse response = client.execute(post);
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(response.getEntity()).isNotNull();
+        assertThat(EntityUtils.toString(response.getEntity())).isEqualTo("Hello, compressed world!");
+
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer).write(any(Correlation.class), captor.capture());
+        final String message = captor.getValue();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", "Hello, compressed world!");
     }
 }


### PR DESCRIPTION
If the response is compressed the Interceptor will log at the wrong time, thus use an ExecHandler.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
This fixes Issue #1112 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
