### PR TITLE
log request/response without body for POST (#1571)

### DIFF
--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/BufferingServerHttpRequest.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/BufferingServerHttpRequest.java
@@ -54,7 +54,6 @@ final class BufferingServerHttpRequest extends ServerHttpRequestDecorator {
                 .doOnComplete(writeHook);
         } else {
             return Mono.fromRunnable(writeHook)
-                .contextCapture() // needed to log MDC fields like traceId/spanId
                 .thenMany(body);
         }
     }

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookWebFilterTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookWebFilterTest.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.spring.webflux;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,6 +19,7 @@ import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
 import org.zalando.logbook.core.DefaultHttpLogFormatter;
 import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.core.WithoutBodyStrategy;
 import org.zalando.logbook.test.TestStrategy;
 
 import java.io.IOException;
@@ -30,19 +32,8 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.zalando.logbook.spring.webflux.LogbookWebFilterTest.FilterConfiguration;
 
-@SpringBootTest(classes = {TestApplication.class, FilterConfiguration.class}, webEnvironment = RANDOM_PORT)
-@Import(MockitoExtension.class)
 class LogbookWebFilterTest {
-
-    @LocalServerPort
-    int port;
-
-    @MockBean
-    public HttpLogWriter writer;
-
-    private WebClient client;
 
     @TestConfiguration
     static class FilterConfiguration {
@@ -62,108 +53,126 @@ class LogbookWebFilterTest {
         }
     }
 
+    @TestConfiguration
+    static class FilterWithoutBodyConfiguration {
 
-    @BeforeEach
-    void setup() {
-        when(writer.isActive()).thenReturn(true);
-        client = WebClient.builder()
-                .baseUrl(String.format("http://localhost:%d", port))
+        @Bean
+        @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+        public Logbook logbook(HttpLogWriter writer) {
+            return Logbook.builder()
+                .strategy(new WithoutBodyStrategy())
+                .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
                 .build();
+        }
+
+        @Bean
+        public WebFilter filter(Logbook logbook) {
+            return new LogbookWebFilter(logbook);
+        }
     }
 
-    @Test
-    void shouldLogRequestWithBody() throws IOException {
-        client.post()
+    @Nested
+    @Import(MockitoExtension.class)
+    @SpringBootTest(classes = {TestApplication.class, FilterConfiguration.class}, webEnvironment = RANDOM_PORT)
+    class WithTestStrategy {
+
+        private WebClient client;
+
+        @MockBean
+        public HttpLogWriter writer;
+
+        @LocalServerPort
+        int port;
+
+        @BeforeEach
+        void setup() {
+            when(writer.isActive()).thenReturn(true);
+            client = WebClient.builder()
+                .baseUrl(String.format("http://localhost:%d", port))
+                .build();
+        }
+
+        @Test
+        void shouldLogRequestWithBody() throws IOException {
+            client.post()
                 .uri("/discard")
                 .bodyValue("Hello, world!")
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
 
-        final String message = captureRequest();
+            final String message = captureRequest(writer);
 
-        assertThat(message)
+            assertThat(message)
                 .startsWith("Incoming Request:")
                 .contains(format("POST http://localhost:%d/discard HTTP/1.1", port))
                 .contains("Hello, world!");
-    }
+        }
 
-    @Test
-    void shouldLogRequestWithoutBody() throws IOException {
-        sendAndReceive();
+        @Test
+        void shouldLogRequestWithoutBody() throws IOException {
+            sendAndReceive(client);
 
-        final String message = captureRequest();
+            final String message = captureRequest(writer);
 
-        assertThat(message)
+            assertThat(message)
                 .startsWith("Incoming Request:")
                 .contains(format("POST http://localhost:%d/echo HTTP/1.1", port))
                 .doesNotContain("Hello, world!");
-    }
+        }
 
-    private String captureRequest() throws IOException {
-        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(writer, timeout(1_000)).write(any(Precorrelation.class), captor.capture());
-        return captor.getValue();
-    }
+        @Test
+        void shouldNotLogRequestIfInactive() throws IOException {
+            when(writer.isActive()).thenReturn(false);
 
-    @Test
-    void shouldNotLogRequestIfInactive() throws IOException {
-        when(writer.isActive()).thenReturn(false);
+            sendAndReceive(client);
 
-        sendAndReceive();
+            verify(writer, never()).write(any(Precorrelation.class), any());
+        }
 
-        verify(writer, never()).write(any(Precorrelation.class), any());
-    }
+        @Test
+        void shouldLogResponseWithoutBody() throws IOException {
+            sendAndReceive(client, "/discard");
 
-    @Test
-    void shouldLogResponseWithoutBody() throws IOException {
-        sendAndReceive("/discard");
+            final String message = captureResponse(writer);
 
-        final String message = captureResponse();
-
-        assertThat(message)
+            assertThat(message)
                 .startsWith("Outgoing Response:")
                 .contains("HTTP/1.1 200 OK")
                 .doesNotContain("Hello, world!");
-    }
+        }
 
-    @Test
-    void shouldLogResponseWithBody() throws IOException {
-        final String response = client.post()
+        @Test
+        void shouldLogResponseWithBody() throws IOException {
+            final String response = client.post()
                 .uri("/echo")
                 .bodyValue("Hello, world!")
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
 
-        assertThat(response).isEqualTo("Hello, world!");
+            assertThat(response).isEqualTo("Hello, world!");
 
-        final String message = captureResponse();
+            final String message = captureResponse(writer);
 
-        assertThat(message)
+            assertThat(message)
                 .startsWith("Outgoing Response:")
                 .contains("HTTP/1.1 200 OK")
                 .contains("Hello, world!");
-    }
+        }
 
-    private String captureResponse() throws IOException {
-        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(writer, timeout(1_000)).write(any(Correlation.class), captor.capture());
-        return captor.getValue();
-    }
+        @Test
+        void shouldNotLogResponseIfInactive() throws IOException {
+            when(writer.isActive()).thenReturn(false);
 
-    @Test
-    void shouldNotLogResponseIfInactive() throws IOException {
-        when(writer.isActive()).thenReturn(false);
+            sendAndReceive(client);
 
-        sendAndReceive();
+            verify(writer, never()).write(any(Correlation.class), any());
+        }
 
-        verify(writer, never()).write(any(Correlation.class), any());
-    }
-
-    @Test
-    void shouldIgnoreBodies() throws IOException {
-        final String response = client.post()
+        @Test
+        void shouldIgnoreBodies() throws IOException {
+            final String response = client.post()
                 .uri("/echo")
                 .header("Ignore", "true")
                 .bodyValue("Hello, world!")
@@ -171,79 +180,126 @@ class LogbookWebFilterTest {
                 .bodyToMono(String.class)
                 .block();
 
-        assertThat(response).isEqualTo("Hello, world!");
+            assertThat(response).isEqualTo("Hello, world!");
 
-        {
-            final String message = captureRequest();
+            {
+                final String message = captureRequest(writer);
 
-            assertThat(message)
+                assertThat(message)
                     .startsWith("Incoming Request:")
                     .contains(format("POST http://localhost:%d/echo HTTP/1.1", port))
                     .doesNotContain("Hello, world!");
-        }
+            }
 
-        {
-            final String message = captureResponse();
+            {
+                final String message = captureResponse(writer);
 
-            assertThat(message)
+                assertThat(message)
                     .startsWith("Outgoing Response:")
                     .contains("HTTP/1.1 200 OK")
                     .doesNotContain("Hello, world!");
+            }
         }
-    }
 
-    @Test
-    void shouldLogGetResponseWithBody() throws IOException {
-        final String response = client
+        @Test
+        void shouldLogGetResponseWithBody() throws IOException {
+            final String response = client
                 .get()
                 .uri("/echo?q=test")
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
 
-        assertThat(response).isEqualTo("test");
+            assertThat(response).isEqualTo("test");
 
-        final String reqMessage = captureRequest();
-        assertThat(reqMessage)
+            final String reqMessage = captureRequest(writer);
+            assertThat(reqMessage)
                 .startsWith("Incoming Request:")
                 .contains(format("GET http://localhost:%d/echo?q=test HTTP/1.1", port));
 
-        final String respMessage = captureResponse();
-        assertThat(respMessage)
+            final String respMessage = captureResponse(writer);
+            assertThat(respMessage)
                 .startsWith("Outgoing Response:")
                 .contains("HTTP/1.1 200 OK");
-    }
+        }
 
-    @Test
-    void shouldLogGetResponseWithoutBody() throws IOException {
-        client
+        @Test
+        void shouldLogGetResponseWithoutBody() throws IOException {
+            client
                 .get()
                 .uri("/empty")
                 .retrieve()
                 .toBodilessEntity()
                 .block();
 
-        final String reqMessage = captureRequest();
-        assertThat(reqMessage)
+            final String reqMessage = captureRequest(writer);
+            assertThat(reqMessage)
                 .startsWith("Incoming Request:")
                 .contains(format("GET http://localhost:%d/empty HTTP/1.1", port));
 
-        final String respMessage = captureResponse();
-        assertThat(respMessage)
+            final String respMessage = captureResponse(writer);
+            assertThat(respMessage)
                 .startsWith("Outgoing Response:")
                 .contains("HTTP/1.1 200 OK");
+        }
     }
 
-    private void sendAndReceive() {
-        sendAndReceive("/echo");
+    @Nested
+    @SpringBootTest(classes = {TestApplication.class, FilterWithoutBodyConfiguration.class}, webEnvironment = RANDOM_PORT)
+    @Import(MockitoExtension.class)
+    class WithoutBody {
+
+        private WebClient client;
+
+        @MockBean
+        public HttpLogWriter writer;
+
+        @LocalServerPort
+        int port;
+
+        @BeforeEach
+        void setup() {
+            when(writer.isActive()).thenReturn(true);
+            client = WebClient.builder()
+                .baseUrl(String.format("http://localhost:%d", port))
+                .build();
+        }
+
+        @Test
+        void shouldLogRequestWithoutBody() throws IOException {
+            sendAndReceive(client);
+
+            final String message = captureRequest(writer);
+
+            assertThat(message)
+                .startsWith("Incoming Request:")
+                .contains(format("POST http://localhost:%d/echo HTTP/1.1", port))
+                .doesNotContain("Hello, world!");
+        }
     }
 
-    private void sendAndReceive(final String uri) {
+    private void sendAndReceive(final WebClient client) {
+        sendAndReceive(client, "/echo");
+    }
+
+    private void sendAndReceive(final WebClient client, final String uri) {
         client
-                .post()
-                .uri(uri)
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
+            .post()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(String.class)
+            .block();
+    }
+
+    private String captureRequest(final HttpLogWriter writer) throws IOException {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer, timeout(1_000)).write(any(Precorrelation.class), captor.capture());
+        return captor.getValue();
+    }
+
+    private String captureResponse(final HttpLogWriter writer) throws IOException {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer, timeout(1_000)).write(any(Correlation.class), captor.capture());
+        return captor.getValue();
     }
 }


### PR DESCRIPTION
Requests/Responses of POST requests in spring cloud gateway are not logged

## Description
The change includes an invocation of the writeHook, including capturing MDC fields to be logged together with the request

## Motivation and Context
https://github.com/zalando/logbook/issues/1571

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
