### PR TITLE
Use getCharacterEncoding when no Content-Type header is set

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LocalResponse.java
@@ -183,13 +183,16 @@ final class LocalResponse extends HttpServletResponseWrapper implements HttpResp
         return Optional
                 .ofNullable(contentTypeHeader)
                 .map(ContentType::parseCharset)
-                /*
-                 * Servlet Spec, 5.6 Internationalization
-                 *
-                 * If the servlet does not specify a character encoding before the getWriter method of the
-                 * ServletResponse interface is called or the response is committed, the default ISO-8859-1 is used.
-                 */
-                .orElse(ISO_8859_1);
+                .orElseGet(() ->
+                        Optional.ofNullable(getCharacterEncoding())
+                                .map(Charset::forName)
+                                /*
+                                 * Servlet Spec, 5.6 Internationalization
+                                 *
+                                 * If the servlet does not specify a character encoding before the getWriter method of the
+                                 * ServletResponse interface is called or the response is committed, the default ISO-8859-1 is used.
+                                 */
+                                .orElse(ISO_8859_1));
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use `getCharacterEncoding()` if `Conent-Type` header is missing in the response, before falling back to ` ISO-8859-1` when determining charset.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changes in https://github.com/zalando/logbook/commit/ca3e0327972bfaa518c238a3a808ff2b4c9797ba started using Content-Type header of response object to determine the Charset. This was done as most server implementations would fallback to ` ISO-8859-1` encoding if the encoding wasn't explicitly set as part of Conent-Type header or in other ways. This cause problems with applications that work with JSON responses, as according to RFC 8259 JSON uses UTF-8 for encoding messages. 

[It was reported](https://github.com/zalando/logbook/issues/870#issuecomment-1625338454) that Thymeleaf projects are affected by the change as at the time of the evaluation, Content-Type header is not yet set to the response object, and Logbook falls back to ISO-8859-1. At the same time, `getCharacterEncoding()` does contain the correct encoding value for the response object. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
