### PR TITLE
Fix deprecated kotlin maven plugin argument

### DIFF
--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -401,7 +401,7 @@
                     <configuration>
                         <jvmTarget>${maven.compiler.target}</jvmTarget>
                         <args>
-                            <arg>-Xopt-in=kotlin.RequiresOptIn</arg>
+                            <arg>-opt-in=kotlin.RequiresOptIn</arg>
                         </args>
                     </configuration>
                     <executions>


### PR DESCRIPTION
`-Xopt-in` argument is deprecated in the new version of `kotlin-maven-plugin`.
It should be replaced with `-opt-in.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
