### PR TITLE
Bump httpclient5 from 5.1.3 to 5.2.1

### DIFF
--- a/logbook-httpclient5/pom.xml
+++ b/logbook-httpclient5/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.1.3</version>
+            <version>5.2.1</version>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
@@ -39,6 +39,7 @@ class LogbookHttpExecHandlerTest extends AbstractHttpTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws IOException {
         driver.addExpectation(onRequestTo("/"),
                 giveResponse("Hello, world!", "text/plain"));
@@ -54,6 +55,7 @@ class LogbookHttpExecHandlerTest extends AbstractHttpTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void shouldLogCompressedResponseWithBody() throws IOException, ParseException {
         byte[] compressedResponse = new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, -1, -13, 72, -51, -55, -55, -41, 81,
                 72, -50, -49, 45, 40, 74, 45, 46, 78, 77, 81, 40, -49, 47, -54, 73, 81, 4, 0, 5, -67, 83, 110, 24, 0, 0, 0};

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsPutTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsPutTest.java
@@ -54,6 +54,7 @@ final class LogbookHttpInterceptorsPutTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void shouldLogRequestWithoutBody() throws IOException {
         driver.addExpectation(onRequestTo("/").withMethod(PUT), giveEmptyResponse());
 

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsTest.java
@@ -7,10 +7,6 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.AfterEach;
-import org.zalando.logbook.DefaultHttpLogFormatter;
-import org.zalando.logbook.DefaultSink;
-import org.zalando.logbook.Logbook;
-import org.zalando.logbook.TestStrategy;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -33,6 +29,7 @@ public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws IOException {
         driver.addExpectation(onRequestTo("/"),
                 giveResponse("Hello, world!", "text/plain"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bumps [httpclient5](https://github.com/apache/httpcomponents-client) from 5.1.3 to 5.2.1. and Closes https://github.com/zalando/logbook/pull/1444

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
