### PR TITLE
Add JavaxSecurityServletFilterConfiguration

### DIFF
--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JavaxFilterTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JavaxFilterTest.java
@@ -26,4 +26,19 @@ class JavaxFilterTest {
 
     }
 
+    @Test
+    void shouldInitializeSecureFilter() {
+        this.contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .withBean("logbookProperties", LogbookProperties.class, LogbookProperties::new)
+                .withUserConfiguration(LogbookAutoConfiguration.JavaxSecurityServletFilterConfiguration.class)
+                .withClassLoader(new FilteredClassLoader(org.zalando.logbook.servlet.LogbookFilter.class))
+                .withClassLoader(new FilteredClassLoader(jakarta.servlet.Servlet.class))
+                .withPropertyValues("logbook.secure-filter.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasBean("secureLogbookFilter");
+                });
+
+    }
+
 }


### PR DESCRIPTION
If spring-security is enabled logbooks autoconfiguration fails. An additional Autoconfiguration when javax.servlet is on the classpath fixes the issue 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
