### PR TITLE
Make logbook-httpclient optional

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -9,6 +9,7 @@
             <cve>CVE-2022-38179</cve>
             <cve>CVE-2022-29035</cve>
             <cve>CVE-2022-38180</cve>
+            <cve>CVE-2023-34339</cve>
             <!-- so far jackson-core and json-path don't have bugfix releases yet for that cve -->
             <cve>CVE-2022-45688</cve>
             <!-- To be removed after upgrading Ktor -->

--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>logbook-httpclient</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support for Apache HttpClient 4 has been removed in Spring Framework 6.0, and replaced with Apache HttpClient 5. Because of that logbook-httpclient should not be added as a default dependency to logbook-spring-boot-autoconfigure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses #1491

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
