### PR TITLE
Fix RemoteResponseTest

### DIFF
--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/RemoteResponseTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/RemoteResponseTest.java
@@ -2,6 +2,7 @@ package org.zalando.logbook.spring;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.mock.http.client.MockClientHttpResponse;
 
 import java.io.IOException;
@@ -15,9 +16,9 @@ class RemoteResponseTest {
 
     @Test
     void statusCanThrow() throws IOException {
-        MockClientHttpResponse response = mock(MockClientHttpResponse.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
         when(response.getRawStatusCode()).thenThrow(new IOException("io exception"));
-        assertThatThrownBy(() -> unit(response).getStatus()).hasMessageContaining("io exception");
+        assertThatThrownBy(() -> new RemoteResponse(response).getStatus()).hasMessageContaining("io exception");
     }
 
     @Test
@@ -34,7 +35,7 @@ class RemoteResponseTest {
         return new MockClientHttpResponse("hello world".getBytes(), HttpStatus.OK);
     }
 
-    private org.zalando.logbook.HttpResponse unit(MockClientHttpResponse response) {
+    private org.zalando.logbook.HttpResponse unit(ClientHttpResponse response) {
         return new RemoteResponse(response);
     }
 }


### PR DESCRIPTION
the `statusCanThrow` test method mocked a mock

## Description
this PR fixes the test method and mocks a real ClientHttpResponse



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
