### PR TITLE
End of support Spring Boot 1 and Spring Famework 4 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        profile: ['', 'spring4']
+        profile: ['']
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Logbook is ready to use out of the box for most common setups. Even for uncommon
 - JAX-RS 2.x Client and Server (optional)
 - Netty 4.x (optional)
 - OkHttp 2.x **or 3.x** (optional)
-- Spring 4.x **or 5.x** (optional)
-- Spring Boot 1.x **or 2.x** (optional)
+- Spring 5.x** (optional)
+- Spring Boot 2.x** (optional)
 - Ktor (optional)
 - logstash-logback-encoder 5.x (optional)
 

--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -12,20 +12,4 @@
             <cve>CVE-2021-4277</cve>
         </suppress>
 
-        <!-- Vulnerabilities related to Spring Framework 4 -->
-        <suppress>
-            <!-- Affects Spring Framework data binding, not used by the library -->
-            <cve>CVE-2022-22968</cve>
-            <!-- Only relevant if the application is Spring MVC or Spring WebFlux application and deployed as a WAR -->
-            <cve>CVE-2022-22965</cve>
-            <!-- Logbook doesn't accept user input -->
-            <cve>CVE-2022-22950</cve>
-            <!-- Logbook doesn't handle file uploads -->
-            <cve>CVE-2022-22970</cve>
-            <cve>CVE-2022-27772</cve>
-            <cve>CVE-2022-22978</cve>
-            <cve>CVE-2022-22976</cve>
-            <cve>CVE-2022-22971</cve>
-            <cve>CVE-2021-22112</cve>
-        </suppress>
 </suppressions>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -39,12 +39,7 @@
         <reactor-netty.version>1.1.2</reactor-netty.version>
         <slf4j.version>1.7.36</slf4j.version>
 
-        <spring4.version>4.3.30.RELEASE</spring4.version>
-        <spring-boot1.version>1.5.22.RELEASE</spring-boot1.version>
-        <spring-security4.version>4.2.20.RELEASE</spring-security4.version>
-
         <spring5.version>5.3.25</spring5.version>
-        <spring-boot2.version>2.7.8</spring-boot2.version>
         <spring-security5.version>5.6.10</spring-security5.version>
 
         <spring.version>5.3.25</spring.version>
@@ -596,14 +591,6 @@
             <modules>
                 <module>../logbook-jmh</module>
             </modules>
-        </profile>
-        <profile>
-            <id>spring4</id>
-            <properties>
-                <spring.version>${spring4.version}</spring.version>
-                <spring-boot.version>${spring-boot1.version}</spring-boot.version>
-                <spring-security.version>${spring-security4.version}</spring-security.version>
-            </properties>
         </profile>
         <profile>
             <id>release</id>

--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -148,23 +148,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                    <version>1.5.0</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -80,7 +80,6 @@ import static org.zalando.logbook.autoconfigure.LogbookAutoConfiguration.Servlet
 @ConditionalOnClass(Logbook.class)
 @EnableConfigurationProperties(LogbookProperties.class)
 @AutoConfigureAfter(value = JacksonAutoConfiguration.class, name = {
-        "org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration", // Spring Boot 1.x
         "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration" // Spring Boot 2.x
 })
 public class LogbookAutoConfiguration {
@@ -396,7 +395,6 @@ public class LogbookAutoConfiguration {
     @ConditionalOnClass(SecurityFilterChain.class)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
-            "org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration", // Spring Boot 1.x
             "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
     })
     static class SecurityServletFilterConfiguration {

--- a/logbook-spring-boot-webflux-autoconfigure/pom.xml
+++ b/logbook-spring-boot-webflux-autoconfigure/pom.xml
@@ -11,19 +11,6 @@
         <relativePath>../logbook-parent/pom.xml</relativePath>
     </parent>
 
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <!-- spring-webflux had been introduced only in spring v5 and spring-boot
-            v2 so we have to prevent testing this module against 4-th spring -->
-            <properties>
-                <spring.version>${spring5.version}</spring.version>
-                <spring-boot.version>2.7.8</spring-boot.version>
-                <spring-security.version>${spring-security5.version}</spring-security.version>
-            </properties>
-        </profile>
-    </profiles>
-
     <artifactId>logbook-spring-boot-webflux-autoconfigure</artifactId>
     <description>Spring Boot Webflux Auto Configuration for Logbook</description>
     <scm>

--- a/logbook-spring-webflux/pom.xml
+++ b/logbook-spring-webflux/pom.xml
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>${spring-boot2.version}</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot2.version}</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## Description
As spring-boot 1.5 has reached it's commercial support on [2020-11-06](https://spring.io/projects/spring-boot#support), with these changes I propose to stop supporting it in Logbook as well.

## Motivation and Context
Support of older versions of Spring Framework and Spring Boot is becoming more problematic, it's a source of vulnerabilities, that can't be addressed, and number of potential users should be low at this point. 

Clients will still be able to use Logbook versions that support older versions of the Spring Framework.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
