### PR TITLE
Httpclient gzipped response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,8 +1014,6 @@ for outputs like
 
 1. The Logbook Servlet Filter interferes with downstream code using `getWriter` and/or `getParameter*()`. See [Servlet](#servlet) for more details.
 2. The Logbook Servlet Filter does **NOT** support `ERROR` dispatch. You're strongly encouraged to not use it to produce error responses.
-2. The Logbook HTTP Client integration is handling gzip-compressed response entities incorrectly if the interceptor runs before a decompressing interceptor. Since logging compressed contents is not
-   really helpful it's advised to register the logbook interceptor as the last interceptor in the chain.
 
 ## Getting Help with Logbook
 

--- a/README.md
+++ b/README.md
@@ -934,21 +934,22 @@ MyClient(RestTemplateBuilder builder, LogbookClientHttpRequestInterceptor interc
 
 The following tables show the available configuration:
 
-| Configuration                      | Description                                                                                          | Default                       |
-|------------------------------------|------------------------------------------------------------------------------------------------------|-------------------------------|
-| `logbook.include`                  | Include only certain URLs (if defined)                                                               | `[]`                          |
-| `logbook.exclude`                  | Exclude certain URLs (overrides `logbook.include`)                                                   | `[]`                          |
-| `logbook.filter.enabled`           | Enable the [`LogbookFilter`](#servlet)                                                               | `true`                        |
-| `logbook.filter.form-request-mode` | Determines how [form requests](#form-requests) are handled                                           | `body`                        |
-| `logbook.secure-filter.enabled`    | Enable the [`SecureLogbookFilter`](#servlet)                                                         | `true`                        |
-| `logbook.format.style`             | [Formatting style](#formatting) (`http`, `json`, `curl` or `splunk`)                                 | `json`                        |
-| `logbook.strategy`                 | [Strategy](#strategy) (`default`, `status-at-least`, `body-only-if-status-at-least`, `without-body`) | `default`                     |
-| `logbook.minimum-status`           | Minimum status to enable logging (`status-at-least` and `body-only-if-status-at-least`)              | `400`                         |
-| `logbook.obfuscate.headers`        | List of header names that need obfuscation                                                           | `[Authorization]`             |
-| `logbook.obfuscate.paths`          | List of paths that need obfuscation. Check [Filtering](#filtering) for syntax.                       | `[]`                          |
-| `logbook.obfuscate.parameters`     | List of parameter names that need obfuscation                                                        | `[access_token]`              |
-| `logbook.write.chunk-size`         | Splits log lines into smaller chunks of size up-to `chunk-size`.                                     | `0` (disabled)                |
-| `logbook.write.max-body-size`      | Truncates the body up to `max-body-size` and appends `...`.                                          | `-1` (disabled)               |
+| Configuration                            | Description                                                                                                                                                                         | Default            |
+|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| `logbook.include`                        | Include only certain URLs (if defined)                                                                                                                                              | `[]`               |
+| `logbook.exclude`                        | Exclude certain URLs (overrides `logbook.include`)                                                                                                                                  | `[]`               |
+| `logbook.filter.enabled`                 | Enable the [`LogbookFilter`](#servlet)                                                                                                                                              | `true`             |
+| `logbook.filter.form-request-mode`       | Determines how [form requests](#form-requests) are handled                                                                                                                          | `body`             |
+| `logbook.secure-filter.enabled`          | Enable the [`SecureLogbookFilter`](#servlet)                                                                                                                                        | `true`             |
+| `logbook.format.style`                   | [Formatting style](#formatting) (`http`, `json`, `curl` or `splunk`)                                                                                                                | `json`             |
+| `logbook.strategy`                       | [Strategy](#strategy) (`default`, `status-at-least`, `body-only-if-status-at-least`, `without-body`)                                                                                | `default`          |
+| `logbook.minimum-status`                 | Minimum status to enable logging (`status-at-least` and `body-only-if-status-at-least`)                                                                                             | `400`              |
+| `logbook.obfuscate.headers`              | List of header names that need obfuscation                                                                                                                                          | `[Authorization]`  |
+| `logbook.obfuscate.paths`                | List of paths that need obfuscation. Check [Filtering](#filtering) for syntax.                                                                                                      | `[]`               |
+| `logbook.obfuscate.parameters`           | List of parameter names that need obfuscation                                                                                                                                       | `[access_token]`   |
+| `logbook.write.chunk-size`               | Splits log lines into smaller chunks of size up-to `chunk-size`.                                                                                                                    | `0` (disabled)     |
+| `logbook.write.max-body-size`            | Truncates the body up to `max-body-size` and appends `...`.                                                                                                                         | `-1` (disabled)    |
+| `logbook.httpclient.decompress-response` | Enables/disables additional decompression process for HttpClient with gzip encoded body (to logging purposes only). This means extra decompression and possible performance impact. | `false` (disabled) |
 
 ##### Example configuration
 

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumer.java
@@ -1,15 +1,16 @@
 package org.zalando.logbook.httpclient;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.apache.http.protocol.HttpContext;
 import org.apiguardian.api.API;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 @API(status = EXPERIMENTAL)
 public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsyncResponseConsumer<T> {
@@ -18,7 +19,7 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
     private final boolean decompressResponse;
     private HttpResponse response;
 
-    public LogbookHttpAsyncResponseConsumer(HttpAsyncResponseConsumer<T> consumer, boolean decompressResponse) {
+    public LogbookHttpAsyncResponseConsumer(final HttpAsyncResponseConsumer<T> consumer, boolean decompressResponse) {
         this.consumer = consumer;
         this.decompressResponse = decompressResponse;
     }

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumer.java
@@ -1,5 +1,9 @@
 package org.zalando.logbook.httpclient;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
@@ -7,19 +11,16 @@ import org.apache.http.protocol.HttpContext;
 import org.apiguardian.api.API;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-
 @API(status = EXPERIMENTAL)
 public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsyncResponseConsumer<T> {
 
     private final HttpAsyncResponseConsumer<T> consumer;
+    private final boolean decompressResponse;
     private HttpResponse response;
 
-    public LogbookHttpAsyncResponseConsumer(final HttpAsyncResponseConsumer<T> consumer) {
+    public LogbookHttpAsyncResponseConsumer(HttpAsyncResponseConsumer<T> consumer, boolean decompressResponse) {
         this.consumer = consumer;
+        this.decompressResponse = decompressResponse;
     }
 
     @Override
@@ -38,7 +39,7 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
         final ResponseProcessingStage stage = find(context);
 
         try {
-            stage.process(new RemoteResponse(response)).write();
+            stage.process(new RemoteResponse(response, decompressResponse)).write();
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
@@ -1,5 +1,8 @@
 package org.zalando.logbook.httpclient;
 
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.io.IOException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.nio.client.HttpAsyncClient;
@@ -7,13 +10,8 @@ import org.apache.http.protocol.HttpContext;
 import org.apiguardian.api.API;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
-import java.io.IOException;
-
-import static org.apiguardian.api.API.Status.STABLE;
-
 /**
- * A response interceptor for synchronous responses. For {@link HttpAsyncClient} support, please use
- * {@link LogbookHttpAsyncResponseConsumer} instead.
+ * A response interceptor for synchronous responses. For {@link HttpAsyncClient} support, please use {@link LogbookHttpAsyncResponseConsumer} instead.
  *
  * @see LogbookHttpRequestInterceptor
  * @see LogbookHttpAsyncResponseConsumer
@@ -21,10 +19,16 @@ import static org.apiguardian.api.API.Status.STABLE;
 @API(status = STABLE)
 public final class LogbookHttpResponseInterceptor implements HttpResponseInterceptor {
 
+    private final boolean decompressResponse;
+
+    public LogbookHttpResponseInterceptor(boolean decompressResponse) {
+        this.decompressResponse = decompressResponse;
+    }
+
     @Override
     public void process(final HttpResponse original, final HttpContext context) throws IOException {
         final ResponseProcessingStage stage = find(context);
-        stage.process(new RemoteResponse(original)).write();
+        stage.process(new RemoteResponse(original, decompressResponse)).write();
     }
 
     private ResponseProcessingStage find(final HttpContext context) {

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
@@ -1,8 +1,5 @@
 package org.zalando.logbook.httpclient;
 
-import static org.apiguardian.api.API.Status.STABLE;
-
-import java.io.IOException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.nio.client.HttpAsyncClient;
@@ -10,8 +7,13 @@ import org.apache.http.protocol.HttpContext;
 import org.apiguardian.api.API;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
+import java.io.IOException;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
 /**
- * A response interceptor for synchronous responses. For {@link HttpAsyncClient} support, please use {@link LogbookHttpAsyncResponseConsumer} instead.
+ * A response interceptor for synchronous responses. For {@link HttpAsyncClient} support, please use
+ * {@link LogbookHttpAsyncResponseConsumer} instead.
  *
  * @see LogbookHttpRequestInterceptor
  * @see LogbookHttpAsyncResponseConsumer

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
@@ -141,11 +141,11 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
         HttpHeaders headers = HttpHeaders.empty();
 
         final Set<Map.Entry<String, List<String>>> entries =
-            Stream.of(response.getAllHeaders())
-                  .collect(groupingBy(
-                      Header::getName,
-                      mapping(Header::getValue, toList())))
-                  .entrySet();
+                Stream.of(response.getAllHeaders())
+                        .collect(groupingBy(
+                                Header::getName,
+                                mapping(Header::getValue, toList())))
+                        .entrySet();
 
         for (final Map.Entry<String, List<String>> entry : entries) {
             final String name = entry.getKey();
@@ -160,9 +160,9 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
     @Override
     public String getContentType() {
         return Optional.of(response)
-                       .map(response -> response.getFirstHeader("Content-Type"))
-                       .map(Header::getValue)
-                       .orElse("");
+                .map(response -> response.getFirstHeader("Content-Type"))
+                .map(Header::getValue)
+                .orElse("");
     }
 
     @Override

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
@@ -28,7 +28,7 @@ import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.Origin;
 
 @AllArgsConstructor
-public class RemoteResponse implements org.zalando.logbook.HttpResponse {
+final class RemoteResponse implements org.zalando.logbook.HttpResponse {
 
     private final AtomicReference<State> state = new AtomicReference<>(new Unbuffered());
     private final HttpResponse response;
@@ -207,7 +207,7 @@ public class RemoteResponse implements org.zalando.logbook.HttpResponse {
     private boolean isGzip() {
         if (response.containsHeader("Content-Encoding")) {
             Header[] headers = response.getHeaders("Content-Encoding");
-            return Arrays.stream(headers).anyMatch(header -> "gzip".equals(header.getValue()));
+            return Arrays.stream(headers).anyMatch(header -> "gzip".equalsIgnoreCase(header.getValue()) || "x-gzip".equalsIgnoreCase(header.getValue()));
         }
         return false;
     }

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
@@ -207,9 +207,17 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
     private boolean isGzip() {
         if (response.containsHeader("Content-Encoding")) {
             Header[] headers = response.getHeaders("Content-Encoding");
-            return Arrays.stream(headers).anyMatch(header -> "gzip".equalsIgnoreCase(header.getValue()) || "x-gzip".equalsIgnoreCase(header.getValue()));
+            return Arrays.stream(headers).anyMatch(this::isGzipHeaderRepresentation);
         }
         return false;
+    }
+
+    private boolean isGzipHeaderRepresentation(Header header) {
+        if ("gzip".equalsIgnoreCase(header.getValue())) {
+            return true;
+        } else {
+            return "x-gzip".equalsIgnoreCase(header.getValue());
+        }
     }
 
 }

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
@@ -168,11 +168,11 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
     @Override
     public Charset getCharset() {
         return Optional.of(response)
-                       .map(response -> response.getFirstHeader("Content-Type"))
-                       .map(Header::getValue)
-                       .map(ContentType::parse)
-                       .map(ContentType::getCharset)
-                       .orElse(UTF_8);
+                .map(response -> response.getFirstHeader("Content-Type"))
+                .map(Header::getValue)
+                .map(ContentType::parse)
+                .map(ContentType::getCharset)
+                .orElse(UTF_8);
     }
 
     @Override

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
@@ -32,6 +32,7 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
 
     private final AtomicReference<State> state = new AtomicReference<>(new Unbuffered());
     private final HttpResponse response;
+    private final boolean decompressResponse;
 
     private interface State {
 
@@ -198,7 +199,7 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
     @Override
     public byte[] getBody() throws IOException {
         byte[] body = state.updateAndGet(throwingUnaryOperator(s -> s.buffer(response))).getBody();
-        if (isGzip()) {
+        if (decompressResponse && isGzip()) {
             return getDecompressedBytes(body);
         }
         return body;

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/RemoteResponse.java
@@ -1,15 +1,20 @@
 package org.zalando.logbook.httpclient;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
-import static org.zalando.fauxpas.FauxPas.throwingUnaryOperator;
+import lombok.AllArgsConstructor;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.Origin;
+
+import javax.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -18,14 +23,12 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
-import javax.annotation.Nullable;
-import lombok.AllArgsConstructor;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.entity.ContentType;
-import org.zalando.logbook.HttpHeaders;
-import org.zalando.logbook.Origin;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static org.zalando.fauxpas.FauxPas.throwingUnaryOperator;
 
 @AllArgsConstructor
 final class RemoteResponse implements org.zalando.logbook.HttpResponse {

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumerTest.java
@@ -79,12 +79,12 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
         }
 
         return client.execute(create(request),
-                new LogbookHttpAsyncResponseConsumer<>(createConsumer()), callback).get();
+                new LogbookHttpAsyncResponseConsumer<>(createConsumer(), false), callback).get();
     }
 
     @Test
     void shouldWrapIOException() throws IOException {
-        final HttpAsyncResponseConsumer<HttpResponse> unit = new LogbookHttpAsyncResponseConsumer<>(createConsumer());
+        final HttpAsyncResponseConsumer<HttpResponse> unit = new LogbookHttpAsyncResponseConsumer<>(createConsumer(), false);
 
         final BasicHttpContext context = new BasicHttpContext();
         context.setAttribute(Attributes.STAGE, stage);

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsGzipTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsGzipTest.java
@@ -1,0 +1,73 @@
+package org.zalando.logbook.httpclient;
+
+import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.GET;
+import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.POST;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponseAsBytes;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.apache.http.HttpHeaders.CONTENT_ENCODING;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.http.entity.ContentType.TEXT_PLAIN;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+import javax.annotation.Nullable;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.test.TestStrategy;
+
+public final class LogbookHttpInterceptorsGzipTest extends AbstractHttpTest {
+
+    private final Logbook logbook = Logbook.builder()
+                                           .strategy(new TestStrategy())
+                                           .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+                                           .build();
+
+    private final CloseableHttpClient client = HttpClientBuilder.create()
+                                                                .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
+                                                                .addInterceptorFirst(new LogbookHttpResponseInterceptor())
+                                                                .build();
+
+    @AfterEach
+    void stop() throws IOException {
+        client.close();
+    }
+
+    @Override
+    protected HttpResponse sendAndReceive(@Nullable final String body) throws IOException {
+        driver.reset();
+        if (body == null) {
+            driver.addExpectation(onRequestTo("/").withMethod(GET), giveEmptyResponse());
+        } else {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream)) {
+                gzipOutputStream.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            byte[] compressedBytes = outputStream.toByteArray();
+            driver.addExpectation(onRequestTo("/").withMethod(POST),
+                                  giveResponseAsBytes(new ByteArrayInputStream(compressedBytes), "text/plain").withHeader(CONTENT_ENCODING, "gzip"));
+        }
+        if (body == null) {
+            return client.execute(new HttpGet(driver.getBaseUrl()));
+        } else {
+            final HttpPost post = new HttpPost(driver.getBaseUrl());
+            post.setEntity(new StringEntity(body));
+            post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
+
+            return client.execute(post);
+        }
+    }
+
+}

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsGzipTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsGzipTest.java
@@ -46,7 +46,7 @@ public final class LogbookHttpInterceptorsGzipTest extends AbstractHttpTest {
 
     private final CloseableHttpClient client = HttpClientBuilder.create()
                                                                 .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
-                                                                .addInterceptorFirst(new LogbookHttpResponseInterceptor())
+                                                                .addInterceptorFirst(new LogbookHttpResponseInterceptor(true))
                                                                 .build();
 
     @AfterEach

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsGzipTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsGzipTest.java
@@ -3,25 +3,35 @@ package org.zalando.logbook.httpclient;
 import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.GET;
 import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.POST;
 import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
 import static com.github.restdriver.clientdriver.RestClientDriver.giveResponseAsBytes;
 import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
 import static org.apache.http.HttpHeaders.CONTENT_ENCODING;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nullable;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zalando.logbook.Correlation;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.core.DefaultHttpLogFormatter;
 import org.zalando.logbook.core.DefaultSink;
@@ -46,6 +56,10 @@ public final class LogbookHttpInterceptorsGzipTest extends AbstractHttpTest {
 
     @Override
     protected HttpResponse sendAndReceive(@Nullable final String body) throws IOException {
+        return sendAndReceiveWithGzipEncoding(body, "gzip");
+    }
+
+    private CloseableHttpResponse sendAndReceiveWithGzipEncoding(String body, String encoding) throws IOException {
         driver.reset();
         if (body == null) {
             driver.addExpectation(onRequestTo("/").withMethod(GET), giveEmptyResponse());
@@ -57,7 +71,7 @@ public final class LogbookHttpInterceptorsGzipTest extends AbstractHttpTest {
 
             byte[] compressedBytes = outputStream.toByteArray();
             driver.addExpectation(onRequestTo("/").withMethod(POST),
-                                  giveResponseAsBytes(new ByteArrayInputStream(compressedBytes), "text/plain").withHeader(CONTENT_ENCODING, "gzip"));
+                                  giveResponseAsBytes(new ByteArrayInputStream(compressedBytes), "text/plain").withHeader(CONTENT_ENCODING, encoding));
         }
         if (body == null) {
             return client.execute(new HttpGet(driver.getBaseUrl()));
@@ -70,4 +84,50 @@ public final class LogbookHttpInterceptorsGzipTest extends AbstractHttpTest {
         }
     }
 
+    @Test
+    void shouldLogResponseWithBodyGzipHeaderVariant1() throws IOException, ExecutionException, InterruptedException {
+        extracted("GziP");
+    }
+
+    @Test
+    void shouldLogResponseWithBodyGzipHeaderVariant2() throws IOException, ExecutionException, InterruptedException {
+        extracted("GZIP");
+    }
+
+    @Test
+    void shouldLogResponseWithBodyGzipHeaderVariant3() throws IOException, ExecutionException, InterruptedException {
+        extracted("x-gzip");
+    }
+
+    @Test
+    void shouldLogResponseWithBodyGzipHeaderVariant4() throws IOException, ExecutionException, InterruptedException {
+        extracted("X-GZIP");
+    }
+
+    @Test
+    void shouldLogResponseWithBodyGzipHeaderVariant5() throws IOException, ExecutionException, InterruptedException {
+        extracted("x-GziP");
+    }
+
+    private void extracted(String encoding) throws IOException {
+        driver.addExpectation(onRequestTo("/").withMethod(POST),
+                              giveResponse("Hello, world!", "text/plain"));
+
+        final HttpResponse response = sendAndReceiveWithGzipEncoding("Hello, world!", encoding);
+
+        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+        assertThat(EntityUtils.toString(response.getEntity())).isEqualTo("Hello, world!");
+
+        final String message = captureResponse();
+
+        assertThat(message)
+            .startsWith("Incoming Response:")
+            .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", "Hello, world!");
+    }
+
+    private String captureResponse() throws IOException {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer).write(any(Correlation.class), captor.capture());
+        return captor.getValue();
+    }
 }

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsPutTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsPutTest.java
@@ -45,7 +45,7 @@ final class LogbookHttpInterceptorsPutTest {
 
     private final CloseableHttpClient client = HttpClientBuilder.create()
             .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
-            .addInterceptorFirst(new LogbookHttpResponseInterceptor())
+            .addInterceptorFirst(new LogbookHttpResponseInterceptor(false))
             .build();
 
     @AfterEach

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsTest.java
@@ -29,7 +29,7 @@ public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
 
     private final CloseableHttpClient client = HttpClientBuilder.create()
             .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
-            .addInterceptorFirst(new LogbookHttpResponseInterceptor())
+            .addInterceptorFirst(new LogbookHttpResponseInterceptor(false))
             .build();
 
     @AfterEach

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/RemoteResponseTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/RemoteResponseTest.java
@@ -19,7 +19,7 @@ final class RemoteResponseTest {
 
     private final BasicHttpEntity entity = new BasicHttpEntity();
     private final HttpResponse delegate = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), 200, "OK");
-    private final RemoteResponse unit = new RemoteResponse(delegate);
+    private final RemoteResponse unit = new RemoteResponse(delegate, false);
 
     @BeforeEach
     void setUpResponseBody() {

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -398,7 +398,7 @@ public class LogbookAutoConfiguration {
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @ConditionalOnClass({
             javax.servlet.Servlet.class,
-            org.zalando.logbook.servlet.javax.LogbookFilter.class
+            org.zalando.logbook.servlet.LogbookFilter.class
     })
     static class JavaxServletFilterConfiguration {
 
@@ -415,10 +415,10 @@ public class LogbookAutoConfiguration {
         @Bean
         @ConditionalOnProperty(name = "logbook.filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
-        public org.zalando.logbook.servlet.javax.LogbookFilter logbookFilter(final Logbook logbook) {
+        public org.zalando.logbook.servlet.LogbookFilter logbookFilter(final Logbook logbook) {
             FormRequestMode fromProperties = properties.getFilter().getFormRequestMode();
-            org.zalando.logbook.servlet.javax.FormRequestMode formRequestMode = org.zalando.logbook.servlet.javax.FormRequestMode.valueOf(fromProperties.name());
-            return new org.zalando.logbook.servlet.javax.LogbookFilter(logbook)
+            org.zalando.logbook.servlet.FormRequestMode formRequestMode = org.zalando.logbook.servlet.FormRequestMode.valueOf(fromProperties.name());
+            return new org.zalando.logbook.servlet.LogbookFilter(logbook)
                     .withFormRequestMode(formRequestMode);
         }
     }
@@ -449,7 +449,7 @@ public class LogbookAutoConfiguration {
     @ConditionalOnClass({
             SecurityFilterChain.class,
             javax.servlet.Servlet.class,
-            org.zalando.logbook.servlet.javax.LogbookFilter.class
+            org.zalando.logbook.servlet.LogbookFilter.class
     })
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
@@ -463,8 +463,8 @@ public class LogbookAutoConfiguration {
         @ConditionalOnProperty(name = "logbook.secure-filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
         @Order(Ordered.HIGHEST_PRECEDENCE + 1)
-        public org.zalando.logbook.servlet.javax.SecureLogbookFilter secureLogbookFilter(final Logbook logbook) {
-            return new org.zalando.logbook.servlet.javax.SecureLogbookFilter(logbook);
+        public org.zalando.logbook.servlet.SecureLogbookFilter secureLogbookFilter(final Logbook logbook) {
+            return new org.zalando.logbook.servlet.SecureLogbookFilter(logbook);
         }
     }
 

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -134,10 +134,10 @@ public class LogbookAutoConfiguration {
 
     private Predicate<HttpRequest> mergeWithIncludes(final Predicate<HttpRequest> predicate) {
         return properties.getInclude().stream()
-                         .map(Conditions::requestTo)
-                         .reduce(Predicate::or)
-                         .map(predicate::and)
-                         .orElse(predicate);
+                .map(Conditions::requestTo)
+                .reduce(Predicate::or)
+                .map(predicate::and)
+                .orElse(predicate);
     }
 
     @API(status = INTERNAL)

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -84,7 +84,7 @@ import static org.zalando.logbook.core.QueryFilters.replaceQuery;
 @ConditionalOnClass(Logbook.class)
 @EnableConfigurationProperties(LogbookProperties.class)
 @AutoConfigureAfter(value = JacksonAutoConfiguration.class, name = {
-    "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration" // Spring Boot 2.x
+        "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration" // Spring Boot 2.x
 })
 public class LogbookAutoConfiguration {
 
@@ -100,36 +100,36 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(Logbook.class)
     public Logbook logbook(
-        final Predicate<HttpRequest> condition,
-        final CorrelationId correlationId,
-        final List<HeaderFilter> headerFilters,
-        final List<PathFilter> pathFilters,
-        final List<QueryFilter> queryFilters,
-        final List<BodyFilter> bodyFilters,
-        final List<RequestFilter> requestFilters,
-        final List<ResponseFilter> responseFilters,
-        final Strategy strategy,
-        final Sink sink) {
+            final Predicate<HttpRequest> condition,
+            final CorrelationId correlationId,
+            final List<HeaderFilter> headerFilters,
+            final List<PathFilter> pathFilters,
+            final List<QueryFilter> queryFilters,
+            final List<BodyFilter> bodyFilters,
+            final List<RequestFilter> requestFilters,
+            final List<ResponseFilter> responseFilters,
+            final Strategy strategy,
+            final Sink sink) {
 
         return Logbook.builder()
-                      .condition(mergeWithExcludes(mergeWithIncludes(condition)))
-                      .correlationId(correlationId)
-                      .headerFilters(headerFilters)
-                      .queryFilters(queryFilters)
-                      .pathFilters(pathFilters)
-                      .bodyFilters(bodyFilters)
-                      .requestFilters(requestFilters)
-                      .responseFilters(responseFilters)
-                      .strategy(strategy)
-                      .sink(sink)
-                      .build();
+                .condition(mergeWithExcludes(mergeWithIncludes(condition)))
+                .correlationId(correlationId)
+                .headerFilters(headerFilters)
+                .queryFilters(queryFilters)
+                .pathFilters(pathFilters)
+                .bodyFilters(bodyFilters)
+                .requestFilters(requestFilters)
+                .responseFilters(responseFilters)
+                .strategy(strategy)
+                .sink(sink)
+                .build();
     }
 
     private Predicate<HttpRequest> mergeWithExcludes(final Predicate<HttpRequest> predicate) {
         return properties.getExclude().stream()
-                         .map(Conditions::requestTo)
-                         .map(Predicate::negate)
-                         .reduce(predicate, Predicate::and);
+                .map(Conditions::requestTo)
+                .map(Predicate::negate)
+                .reduce(predicate, Predicate::and);
     }
 
     private Predicate<HttpRequest> mergeWithIncludes(final Predicate<HttpRequest> predicate) {
@@ -160,8 +160,8 @@ public class LogbookAutoConfiguration {
     public QueryFilter queryFilter() {
         final List<String> parameters = properties.getObfuscate().getParameters();
         return parameters.isEmpty() ?
-            QueryFilters.defaultValue() :
-            replaceQuery(new HashSet<>(parameters)::contains, "XXX");
+                QueryFilters.defaultValue() :
+                replaceQuery(new HashSet<>(parameters)::contains, "XXX");
     }
 
     @API(status = INTERNAL)
@@ -172,8 +172,8 @@ public class LogbookAutoConfiguration {
         headers.addAll(properties.getObfuscate().getHeaders());
 
         return headers.isEmpty() ?
-            HeaderFilters.defaultValue() :
-            replaceHeaders(headers, "XXX");
+                HeaderFilters.defaultValue() :
+                replaceHeaders(headers, "XXX");
     }
 
     @API(status = INTERNAL)
@@ -182,11 +182,11 @@ public class LogbookAutoConfiguration {
     public PathFilter pathFilter() {
         final List<String> paths = properties.getObfuscate().getPaths();
         return paths.isEmpty() ?
-            PathFilter.none() :
-            paths.stream()
-                 .map(path -> PathFilters.replace(path, "XXX"))
-                 .reduce(PathFilter::merge)
-                 .orElseGet(PathFilter::none);
+                PathFilter.none() :
+                paths.stream()
+                        .map(path -> PathFilters.replace(path, "XXX"))
+                        .reduce(PathFilter::merge)
+                        .orElseGet(PathFilter::none);
     }
 
     @API(status = INTERNAL)
@@ -253,8 +253,8 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(Sink.class)
     public Sink sink(
-        final HttpLogFormatter formatter,
-        final HttpLogWriter writer) {
+            final HttpLogFormatter formatter,
+            final HttpLogWriter writer) {
         return new DefaultSink(formatter, writer);
     }
 
@@ -295,7 +295,7 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(HttpLogFormatter.class)
     public HttpLogFormatter jsonFormatter(
-        final ObjectMapper mapper) {
+            final ObjectMapper mapper) {
         return new JsonHttpLogFormatter(mapper);
     }
 
@@ -314,9 +314,9 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-        HttpClient.class,
-        LogbookHttpRequestInterceptor.class,
-        LogbookHttpResponseInterceptor.class
+            HttpClient.class,
+            LogbookHttpRequestInterceptor.class,
+            LogbookHttpResponseInterceptor.class
     })
     static class HttpClientAutoConfiguration {
 
@@ -336,9 +336,9 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-        org.apache.hc.client5.http.classic.HttpClient.class,
-        org.zalando.logbook.httpclient5.LogbookHttpRequestInterceptor.class,
-        org.zalando.logbook.httpclient5.LogbookHttpResponseInterceptor.class
+            org.apache.hc.client5.http.classic.HttpClient.class,
+            org.zalando.logbook.httpclient5.LogbookHttpRequestInterceptor.class,
+            org.zalando.logbook.httpclient5.LogbookHttpResponseInterceptor.class
     })
     static class HttpClient5AutoConfiguration {
 
@@ -359,8 +359,8 @@ public class LogbookAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @ConditionalOnClass({
-        Servlet.class,
-        LogbookFilter.class
+            Servlet.class,
+            LogbookFilter.class
     })
     static class JakartaServletFilterConfiguration {
 
@@ -379,7 +379,7 @@ public class LogbookAutoConfiguration {
         @ConditionalOnMissingBean(name = FILTER_NAME)
         public FilterRegistrationBean logbookFilter(final Logbook logbook) {
             final LogbookFilter filter = new LogbookFilter(logbook)
-                .withFormRequestMode(properties.getFilter().getFormRequestMode());
+                    .withFormRequestMode(properties.getFilter().getFormRequestMode());
             return newFilter(filter, FILTER_NAME, Ordered.LOWEST_PRECEDENCE);
         }
 
@@ -397,8 +397,8 @@ public class LogbookAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @ConditionalOnClass({
-        javax.servlet.Servlet.class,
-        org.zalando.logbook.servlet.javax.LogbookFilter.class
+            javax.servlet.Servlet.class,
+            org.zalando.logbook.servlet.javax.LogbookFilter.class
     })
     static class JavaxServletFilterConfiguration {
 
@@ -419,19 +419,19 @@ public class LogbookAutoConfiguration {
             FormRequestMode fromProperties = properties.getFilter().getFormRequestMode();
             org.zalando.logbook.servlet.javax.FormRequestMode formRequestMode = org.zalando.logbook.servlet.javax.FormRequestMode.valueOf(fromProperties.name());
             return new org.zalando.logbook.servlet.javax.LogbookFilter(logbook)
-                .withFormRequestMode(formRequestMode);
+                    .withFormRequestMode(formRequestMode);
         }
     }
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-        SecurityFilterChain.class,
-        Servlet.class,
-        LogbookFilter.class
+            SecurityFilterChain.class,
+            Servlet.class,
+            LogbookFilter.class
     })
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
-        "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
+            "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
     })
     static class JakartaSecurityServletFilterConfiguration {
 
@@ -447,13 +447,13 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-        SecurityFilterChain.class,
-        javax.servlet.Servlet.class,
-        org.zalando.logbook.servlet.javax.LogbookFilter.class
+            SecurityFilterChain.class,
+            javax.servlet.Servlet.class,
+            org.zalando.logbook.servlet.javax.LogbookFilter.class
     })
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
-        "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
+            "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
     })
     static class JavaxSecurityServletFilterConfiguration {
 
@@ -470,8 +470,8 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-        Logger.class,
-        FeignLogbookLogger.class
+            Logger.class,
+            FeignLogbookLogger.class
     })
     static class FeignLogbookLoggerConfiguration {
 

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -84,7 +84,7 @@ import static org.zalando.logbook.core.QueryFilters.replaceQuery;
 @ConditionalOnClass(Logbook.class)
 @EnableConfigurationProperties(LogbookProperties.class)
 @AutoConfigureAfter(value = JacksonAutoConfiguration.class, name = {
-        "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration" // Spring Boot 2.x
+    "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration" // Spring Boot 2.x
 })
 public class LogbookAutoConfiguration {
 
@@ -100,44 +100,44 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(Logbook.class)
     public Logbook logbook(
-            final Predicate<HttpRequest> condition,
-            final CorrelationId correlationId,
-            final List<HeaderFilter> headerFilters,
-            final List<PathFilter> pathFilters,
-            final List<QueryFilter> queryFilters,
-            final List<BodyFilter> bodyFilters,
-            final List<RequestFilter> requestFilters,
-            final List<ResponseFilter> responseFilters,
-            final Strategy strategy,
-            final Sink sink) {
+        final Predicate<HttpRequest> condition,
+        final CorrelationId correlationId,
+        final List<HeaderFilter> headerFilters,
+        final List<PathFilter> pathFilters,
+        final List<QueryFilter> queryFilters,
+        final List<BodyFilter> bodyFilters,
+        final List<RequestFilter> requestFilters,
+        final List<ResponseFilter> responseFilters,
+        final Strategy strategy,
+        final Sink sink) {
 
         return Logbook.builder()
-                .condition(mergeWithExcludes(mergeWithIncludes(condition)))
-                .correlationId(correlationId)
-                .headerFilters(headerFilters)
-                .queryFilters(queryFilters)
-                .pathFilters(pathFilters)
-                .bodyFilters(bodyFilters)
-                .requestFilters(requestFilters)
-                .responseFilters(responseFilters)
-                .strategy(strategy)
-                .sink(sink)
-                .build();
+                      .condition(mergeWithExcludes(mergeWithIncludes(condition)))
+                      .correlationId(correlationId)
+                      .headerFilters(headerFilters)
+                      .queryFilters(queryFilters)
+                      .pathFilters(pathFilters)
+                      .bodyFilters(bodyFilters)
+                      .requestFilters(requestFilters)
+                      .responseFilters(responseFilters)
+                      .strategy(strategy)
+                      .sink(sink)
+                      .build();
     }
 
     private Predicate<HttpRequest> mergeWithExcludes(final Predicate<HttpRequest> predicate) {
         return properties.getExclude().stream()
-                .map(Conditions::requestTo)
-                .map(Predicate::negate)
-                .reduce(predicate, Predicate::and);
+                         .map(Conditions::requestTo)
+                         .map(Predicate::negate)
+                         .reduce(predicate, Predicate::and);
     }
 
     private Predicate<HttpRequest> mergeWithIncludes(final Predicate<HttpRequest> predicate) {
         return properties.getInclude().stream()
-                .map(Conditions::requestTo)
-                .reduce(Predicate::or)
-                .map(predicate::and)
-                .orElse(predicate);
+                         .map(Conditions::requestTo)
+                         .reduce(Predicate::or)
+                         .map(predicate::and)
+                         .orElse(predicate);
     }
 
     @API(status = INTERNAL)
@@ -160,8 +160,8 @@ public class LogbookAutoConfiguration {
     public QueryFilter queryFilter() {
         final List<String> parameters = properties.getObfuscate().getParameters();
         return parameters.isEmpty() ?
-                QueryFilters.defaultValue() :
-                replaceQuery(new HashSet<>(parameters)::contains, "XXX");
+            QueryFilters.defaultValue() :
+            replaceQuery(new HashSet<>(parameters)::contains, "XXX");
     }
 
     @API(status = INTERNAL)
@@ -172,8 +172,8 @@ public class LogbookAutoConfiguration {
         headers.addAll(properties.getObfuscate().getHeaders());
 
         return headers.isEmpty() ?
-                HeaderFilters.defaultValue() :
-                replaceHeaders(headers, "XXX");
+            HeaderFilters.defaultValue() :
+            replaceHeaders(headers, "XXX");
     }
 
     @API(status = INTERNAL)
@@ -182,11 +182,11 @@ public class LogbookAutoConfiguration {
     public PathFilter pathFilter() {
         final List<String> paths = properties.getObfuscate().getPaths();
         return paths.isEmpty() ?
-                PathFilter.none() :
-                paths.stream()
-                        .map(path -> PathFilters.replace(path, "XXX"))
-                        .reduce(PathFilter::merge)
-                        .orElseGet(PathFilter::none);
+            PathFilter.none() :
+            paths.stream()
+                 .map(path -> PathFilters.replace(path, "XXX"))
+                 .reduce(PathFilter::merge)
+                 .orElseGet(PathFilter::none);
     }
 
     @API(status = INTERNAL)
@@ -253,8 +253,8 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(Sink.class)
     public Sink sink(
-            final HttpLogFormatter formatter,
-            final HttpLogWriter writer) {
+        final HttpLogFormatter formatter,
+        final HttpLogWriter writer) {
         return new DefaultSink(formatter, writer);
     }
 
@@ -295,7 +295,7 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(HttpLogFormatter.class)
     public HttpLogFormatter jsonFormatter(
-            final ObjectMapper mapper) {
+        final ObjectMapper mapper) {
         return new JsonHttpLogFormatter(mapper);
     }
 
@@ -314,9 +314,9 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-            HttpClient.class,
-            LogbookHttpRequestInterceptor.class,
-            LogbookHttpResponseInterceptor.class
+        HttpClient.class,
+        LogbookHttpRequestInterceptor.class,
+        LogbookHttpResponseInterceptor.class
     })
     static class HttpClientAutoConfiguration {
 
@@ -336,9 +336,9 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-            org.apache.hc.client5.http.classic.HttpClient.class,
-            org.zalando.logbook.httpclient5.LogbookHttpRequestInterceptor.class,
-            org.zalando.logbook.httpclient5.LogbookHttpResponseInterceptor.class
+        org.apache.hc.client5.http.classic.HttpClient.class,
+        org.zalando.logbook.httpclient5.LogbookHttpRequestInterceptor.class,
+        org.zalando.logbook.httpclient5.LogbookHttpResponseInterceptor.class
     })
     static class HttpClient5AutoConfiguration {
 
@@ -359,8 +359,8 @@ public class LogbookAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @ConditionalOnClass({
-            Servlet.class,
-            LogbookFilter.class
+        Servlet.class,
+        LogbookFilter.class
     })
     static class JakartaServletFilterConfiguration {
 
@@ -379,7 +379,7 @@ public class LogbookAutoConfiguration {
         @ConditionalOnMissingBean(name = FILTER_NAME)
         public FilterRegistrationBean logbookFilter(final Logbook logbook) {
             final LogbookFilter filter = new LogbookFilter(logbook)
-                    .withFormRequestMode(properties.getFilter().getFormRequestMode());
+                .withFormRequestMode(properties.getFilter().getFormRequestMode());
             return newFilter(filter, FILTER_NAME, Ordered.LOWEST_PRECEDENCE);
         }
 
@@ -397,8 +397,8 @@ public class LogbookAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @ConditionalOnClass({
-            javax.servlet.Servlet.class,
-            org.zalando.logbook.servlet.LogbookFilter.class
+        javax.servlet.Servlet.class,
+        org.zalando.logbook.servlet.javax.LogbookFilter.class
     })
     static class JavaxServletFilterConfiguration {
 
@@ -415,23 +415,23 @@ public class LogbookAutoConfiguration {
         @Bean
         @ConditionalOnProperty(name = "logbook.filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
-        public org.zalando.logbook.servlet.LogbookFilter logbookFilter(final Logbook logbook) {
+        public org.zalando.logbook.servlet.javax.LogbookFilter logbookFilter(final Logbook logbook) {
             FormRequestMode fromProperties = properties.getFilter().getFormRequestMode();
-            org.zalando.logbook.servlet.FormRequestMode formRequestMode = org.zalando.logbook.servlet.FormRequestMode.valueOf(fromProperties.name());
-            return new org.zalando.logbook.servlet.LogbookFilter(logbook)
-                    .withFormRequestMode(formRequestMode);
+            org.zalando.logbook.servlet.javax.FormRequestMode formRequestMode = org.zalando.logbook.servlet.javax.FormRequestMode.valueOf(fromProperties.name());
+            return new org.zalando.logbook.servlet.javax.LogbookFilter(logbook)
+                .withFormRequestMode(formRequestMode);
         }
     }
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-            SecurityFilterChain.class,
-            Servlet.class,
-            LogbookFilter.class
+        SecurityFilterChain.class,
+        Servlet.class,
+        LogbookFilter.class
     })
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
-            "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
+        "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
     })
     static class JakartaSecurityServletFilterConfiguration {
 
@@ -447,13 +447,13 @@ public class LogbookAutoConfiguration {
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-            SecurityFilterChain.class,
-            javax.servlet.Servlet.class,
-            org.zalando.logbook.servlet.LogbookFilter.class
+        SecurityFilterChain.class,
+        javax.servlet.Servlet.class,
+        org.zalando.logbook.servlet.javax.LogbookFilter.class
     })
     @ConditionalOnWebApplication(type = Type.SERVLET)
     @AutoConfigureAfter(name = {
-            "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
+        "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration" // Spring Boot 2.x
     })
     static class JavaxSecurityServletFilterConfiguration {
 
@@ -463,15 +463,15 @@ public class LogbookAutoConfiguration {
         @ConditionalOnProperty(name = "logbook.secure-filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
         @Order(Ordered.HIGHEST_PRECEDENCE + 1)
-        public org.zalando.logbook.servlet.SecureLogbookFilter secureLogbookFilter(final Logbook logbook) {
-            return new org.zalando.logbook.servlet.SecureLogbookFilter(logbook);
+        public org.zalando.logbook.servlet.javax.SecureLogbookFilter secureLogbookFilter(final Logbook logbook) {
+            return new org.zalando.logbook.servlet.javax.SecureLogbookFilter(logbook);
         }
     }
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass({
-            Logger.class,
-            FeignLogbookLogger.class
+        Logger.class,
+        FeignLogbookLogger.class
     })
     static class FeignLogbookLoggerConfiguration {
 

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -328,8 +328,8 @@ public class LogbookAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean(LogbookHttpResponseInterceptor.class)
-        public LogbookHttpResponseInterceptor logbookHttpResponseInterceptor() {
-            return new LogbookHttpResponseInterceptor();
+        public LogbookHttpResponseInterceptor logbookHttpResponseInterceptor(@Value("${logbook.httpclient.decompress-response:false}") final boolean decompressResponse) {
+            return new LogbookHttpResponseInterceptor(decompressResponse);
         }
 
     }

--- a/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -65,6 +65,12 @@
       "type": "java.lang.Integer",
       "defaultValue": 400,
       "description": "Minimum status code for conditional strategies."
+    },
+    {
+      "name": "logbook.httpclient.decompress-response",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables/disables additional decompression process for HttpClient with gzip encoded body (to logging purposes only)."
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This version perform the logging mechanism of gzip content responses.

## Motivation and Context
Related Known Issue:
"The Logbook HTTP Client integration is handling gzip-compressed response entities incorrectly if the interceptor runs before a decompressing interceptor. Since logging compressed contents is not really helpful it's advised to register the logbook interceptor as the last interceptor in the chain."

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
