### PR TITLE
Do not fail all composite body filters if one fails

### DIFF
--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
@@ -154,7 +154,11 @@ public final class JsonPathBodyFilters {
             DocumentContext result = context;
 
             for (final Operation operation : operations) {
-                result = operation.filter(result);
+                try {
+                    result = operation.filter(result);
+                } catch (Exception e) {
+                    log.trace("Composite filter operation could not complete, the following exception {} has been thrown", e.getClass());
+                }
             }
 
             return result;

--- a/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JsonPathBodyFilters.java
@@ -20,8 +20,10 @@ import org.apiguardian.api.API;
 import org.zalando.logbook.BodyFilter;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -153,12 +155,18 @@ public final class JsonPathBodyFilters {
         public DocumentContext filter(final DocumentContext context) {
             DocumentContext result = context;
 
+            final List<String> filterExceptions = new ArrayList<>();
             for (final Operation operation : operations) {
                 try {
                     result = operation.filter(result);
                 } catch (Exception e) {
-                    log.trace("Composite filter operation could not complete, the following exception {} has been thrown", e.getClass());
+                    filterExceptions.add(String.format("Exception class: %s. Message: %s", e.getClass().getName(), e.getMessage()));
                 }
+            }
+
+            if (!filterExceptions.isEmpty()) {
+                log.trace("JsonPathBodyFilter filter operation(s) could not complete, the following exception(s) have been thrown: " +
+                        String.join(";", filterExceptions));
             }
 
             return result;

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
@@ -282,9 +282,13 @@ class JsonPathBodyFiltersTest {
     @Test
     void shouldNotFailWhenOneOfTheFiltersInCompositeThrowsException() {
         final BodyFilter nameFilter = jsonPath("$.name").replace("XXX");
-        final BodyFilter nonexistingFieldFilter = jsonPath("$[0].thisFieldDoesntExist").delete();
+        final BodyFilter nonExistingFieldFilter = jsonPath("$[0].thisFieldDoesntExist").delete();
+        final BodyFilter anotherNonExistingFieldFilter = jsonPath("$.nonExistingArray[0].thisFieldDoesntExist").delete();
         final BodyFilter addressFilter = jsonPath("$.address").replace( "XXX");
-        final BodyFilter unit = nameFilter.tryMerge(nonexistingFieldFilter).tryMerge(addressFilter);
+        final BodyFilter unit = nameFilter
+                .tryMerge(nonExistingFieldFilter)
+                .tryMerge(anotherNonExistingFieldFilter)
+                .tryMerge(addressFilter);
 
         with(requireNonNull(unit).filter(type, student))
                 .assertEquals("$.name", "XXX")

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonPathBodyFiltersTest.java
@@ -278,4 +278,16 @@ class JsonPathBodyFiltersTest {
 
         assertThat(actual).isEqualTo(invalidBody);
     }
+
+    @Test
+    void shouldNotFailWhenOneOfTheFiltersInCompositeThrowsException() {
+        final BodyFilter nameFilter = jsonPath("$.name").replace("XXX");
+        final BodyFilter nonexistingFieldFilter = jsonPath("$[0].thisFieldDoesntExist").delete();
+        final BodyFilter addressFilter = jsonPath("$.address").replace( "XXX");
+        final BodyFilter unit = nameFilter.tryMerge(nonexistingFieldFilter).tryMerge(addressFilter);
+
+        with(requireNonNull(unit).filter(type, student))
+                .assertEquals("$.name", "XXX")
+                .assertEquals("$.address", "XXX");
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If one out of several body filters fails (for example because of the issue mentioned in https://github.com/zalando/logbook/issues/1369), it should not discard the results of other filters.

## Motivation and Context
addresses https://github.com/zalando/logbook/issues/1500

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
