### PR TITLE
Request getHeaders() from ClientHttpResponse before retrieving body

### DIFF
--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapper.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapper.java
@@ -17,19 +17,10 @@ public class BufferingClientHttpResponseWrapper implements ClientHttpResponse {
 
     public BufferingClientHttpResponseWrapper(ClientHttpResponse delegate) throws IOException {
         this.delegate = delegate;
-        InputStream delegateBody;
-        try {
-            delegateBody = delegate.getBody();
-        } catch (IOException e) {
-            log.trace("Could not extract body of the response. Falling back to empty InputStream");
-            // As java 8 version is used for compilation, InputStream.nullInputStream() is not yet available.
-            delegateBody = new InputStream() {
-                @Override
-                public int read() {
-                    return -1;
-                }
-            };
-        }
+        // Must call getHeaders() first as some URLConnection implementations throw exceptions first time
+        // getInputStream() is requested if response code >= 400. E.g. sun.net.www.protocol.http.HttpURLConnection.
+        delegate.getHeaders();
+        InputStream delegateBody = delegate.getBody();
         this.body = delegateBody.markSupported() ? delegateBody : new BufferedInputStream(delegateBody);
     }
 

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapperTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapperTest.java
@@ -43,13 +43,6 @@ class BufferingClientHttpResponseWrapperTest {
     }
 
     @Test
-    void useEmptyInputStreamWhenBodyExtractionFails() throws IOException {
-        when(delegate.getBody()).thenThrow(new IOException("Bad request"));
-
-        assertEquals(new BufferingClientHttpResponseWrapper(delegate).getBody().read(), -1);
-    }
-
-    @Test
     void dontWrapBodyInBufferedInputStreamWhenMarkSupported() throws IOException {
         when(inputStream.markSupported()).thenReturn(true);
 

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorTest.java
@@ -65,7 +65,7 @@ class LogbookClientHttpRequestInterceptorTest {
                 .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
                 .build();
         LogbookClientHttpRequestInterceptor interceptor = new LogbookClientHttpRequestInterceptor(logbook);
-        restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+        restTemplate = new RestTemplate();
         restTemplate.getInterceptors().add(interceptor);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a follow up after https://github.com/zalando/logbook/pull/1453. It was reported that no response body was logged when in previous versions of logbook this happened. 

Further investigation with the help of the PR (https://github.com/zalando/logbook/pull/1461) with the failing tests showed that some implementations of URLConnection (e.g. `sun.net.www.protocol.http.HttpURLConnection` on JDK 17 temurin) throw exceptions the first time `getInputStream()` is called when the response code is >= 400.

The issue was not spotted before, as by the time the response body is requested, header filters were accessing getHeaders() first. After that, the response input stream reference is returned without the status code check.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses https://github.com/zalando/logbook/issues/1451


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
