### PR TITLE
Fix: The underlying HTTP client completed without emitting a response

### DIFF
--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -263,6 +263,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>3.0.0-beta-7</version>
+                <scope>test</scope>
+            </dependency>
             <!-- Needed by json-path-assert and rest-client-driver... -->
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/logbook-spring-webflux/pom.xml
+++ b/logbook-spring-webflux/pom.xml
@@ -77,6 +77,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/logbook-spring-webflux/pom.xml
+++ b/logbook-spring-webflux/pom.xml
@@ -74,6 +74,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+        </dependency>
     </dependencies>
-    
+
 </project>

--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunction.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunction.java
@@ -46,7 +46,8 @@ public class LogbookExchangeFilterFunction implements ExchangeFilterFunction {
                                     return it
                                             .bodyToMono(byte[].class)
                                             .doOnNext(clientResponse::buffer)
-                                            .map(b -> response.mutate().body(Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(b))).build());
+                                            .map(b -> response.mutate().body(Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(b))).build())
+                                            .switchIfEmpty(Mono.just(it));
                                 } else {
                                     return Mono.just(it);
                                 }

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
@@ -169,6 +169,7 @@ class LogbookExchangeFilterFunctionTest {
         assertThat(message)
                 .startsWith("Incoming Response:")
                 .contains("HTTP/1.1 200 OK")
+                .contains("Content-Length: 0")
                 .doesNotContain("Hello, world!");
     }
 
@@ -190,6 +191,7 @@ class LogbookExchangeFilterFunctionTest {
         assertThat(message)
                 .startsWith("Incoming Response:")
                 .contains("HTTP/1.1 200 OK")
+                .contains("Content-Length: 13")
                 .contains("Hello, world!");
     }
 

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
@@ -1,26 +1,44 @@
 package org.zalando.logbook.spring.webflux;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.zalando.logbook.*;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.DefaultHttpLogFormatter;
+import org.zalando.logbook.DefaultSink;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.TestStrategy;
+import reactor.netty.http.client.HttpClient;
 
 import java.io.IOException;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest(classes = TestApplication.class, webEnvironment = RANDOM_PORT)
 class LogbookExchangeFilterFunctionTest {
 
-    @LocalServerPort
-    int port;
+    private final WireMockServer server = new WireMockServer(options().dynamicPort());
 
     private final HttpLogWriter writer = mock(HttpLogWriter.class);
 
@@ -33,27 +51,68 @@ class LogbookExchangeFilterFunctionTest {
 
     @BeforeEach
     void setup() {
+        server.start();
         when(writer.isActive()).thenReturn(true);
+
         client = WebClient.builder()
-                .baseUrl(String.format("http://localhost:%d", port))
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create()))
+                .baseUrl(server.baseUrl())
                 .filter(new LogbookExchangeFilterFunction(logbook))
+                .codecs(it -> it.customCodecs().register(new Jackson2JsonEncoder(new ObjectMapper())))
+                .codecs(it -> it.customCodecs().register(new Jackson2JsonDecoder(new ObjectMapper())))
                 .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
     }
 
     @Test
     void shouldLogRequestWithoutBody() throws IOException {
+        server.stubFor(post("/echo").willReturn(aResponse().withStatus(200)));
+
         sendAndReceive();
 
         final String message = captureRequest();
 
         assertThat(message)
                 .startsWith("Outgoing Request:")
-                .contains(format("POST http://localhost:%d/echo HTTP/1.1", port))
+                .contains(format("POST %s/echo HTTP/1.1", server.baseUrl()))
                 .doesNotContain("Hello, world!");
     }
 
     @Test
