### PR TITLE
Fix NPE on calling toString() on remoteAddress()

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
@@ -53,8 +53,12 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
     }
 
     @Override
+    @Nullable
     public String getRemote() {
-        return context.channel().remoteAddress().toString();
+        // According to io.netty.channel.Channel documentation,
+        // remoteAddress() returns null if the channel is not connected.
+        SocketAddress remoteAddress = context.channel().remoteAddress();
+        return (remoteAddress == null) ? null : remoteAddress.toString();
     }
 
     @Override

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
@@ -91,10 +91,23 @@ public class RequestUnitTest {
         Request remoteRequest = new Request(context, REMOTE, req);
 
         assertThat(remoteRequest.getRequestUri()).isEqualTo("https://unknown/libs/dam/merge/metadata.json;\n" +
-                                                                ".json?path=<h1>Rhack&;%0A.inc.js");
+                ".json?path=<h1>Rhack&;%0A.inc.js");
         assertThat(remoteRequest.getPath()).isEqualTo("/libs/dam/merge/metadata.json;\n" +
-                                                          ".json");
+                ".json");
         assertThat(remoteRequest.getQuery()).isEqualTo("path=<h1>Rhack&;%0A.inc.js");
+    }
+
+    @Test
+    void shouldHandleNullRemoteAddress() {
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/test?a=b");
+
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        when(context.channel()).thenReturn(mock(Channel.class));
+        when(context.channel().remoteAddress()).thenReturn(null);
+
+        Request remoteRequest = new Request(context, REMOTE, req);
+        assertThat(remoteRequest.getRemote()).isEqualTo(null);
     }
 
     private ChannelHandlerContext mockChannelHandlerContext() {


### PR DESCRIPTION
## Description
According to [Netty Channel class documentation](https://github.com/netty/netty/blob/c1a6994455cea05c873502416cc34d7d9d9610ad/transport/src/main/java/io/netty/channel/Channel.java#L140):

> return the remote address of this channel.
>  null if this channel is not connected.
>  ...
>  SocketAddress remoteAddress();

Therefore, if `remoteAddress()` returns `null`, calling `toString()` on it will result in NPE.

## Motivation and Context
Fixes #1306

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
