### PR TITLE
Fallback to empty input stream when getBody throws exception

### DIFF
--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapperTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapperTest.java
@@ -43,6 +43,13 @@ class BufferingClientHttpResponseWrapperTest {
     }
 
     @Test
+    void useEmptyInputStreamWhenBodyExtractionFails() throws IOException {
+        when(delegate.getBody()).thenThrow(new IOException("Bad request"));
+
+        assertEquals(new BufferingClientHttpResponseWrapper(delegate).getBody().read(), -1);
+    }
+
+    @Test
     void dontWrapBodyInBufferedInputStreamWhenMarkSupported() throws IOException {
         when(inputStream.markSupported()).thenReturn(true);
 


### PR DESCRIPTION
## Description
When ClientHttpResponse throws exception on getBody() call, Logbook throws ResourceAccessException. 
To prevent this, I'm adding a fallback to empty InputStream when such cases occur.

## Motivation and Context
After the introduction of BufferingClientHttpResponseWrapper in https://github.com/zalando/logbook/pull/1041, initialization of BufferingClientHttpResponseWrapper fails in cases when getBody() of ClientHttpResponse throws exception. This happens on some implementations when error status codes are returned. 

Addresses https://github.com/zalando/logbook/issues/1451

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