+    void shouldLogEmptyResponseWithTransferEncodingChunked() throws IOException {
+        server.stubFor(get("/empty-chunked").willReturn(aResponse().withStatus(400)));
+
+        assertThatThrownBy(() -> client
+                .get()
+                .uri(server.baseUrl() + "/empty-chunked")
+                .retrieve()
+                .toBodilessEntity()
+                .block())
+                .isInstanceOf(WebClientResponseException.class)
+                .hasMessage(format("400 Bad Request from GET %s/empty-chunked", server.baseUrl()));
+
+        final String message = captureRequest();
+        final String response = captureResponse();
+
+        assertThat(message)
+                .startsWith("Outgoing Request:")
+                .contains(format("GET %s/empty-chunked HTTP/1.1", server.baseUrl()))
+                .doesNotContain("Hello, world!");
+
+        assertThat(response)
+                .startsWith("Incoming Response:")
+                .contains("Transfer-Encoding: chunked")
+                .contains("HTTP/1.1 400 Bad Request");
+    }
+
+    @Test
     void shouldLogRequestWithBody() throws IOException {
+        server.stubFor(post("/discard").willReturn(aResponse().withStatus(200)));
+
         client.post()
                 .uri("/discard")
                 .bodyValue("Hello, world!")
@@ -65,7 +124,7 @@ class LogbookExchangeFilterFunctionTest {
 
         assertThat(message)
                 .startsWith("Outgoing Request:")
-                .contains(format("POST http://localhost:%d/discard HTTP/1.1", port))
+                .contains(format("POST %s/discard HTTP/1.1", server.baseUrl()))
                 .contains("Hello, world!");
     }
 
@@ -77,6 +136,8 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldNotLogRequestIfInactive() throws IOException {
+        server.stubFor(post("/echo").willReturn(aResponse().withStatus(200)));
+
         when(writer.isActive()).thenReturn(false);
 
         sendAndReceive();
@@ -86,6 +147,8 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldLogResponseWithoutBody() throws IOException {
+        server.stubFor(post("/discard").willReturn(aResponse().withStatus(200)));
+
         sendAndReceive("/discard");
 
         final String message = captureResponse();
@@ -98,6 +161,8 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
+        server.stubFor(post("/echo").willReturn(aResponse().withStatus(200).withBody("Hello, world!")));
+
         final String response = client.post()
                 .uri("/echo")
                 .bodyValue("Hello, world!")
@@ -123,6 +188,8 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldNotLogResponseIfInactive() throws IOException {
+        server.stubFor(post("/echo").willReturn(aResponse().withStatus(200)));
+
         when(writer.isActive()).thenReturn(false);
 
         sendAndReceive();
@@ -132,6 +199,8 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldLogChunkedResponseWithBody() throws IOException {
+        server.stubFor(get("/chunked").willReturn(aResponse().withStatus(200).withBody("Hello, world!")));
+
         final String response = client.get()
                 .uri("/chunked")
                 .retrieve()
@@ -145,12 +214,14 @@ class LogbookExchangeFilterFunctionTest {
         assertThat(message)
                 .startsWith("Incoming Response:")
                 .contains("HTTP/1.1 200 OK")
-                .contains("transfer-encoding: chunked")
+                .contains("Transfer-Encoding: chunked")
                 .contains("Hello, world!");
     }
 
     @Test
     void shouldIgnoreBodies() throws IOException {
+        server.stubFor(post("/echo").willReturn(aResponse().withStatus(200).withBody("Hello, world!")));
+
         final String response = client.post()
                 .uri("/echo")
                 .header("Ignore", "true")
@@ -166,7 +237,7 @@ class LogbookExchangeFilterFunctionTest {
 
             assertThat(message)
                     .startsWith("Outgoing Request:")
-                    .contains(format("POST http://localhost:%d/echo HTTP/1.1", port))
+                    .contains(format("POST %s/echo HTTP/1.1", server.baseUrl()))
                     .doesNotContain("Hello, world!");
         }
 

--- a/logbook-spring/pom.xml
+++ b/logbook-spring/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/logbook-spring/pom.xml
+++ b/logbook-spring/pom.xml
@@ -73,9 +73,7 @@
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.35.0</version>
-            <scope>test</scope>
+            <artifactId>wiremock</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
LogbookExchangeFilterFunction was not handing case of empty response with `Transfer-Encoding: chunked`. This should not happen, but it happens. This resulted in WebClient throwing an error as ExchangeFunction returned an empty Mono.

The issue was not reproducible without Wiremock as Spring would always return `Content-Length: 0` with empty response. To add tests for the issue, I rewrote LogbookExchangeFilterFunctionTest to use WireMock.

Note: I added wiremock version 3.0.0-beta-7, which supports jakarta servlet api. Versions lower than 3 were resulting in application startup errors.

## Motivation and Context

Addresses the issue mentioned in [this comment](https://github.com/zalando/logbook/issues/1199#issuecomment-1466977403) in issue 1199, but not the initial issue. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
