### PR TITLE
Add Coverage Profile To Reactor Pom

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,4 +43,4 @@ jobs:
       run: ./mvnw verify -P "${{ matrix.profile }}" -B
     - name: Coverage
       if: github.event_name != 'pull_request'
-      run: ./mvnw coveralls:report -B -D repoToken=${{ secrets.COVERALLS_TOKEN }}
+      run: ./mvnw -P coverage coveralls:report -B -D repoToken=${{ secrets.COVERALLS_TOKEN }}

--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -10,6 +10,8 @@
             <cve>CVE-2021-0341</cve>
             <!-- ktor requires a major upgrade. Suppressing until then -->
             <cve>CVE-2021-4277</cve>
+            <!-- so far jackson-core and json-path don't have bugfix releases yet for that cve -->
+            <cve>CVE-2022-45688</cve>
         </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -107,22 +107,25 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eluder.coveralls</groupId>
+                        <artifactId>coveralls-maven-plugin</artifactId>
+                        <version>4.3.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.xml.bind</groupId>
+                                <artifactId>jaxb-api</artifactId>
+                                <version>2.3.1</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.3.1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Using a coverage profile in the build action to ensure coveralls plugin runs with provided jaxb-api