### PR TITLE
Java 17 compiler support while keeping source/target levels intact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,16 +25,18 @@ jobs:
         profile: ['']
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: m2
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: 17
+        cache: 'maven'
     - name: Compile
       run: ./mvnw clean test-compile -B
     - name: Test

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -27,9 +27,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>17</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
 
         <jackson.version>2.14.2</jackson.version>
         <json-path.version>2.7.0</json-path.version>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -27,9 +27,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <jackson.version>2.14.2</jackson.version>
         <json-path.version>2.7.0</json-path.version>
@@ -402,7 +402,7 @@
                     <artifactId>kotlin-maven-plugin</artifactId>
                     <version>${kotlin.version}</version>
                     <configuration>
-                        <jvmTarget>${java.version}</jvmTarget>
+                        <jvmTarget>${maven.compiler.target}</jvmTarget>
                         <args>
                             <arg>-Xopt-in=kotlin.RequiresOptIn</arg>
                         </args>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>17</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <modules>
         <module>logbook-parent</module>


### PR DESCRIPTION
## Description
Change Java compiler version to 17.
Keep `maven.compiler.source` and `maven.compiler.target` intact for backwards compatibility.

## Motivation and Context
- Use optimizations in the new compiler for faster compilation process (looking at the history of builds, they usually took ~ 8 min while this branch took ~ 4 min)
- Pave the way for Spring 6 / Spring Boot 3 support

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
