### PR TITLE
LogbookFilter flush buffer will make tomcat add Transfer-Encoding: chunked header

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -85,7 +85,7 @@ public final class LogbookFilter implements HttpFilter {
     private void write(RemoteRequest request, LocalResponse response, ResponseWritingStage writing) throws IOException {
         final AtomicBoolean attribute = (AtomicBoolean) request.getAttribute(responseWritingStageSynchronizationName);
         if (!attribute.getAndSet(true)) {
-            response.flushBuffer();
+            //response.flushBuffer();
             writing.write();
         }
     }

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
@@ -67,6 +67,7 @@ final class AsyncDispatchTest {
                     response.setStatus(200);
                     response.addHeader("Content-Type", "text/plain");
                     response.getWriter().println("Hello Async");
+                    response.flushBuffer();
                     asyncContext.complete();
                 } catch (Exception e) {
                     throw new RuntimeException(e);

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ExampleController.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/ExampleController.java
@@ -93,6 +93,7 @@ public class ExampleController {
     @RequestMapping(path = "/reader", produces = TEXT_PLAIN_VALUE)
     public void reader(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         copy(request.getReader(), response.getWriter());
+        response.getWriter().flush();
     }
 
     @RequestMapping(path = "/binary", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)


### PR DESCRIPTION
LogbookFilter flush buffer will make tomcat add Transfer-Encoding: chunked header

## Description
HttpServletResponseWrapper.flushBuffer() changes output header in Spring-Boot:  (v2.5.4) with Tomcat
It adds Transfer-Encoding: chunked, and not allow Tomcat to insert Content-Length=0 with empty body responses.

## Motivation and Context
As I see there is no need in executing HttpServletResponseWrapper.flushBuffer() in LogbookFilter (actually any HttpFilter)
Logbook logging works without it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

