### PR TITLE
feature(logbook-spring-boot-autoconfigure): add support for logbook-openfeign

### DIFF
--- a/logbook-openfeign/pom.xml
+++ b/logbook-openfeign/pom.xml
@@ -20,10 +20,6 @@
         <developerConnection>scm:git:git@github.com:zalando/logbook.git</developerConnection>
     </scm>
 
-    <properties>
-        <feign.version>12.3</feign.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.zalando</groupId>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -35,6 +35,7 @@
         <netty.version>4.1.93.Final</netty.version>
         <reactor-netty.version>1.1.7</reactor-netty.version>
         <slf4j.version>1.7.36</slf4j.version>
+        <feign.version>12.3</feign.version>
 
         <spring.version>6.0.9</spring.version>
         <spring-boot.version>3.1.0</spring-boot.version>

--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -73,7 +73,7 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
             <version>${feign.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -65,6 +65,17 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>logbook-openfeign</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-core</artifactId>
+            <version>${feign.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <version>${spring-boot.version}</version>

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Logger;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 import org.apache.http.client.HttpClient;
@@ -56,6 +57,7 @@ import org.zalando.logbook.core.WithoutBodyStrategy;
 import org.zalando.logbook.httpclient.LogbookHttpRequestInterceptor;
 import org.zalando.logbook.httpclient.LogbookHttpResponseInterceptor;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
+import org.zalando.logbook.openfeign.FeignLogbookLogger;
 import org.zalando.logbook.servlet.FormRequestMode;
 import org.zalando.logbook.servlet.LogbookFilter;
 import org.zalando.logbook.servlet.SecureLogbookFilter;
@@ -463,6 +465,20 @@ public class LogbookAutoConfiguration {
         @Order(Ordered.HIGHEST_PRECEDENCE + 1)
         public org.zalando.logbook.servlet.javax.SecureLogbookFilter secureLogbookFilter(final Logbook logbook) {
             return new org.zalando.logbook.servlet.javax.SecureLogbookFilter(logbook);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass({
+            Logger.class,
+            FeignLogbookLogger.class
+    })
+    static class FeignLogbookLoggerConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(Logger.class)
+        public Logger feignLogbookLogger(Logbook logbook) {
+            return new FeignLogbookLogger(logbook);
         }
     }
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FeignTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FeignTest.java
@@ -1,0 +1,24 @@
+package org.zalando.logbook.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.zalando.logbook.Logbook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeignTest {
+
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner();
+
+    @Test
+    void shouldInitializeFeignLogbookLogger() {
+        this.contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .withBean("logbookProperties", LogbookProperties.class, LogbookProperties::new)
+                .withUserConfiguration(LogbookAutoConfiguration.FeignLogbookLoggerConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasBean("feignLogbookLogger");
+                });
+    }
+
+}


### PR DESCRIPTION
Add support for `logbook-openfeign` in `logbook-spring-boot-starter` package.

## Detailed Description
Add Conditional `FeignLogbookLoggerConfiguration` to `LogbookAutoConfiguration` to enable auto-configuration of `FeignLogbookLogger` class.