### PR TITLE
Make servlet-api optional 

### DIFF
--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -147,6 +147,7 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>
+            <optional>true</optional>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
set the servlet-api to optional in order to be still able to compile