### PR TITLE
Migrate to Spring 6 / Spring Boot 3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,9 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: 17
+        cache: 'maven'
     - name: Compile
       run: ./mvnw clean test-compile -B
     - name: Test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 17
     - name: Compile
       run: ./mvnw clean test-compile -B
     - name: Test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,14 +25,14 @@ jobs:
         profile: ['']
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: m2
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 17
     - name: Compile

--- a/logbook-jaxrs/pom.xml
+++ b/logbook-jaxrs/pom.xml
@@ -31,9 +31,9 @@
             <artifactId>logbook-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>2.1.6</version>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/logbook-ktor-common/src/main/kotlin/org/zalando/logbook/common/ExperimentalLogbookKtorApi.kt
+++ b/logbook-ktor-common/src/main/kotlin/org/zalando/logbook/common/ExperimentalLogbookKtorApi.kt
@@ -10,7 +10,7 @@ import kotlin.annotation.AnnotationTarget.*
  *
  * Any usage of a declaration annotated with `@ExperimentalLogbookKtorApi` must be accepted either by
  * annotating that usage with the [OptIn] annotation, e.g. `@OptIn(ExperimentalLogbookKtorApi::class)`,
- * or by using the compiler argument `-Xopt-in=org.zalando.logbook.ktor.ExperimentalLogbookKtorApi`.
+ * or by using the compiler argument `-Opt-in=org.zalando.logbook.ktor.ExperimentalLogbookKtorApi`.
  */
 @RequiresOptIn(level = WARNING)
 @Retention(BINARY)

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -39,15 +39,12 @@
         <reactor-netty.version>1.1.2</reactor-netty.version>
         <slf4j.version>1.7.36</slf4j.version>
 
-        <spring5.version>5.3.25</spring5.version>
-        <spring-security5.version>5.6.10</spring-security5.version>
-
-        <spring.version>5.3.25</spring.version>
-        <spring-boot.version>2.7.8</spring-boot.version>
-        <spring-security.version>5.8.1</spring-security.version>
+        <spring.version>6.0.4</spring.version>
+        <spring-boot.version>3.0.2</spring-boot.version>
+        <spring-security.version>6.0.1</spring-security.version>
 
         <junit.version>5.9.2</junit.version>
-        <mockito.version>4.11.0</mockito.version>
+        <mockito.version>5.1.1</mockito.version>
         <jmh.version>1.36</jmh.version>
     </properties>
     <dependencyManagement>
@@ -136,9 +133,9 @@
             </dependency>
             <!-- javax -->
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>4.0.1</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>6.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <!-- JsonPath -->
@@ -383,16 +380,16 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.1</version>
                     <configuration>
                         <compilerArgs>
                             <compilerArg>-Xlint:unchecked,deprecation</compilerArg>
-                            <compilerArg>-Werror</compilerArg>
+                            <!--<compilerArg>-Werror</compilerArg>-->
                             <compilerArg>-parameters</compilerArg>
                         </compilerArgs>
                     </configuration>
@@ -439,7 +436,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>0.8.8</version>
                     <executions>
                         <execution>
                             <id>prepare-agent</id>
@@ -612,7 +609,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.2</version>
+                        <version>3.4.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -389,7 +389,7 @@
                     <configuration>
                         <compilerArgs>
                             <compilerArg>-Xlint:unchecked,deprecation</compilerArg>
-                            <!--<compilerArg>-Werror</compilerArg>-->
+                            <compilerArg>-Werror</compilerArg>
                             <compilerArg>-parameters</compilerArg>
                         </compilerArgs>
                     </configuration>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -401,7 +401,7 @@
                     <configuration>
                         <jvmTarget>${java.version}</jvmTarget>
                         <args>
-                            <arg>-Xopt-in=kotlin.RequiresOptIn</arg>
+                            <arg>-opt-in=kotlin.RequiresOptIn</arg>
                         </args>
                     </configuration>
                     <executions>

--- a/logbook-servlet/pom.xml
+++ b/logbook-servlet/pom.xml
@@ -24,8 +24,8 @@
             <artifactId>logbook-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListener.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListener.java
@@ -1,7 +1,8 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.AsyncEvent;
+
 import java.io.IOException;
