### PR TITLE
Fix hangs on GET requests to ktor-server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,11 +776,14 @@ A `LogbookServer` to be used with an `Application`:
 
 ```kotlin
 private val server = embeddedServer(CIO) {
+    install(DoubleReceive)
     install(LogbookServer) {
         logbook = logbook
     }
 }
 ```
+
+Pay attention, that additional feature `DoubleReceive` required for logging of incoming requests body.
 
 Alternatively, you can use `logbook-ktor`, which ships both `logbook-ktor-client` and `logbook-ktor-server` modules.
 


### PR DESCRIPTION
## Description
Currently ktor-server hangs on any request without call of methods `receive...`, for example on GET request processing.
For reproduction see test `Should log request with not consumed body`

## Motivation and Context
Previous interceptor calls only on body consumption event, but body isn't always required.  
New interceptor `pipeline.intercept(ApplicationCallPipeline.Monitoring)` runs on any request to the server. 

## Type of changes
 Bug fix (non-breaking change which fixes an issue)

## Other changes:
-  I have updated the documentation accordingly.
-  I have added tests to cover my changes.
