### PR TITLE
fix netty sequence ability to log subsequent reads and writes

### DIFF
--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Sequence.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Sequence.java
@@ -35,6 +35,11 @@ final class Sequence {
             tasks.set(next, null);
             next++;
         }
+
+        // Reset next to 0, we've exhausted the tasks and this instance will live on in the thread
+        // that it was created in, so we need to reset next back to 0 if we want to see any more output
+
+        next = 0;
     }
 
 }

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/SequenceTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/SequenceTest.java
@@ -14,6 +14,17 @@ class SequenceTest {
     private final Runnable second = mock(Runnable.class, "second");
     private final Runnable third = mock(Runnable.class, "third");
 
+    private final Runnable fourth = mock(Runnable.class, "fourth");
+    private final Runnable fifth = mock(Runnable.class, "fifth");
+    private final Runnable sixth = mock(Runnable.class, "sixth");
+
+    private final Runnable seventh = mock(Runnable.class, "seventh");
+    private final Runnable eighth = mock(Runnable.class, "eighth");
+    private final Runnable ninth = mock(Runnable.class, "ninth");
+
+    private final Runnable tenth = mock(Runnable.class, "tenth");
+    private final Runnable eleventh = mock(Runnable.class, "eleventh");
+
     private final Sequence unit = new Sequence(3);
 
     @Test
@@ -41,6 +52,44 @@ class SequenceTest {
         inOrder.verify(first).run();
         inOrder.verify(second).run();
         inOrder.verify(third).run();
+    }
+
+    @Test
+    void runsMoreEagerlyAllowsSequenceReuse() {
+        // reusing the slots of the sequence array should allow reuse
+        unit.set(2, ninth);
+        unit.set(1, eighth);
+        unit.set(0, seventh);
+
+        unit.set(2, sixth);
+        unit.set(1, fifth);
+        unit.set(0, fourth);
+
+        unit.set(2, third);
+        unit.set(1, second);
+        unit.set(0, first);
+
+        // still doesn't run partial sequence when reused
+        unit.set(2, tenth);
+        unit.set(1, eleventh);
+
+        final InOrder inOrder1 = inOrder(seventh, eighth, ninth);
+        final InOrder inOrder2 = inOrder(fourth, fifth, sixth);
+        final InOrder inOrder3 = inOrder(first, second, third);
+
+        inOrder3.verify(first).run();
+        inOrder3.verify(second).run();
+        inOrder3.verify(third).run();
+        inOrder2.verify(fourth).run();
+        inOrder2.verify(fifth).run();
+        inOrder2.verify(sixth).run();
+        inOrder1.verify(seventh).run();
+        inOrder1.verify(eighth).run();
+        inOrder1.verify(ninth).run();
+
+        // these two shouldn't run because they are missing their 3rd companion
+        verify(tenth, never()).run();
+        verify(eleventh, never()).run();
     }
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fixes the bug with the Netty module where it doesn't log subsequent requests.  The issue is that the Sequence class that manages sequential processing of reads, then writes has a bug.  The method runEagerly() keeps track of a next pointer that tells it which task to run.  The problem, also described in the linked issue, is the next pointer is never reset back to the first position in the task array.  Applying the suggested changes have fixed the issue.  I tested this in a Micronaut app and it is now logging all requests from the server and client reliably.  I also wrote a new unit tests showing the Sequence can be reused to process new tasks/requests/responses.  Also I wrote the unit test first to ensure it fails without the change.

## Motivation and Context
Fixes [1216](https://github.com/zalando/logbook/issues/1216)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
