### PR TITLE
Upgraded spring-boot-version to 3.0.6 to allow logbook pull 1492 to s…

### DIFF
--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -37,7 +37,7 @@
         <slf4j.version>1.7.36</slf4j.version>
 
         <spring.version>6.0.8</spring.version>
-        <spring-boot.version>3.0.5</spring-boot.version>
+        <spring-boot.version>3.0.6</spring-boot.version>
         <spring-security.version>6.0.3</spring-security.version>
 
         <junit.version>5.9.2</junit.version>


### PR DESCRIPTION
Upgraded spring boot version to 3.0.6

## Description
Spring Boot 3.0.5 jar has known CVE (CVE-2023-20873). Upgrading to at least 3.0.6 is recommended.

## Motivation and Context
It should fix https://github.com/zalando/logbook/pull/1492 failure.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