-import javax.servlet.AsyncEvent;
 
 @FunctionalInterface
 interface AsyncOnCompleteListener {

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/HttpFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/HttpFilter.java
@@ -1,13 +1,14 @@
 package org.zalando.logbook.servlet;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 interface HttpFilter extends Filter {

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -1,16 +1,16 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Origin;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletResponse;
-import javax.servlet.WriteListener;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookAsyncListener.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookAsyncListener.java
@@ -1,8 +1,9 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+
 import java.io.IOException;
-import javax.servlet.AsyncEvent;
-import javax.servlet.AsyncListener;
 
 class LogbookAsyncListener implements AsyncListener {
 

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -1,14 +1,9 @@
 package org.zalando.logbook.servlet;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nullable;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.With;
 import org.apiguardian.api.API;
@@ -18,7 +13,14 @@ import org.zalando.logbook.Logbook.RequestWritingStage;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
 import org.zalando.logbook.Logbook.ResponseWritingStage;
 import org.zalando.logbook.Strategy;
-import static javax.servlet.DispatcherType.ASYNC;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static jakarta.servlet.DispatcherType.ASYNC;
 import static lombok.AccessLevel.PRIVATE;
 import static org.apiguardian.api.API.Status.STABLE;
 

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/RemoteRequest.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/RemoteRequest.java
@@ -1,5 +1,20 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.HttpRequest;
+import org.zalando.logbook.Origin;
+import org.zalando.logbook.common.MediaTypeQuery;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -13,20 +28,7 @@ import java.util.Enumeration;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
-import javax.servlet.AsyncContext;
-import javax.servlet.AsyncListener;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.SneakyThrows;
-import org.zalando.logbook.HttpHeaders;
-import org.zalando.logbook.HttpRequest;
-import org.zalando.logbook.Origin;
-import org.zalando.logbook.common.MediaTypeQuery;
+
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.util.Collections.list;
 import static java.util.stream.Collectors.joining;

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecureLogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecureLogbookFilter.java
@@ -1,13 +1,13 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apiguardian.api.API;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.SecurityStrategy;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static org.apiguardian.api.API.Status.STABLE;

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/ServletInputStreamAdapter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/ServletInputStreamAdapter.java
@@ -1,9 +1,9 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 import lombok.AllArgsConstructor;
 
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
@@ -1,12 +1,10 @@
 package org.zalando.logbook.servlet;
 
-import java.io.IOException;
-import java.time.Duration;
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,8 +25,12 @@ import org.zalando.logbook.DefaultSink;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
-import static javax.servlet.DispatcherType.ASYNC;
-import static javax.servlet.DispatcherType.REQUEST;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static jakarta.servlet.DispatcherType.ASYNC;
+import static jakarta.servlet.DispatcherType.REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ExampleController.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ExampleController.java
@@ -1,5 +1,9 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -8,10 +12,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.CharBuffer;
 import java.util.Objects;

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/HttpSupportTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/HttpSupportTest.java
@@ -1,14 +1,14 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.zalando.logbook.Logbook;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LocalResponseTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LocalResponseTest.java
@@ -1,11 +1,11 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.WriteListener;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookAsyncListenerTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookAsyncListenerTest.java
@@ -1,8 +1,10 @@
 package org.zalando.logbook.servlet;
 
-import java.io.IOException;
-import javax.servlet.AsyncEvent;
+import jakarta.servlet.AsyncEvent;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookFilterTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookFilterTest.java
@@ -1,8 +1,7 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.FilterConfig;
 import org.junit.jupiter.api.Test;
-
-import javax.servlet.FilterConfig;
 
 import static org.mockito.Mockito.mock;
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/MultiFilterTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/MultiFilterTest.java
@@ -1,5 +1,7 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -16,8 +18,6 @@ import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
 
-import javax.servlet.Filter;
-import javax.servlet.ServletException;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/RemoteRequestTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/RemoteRequestTest.java
@@ -1,14 +1,14 @@
 package org.zalando.logbook.servlet;
 
-import java.util.Optional;
-import javax.servlet.AsyncContext;
-import javax.servlet.AsyncListener;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/RequestBuilders.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/RequestBuilders.java
@@ -1,10 +1,9 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.DispatcherType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
-
-import javax.servlet.DispatcherType;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/SecurityFilter.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/SecurityFilter.java
@@ -1,10 +1,11 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import javax.annotation.Nullable;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 class SecurityFilter implements HttpFilter {

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ServletInputStreamAdapterTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ServletInputStreamAdapterTest.java
@@ -1,10 +1,10 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/SkipTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/SkipTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.DispatcherType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
@@ -13,8 +14,6 @@ import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
-
-import javax.servlet.DispatcherType;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/SpyableFilter.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/SpyableFilter.java
@@ -1,14 +1,15 @@
 package org.zalando.logbook.servlet;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
 import java.io.IOException;
 
-// non final so we can wrap a spy around it
+// non-final so we can wrap a spy around it
 class SpyableFilter implements Filter {
 
     private final Filter filter;

--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>logbook-servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -1,6 +1,8 @@
 package org.zalando.logbook.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.Filter;
+import jakarta.servlet.Servlet;
 import org.apache.http.client.HttpClient;
 import org.apiguardian.api.API;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,16 +59,14 @@ import org.zalando.logbook.servlet.LogbookFilter;
 import org.zalando.logbook.servlet.SecureLogbookFilter;
 import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
 
-import javax.servlet.Filter;
-import javax.servlet.Servlet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 
-import static javax.servlet.DispatcherType.ASYNC;
-import static javax.servlet.DispatcherType.REQUEST;
+import static jakarta.servlet.DispatcherType.ASYNC;
+import static jakarta.servlet.DispatcherType.REQUEST;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.zalando.logbook.BodyFilters.defaultValue;
@@ -249,7 +249,7 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(Sink.class)
     public Sink sink(
-            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final HttpLogFormatter formatter,
+            final HttpLogFormatter formatter,
             final HttpLogWriter writer) {
         return new DefaultSink(formatter, writer);
     }
@@ -289,10 +289,9 @@ public class LogbookAutoConfiguration {
 
     @API(status = INTERNAL)
     @Bean
-    @ConditionalOnBean(ObjectMapper.class)
     @ConditionalOnMissingBean(HttpLogFormatter.class)
     public HttpLogFormatter jsonFormatter(
-            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final ObjectMapper mapper) {
+            final ObjectMapper mapper) {
         return new JsonHttpLogFormatter(mapper);
     }
 

--- a/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration = org.zalando.logbook.autoconfigure.LogbookAutoConfiguration

--- a/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.zalando.logbook.autoconfigure.LogbookAutoConfiguration

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ExcludeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ExcludeTest.java
@@ -22,16 +22,16 @@ import static org.mockito.Mockito.verify;
 import static org.zalando.logbook.Conditions.exclude;
 import static org.zalando.logbook.Conditions.requestTo;
 
-@LogbookTest(profiles = "exclude", imports = ExcludeTest.Config.class)
-class ExcludeTest {
-
-    @TestConfiguration
-    public static class Config {
-        @Bean
-        public Predicate<HttpRequest> requestCondition() {
-            return exclude(requestTo("/health"));
-        }
+@TestConfiguration
+class Config {
+    @Bean
+    public Predicate<HttpRequest> requestCondition() {
+        return exclude(requestTo("/health"));
     }
+}
+
+@LogbookTest(profiles = "exclude", imports = Config.class)
+class ExcludeTest {
 
     @Autowired
     private Logbook logbook;

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/LogbookTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/LogbookTest.java
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @ActiveProfiles
 @TestPropertySource
 @WebAppConfiguration
-@Import(Void.class)
+@Import(Object.class)
 @ExtendWith(SpringExtension.class)
 @interface LogbookTest {
 

--- a/logbook-spring-boot-webflux-autoconfigure/pom.xml
+++ b/logbook-spring-boot-webflux-autoconfigure/pom.xml
@@ -35,8 +35,8 @@
             <artifactId>logbook-spring-boot-autoconfigure</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/logbook-spring-webflux/pom.xml
+++ b/logbook-spring-webflux/pom.xml
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>${spring5.version}</version>
+                <version>${spring.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -51,6 +51,12 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
             <version>${spring-boot.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ClientResponse.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ClientResponse.java
@@ -1,14 +1,12 @@
 package org.zalando.logbook.spring.webflux;
 
 import lombok.AllArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Origin;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,7 +22,8 @@ final class ClientResponse implements HttpResponse {
 
     @Override
     public int getStatus() {
-        return response.rawStatusCode();
+        // FIX-ME: May throw NPE
+        return response.statusCode().value();
     }
 
     @Override
@@ -53,7 +52,7 @@ final class ClientResponse implements HttpResponse {
     }
 
     @Override
-    public HttpResponse withBody() throws IOException {
+    public HttpResponse withBody() {
         state.updateAndGet(State::with);
         return this;
     }
@@ -73,7 +72,7 @@ final class ClientResponse implements HttpResponse {
     }
 
     @Override
-    public byte[] getBody() throws IOException {
+    public byte[] getBody() {
         return state.get().getBody();
     }
 }

--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerRequest.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerRequest.java
@@ -42,7 +42,7 @@ final class ServerRequest implements HttpRequest {
 
     @Override
     public String getMethod() {
-        return request.getMethodValue();
+        return request.getMethod().name();
     }
 
     @Override

--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerResponse.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerResponse.java
@@ -1,7 +1,7 @@
 package org.zalando.logbook.spring.webflux;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatusCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.MimeType;
 import org.zalando.logbook.HttpHeaders;
@@ -34,8 +34,9 @@ final class ServerResponse implements HttpResponse {
 
     @Override
     public int getStatus() {
-        HttpStatusCode httpStatus = response.getStatusCode();
-        return httpStatus != null ? httpStatus.value() : 200;
+        return Optional.ofNullable(response.getStatusCode())
+                .orElse(HttpStatus.OK)
+                .value();
     }
 
     @Nullable

--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerResponse.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerResponse.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.spring.webflux;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.MimeType;
 import org.zalando.logbook.HttpHeaders;
@@ -8,7 +9,6 @@ import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Origin;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,7 +34,8 @@ final class ServerResponse implements HttpResponse {
 
     @Override
     public int getStatus() {
-        return Optional.ofNullable(response.getRawStatusCode()).orElse(200);
+        HttpStatusCode httpStatus = response.getStatusCode();
+        return httpStatus != null ? httpStatus.value() : 200;
     }
 
     @Nullable
@@ -53,7 +54,7 @@ final class ServerResponse implements HttpResponse {
     }
 
     @Override
-    public HttpResponse withBody() throws IOException {
+    public HttpResponse withBody() {
         state.updateAndGet(State::with);
         return this;
     }
@@ -73,7 +74,7 @@ final class ServerResponse implements HttpResponse {
     }
 
     @Override
-    public byte[] getBody() throws IOException {
+    public byte[] getBody() {
         return state.get().getBody();
     }
 }

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
@@ -105,7 +105,8 @@ final class RemoteResponse implements HttpResponse {
     @Override
     public int getStatus() {
         try {
-            return response.getRawStatusCode();
+            // This may throw NPE
+            return response.getStatusCode().value();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -143,7 +144,7 @@ final class RemoteResponse implements HttpResponse {
     }
 
     @Override
-    public HttpResponse withBody() throws IOException {
+    public HttpResponse withBody() {
         state.updateAndGet(State::with);
         return this;
     }

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
@@ -105,7 +105,7 @@ final class RemoteResponse implements HttpResponse {
     @Override
     public int getStatus() {
         try {
-            // This may throw NPE
+            // FIX-ME: May throw NPE
             return response.getStatusCode().value();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/RemoteResponseTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/RemoteResponseTest.java
@@ -14,9 +14,9 @@ import static org.mockito.Mockito.when;
 class RemoteResponseTest {
 
     @Test
-    void statusCanThrow() throws IOException {
+    void statusCanThrow() {
         MockClientHttpResponse response = mock(MockClientHttpResponse.class);
-        when(response.getRawStatusCode()).thenThrow(new IOException("io exception"));
+        when(response.getStatusCode()).thenThrow(new IOException("io exception"));
         assertThatThrownBy(() -> unit(response).getStatus()).hasMessageContaining("io exception");
     }
 


### PR DESCRIPTION
Bumping version of Spring to 6, Spring Boot to 3, and using `jakarta.*` instead of `javax.*` in most places. This is a breaking change, as it drops support for previous versions. See `Description` for further info.

## Description
Migrate Logbook to exclusively use Spring 6 / Spring Boot 3. That is, we drop support for Spring 5.x or Spring Boot 2.x.
It is yet to be decided whether we want to drop this support, so this PR is provided on a just-in-case basis.

## Motivation and Context
Fixes #1344

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
    - **Some changes to the documentation are required. They will be applied once we make sure that we want to proceed with this approach.**
- [ ] I have added tests to cover my changes.
