### PR TITLE
Define json body obfuscation fields via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,6 +950,9 @@ The following tables show the available configuration:
 | `logbook.write.chunk-size`               | Splits log lines into smaller chunks of size up-to `chunk-size`.                                                                                                                    | `0` (disabled)     |
 | `logbook.write.max-body-size`            | Truncates the body up to `max-body-size` and appends `...`.                                                                                                                         | `-1` (disabled)    |
 | `logbook.httpclient.decompress-response` | Enables/disables additional decompression process for HttpClient with gzip encoded body (to logging purposes only). This means extra decompression and possible performance impact. | `false` (disabled) |
+| `logbook.obfuscate.json-body-fields`     | List of JSON body fields to be obfuscated                                                                                                                                           | `[]`               |
+| `logbook.obfuscate.replacement`          | A value to be used instead of an obfuscated one                                                                                                                                     | `XXX`              |
+| `logbook.filters.body.default-enabled`   | Enables/disables default body filters that are collected by java.util.ServiceLoader                                                                                                 | `true`            |
 
 ##### Example configuration
 

--- a/logbook-core/src/main/java/org/zalando/logbook/core/TruncatingBodyFilter.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/TruncatingBodyFilter.java
@@ -1,0 +1,23 @@
+package org.zalando.logbook.core;
+
+import lombok.experimental.Delegate;
+import org.apiguardian.api.API;
+import org.zalando.logbook.BodyFilter;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.zalando.logbook.core.BodyFilters.truncate;
+
+@API(status = INTERNAL)
+public final class TruncatingBodyFilter implements BodyFilter {
+
+    @Delegate
+    private final BodyFilter delegate;
+
+    public TruncatingBodyFilter(final int maxBodySize) {
+        if (maxBodySize < 0) {
+            this.delegate = (contentType, body) -> body;
+        } else {
+            this.delegate = truncate(maxBodySize);
+        }
+    }
+}

--- a/logbook-core/src/test/java/org/zalando/logbook/core/TruncatingBodyFilterTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/TruncatingBodyFilterTest.java
@@ -1,0 +1,37 @@
+package org.zalando.logbook.core;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.BodyFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TruncatingBodyFilterTest {
+
+    @Test
+    void shouldNotTruncateIfMaxLengthSetToLessThanZero() {
+        final BodyFilter unit = new TruncatingBodyFilter(-1);
+
+
+        final String resul = unit.filter("application/json", "{\"foo\":\"secret\"}");
+
+        assertThat(resul).isEqualTo("{\"foo\":\"secret\"}");
+    }
+
+    @Test
+    void shouldTruncateBodyIfTooLong() {
+        final BodyFilter unit = new TruncatingBodyFilter(5);
+
+        final String actual = unit.filter("application/json", "{\"foo\":\"secret\"}");
+
+        assertThat(actual).isEqualTo("{\"foo...");
+    }
+
+    @Test
+    void shouldNotTruncateBodyIfTooShort() {
+        final BodyFilter unit = new TruncatingBodyFilter(50);
+
+        final String actual = unit.filter("application/json", "{\"foo\":\"secret\"}");
+
+        assertThat(actual).isEqualTo("{\"foo\":\"secret\"}");
+    }
+}

--- a/logbook-jmh/src/main/java/org/zalando/logbook/benchmark/LogbookState.java
+++ b/logbook-jmh/src/main/java/org/zalando/logbook/benchmark/LogbookState.java
@@ -25,15 +25,15 @@ public class LogbookState {
         final LogbookProperties properties = new LogbookProperties();
         final LogbookAutoConfiguration ac = new LogbookAutoConfiguration(properties);
 
-        autoconfigurationLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.bodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), ac.sink(ac.httpFormatter(), ac.writer()));
+        autoconfigurationLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.defaultBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), ac.sink(ac.httpFormatter(), ac.writer()));
 
         final Sink sink = new LogstashLogbackSink(state.getJsonHttpLogFormatter());
 
-        autoconfigurationLogstashLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.bodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), sink);
+        autoconfigurationLogstashLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.defaultBodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), sink);
 
         final Sink noop = new LogstashLogbackSink(state.getNoopHttpLogFormatter());
 
-        noopHttpLogFormatterLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.bodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), noop);
+        noopHttpLogFormatterLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.defaultBodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), noop);
     }
 
     public Logbook getAutoconfigurationLogbook() {

--- a/logbook-jmh/src/main/java/org/zalando/logbook/benchmark/LogbookState.java
+++ b/logbook-jmh/src/main/java/org/zalando/logbook/benchmark/LogbookState.java
@@ -25,15 +25,15 @@ public class LogbookState {
         final LogbookProperties properties = new LogbookProperties();
         final LogbookAutoConfiguration ac = new LogbookAutoConfiguration(properties);
 
-        autoconfigurationLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.defaultBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), ac.sink(ac.httpFormatter(), ac.writer()));
+        autoconfigurationLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.bodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), ac.sink(ac.httpFormatter(), ac.writer()));
 
         final Sink sink = new LogstashLogbackSink(state.getJsonHttpLogFormatter());
 
-        autoconfigurationLogstashLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.defaultBodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), sink);
+        autoconfigurationLogstashLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.bodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), sink);
 
         final Sink noop = new LogstashLogbackSink(state.getNoopHttpLogFormatter());
 
-        noopHttpLogFormatterLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.defaultBodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), noop);
+        noopHttpLogFormatterLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Arrays.asList(ac.headerFilter()), Arrays.asList(ac.pathFilter()), Arrays.asList(ac.queryFilter()), Arrays.asList(ac.bodyFilter(), new CompactingJsonBodyFilter()), Arrays.asList(ac.requestFilter()), Arrays.asList(ac.responseFilter()), ac.strategy(), noop);
     }
 
     public Logbook getAutoconfigurationLogbook() {

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -212,7 +212,6 @@ public class LogbookAutoConfiguration {
     @API(status = INTERNAL)
     @Bean
     @ConditionalOnMissingBean(JacksonJsonFieldBodyFilter.class)
-    @ConditionalOnProperty("logbook.obfuscate.json-body-fields")
     public BodyFilter jsonBodyFieldsFilter() {
         final LogbookProperties.Obfuscate obfuscate = properties.getObfuscate();
         final List<String> jsonBodyFields = obfuscate.getJsonBodyFields();

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -194,7 +194,7 @@ public class LogbookAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(BodyFilter.class)
     @ConditionalOnProperty(value = "logbook.filters.body.default-enabled", havingValue = "true", matchIfMissing = true)
-    public BodyFilter defaultBodyFilter() {
+    public BodyFilter bodyFilter() {
         return defaultValue();
     }
 

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -53,9 +53,11 @@ import org.zalando.logbook.core.RequestFilters;
 import org.zalando.logbook.core.ResponseFilters;
 import org.zalando.logbook.core.SplunkHttpLogFormatter;
 import org.zalando.logbook.core.StatusAtLeastStrategy;
+import org.zalando.logbook.core.TruncatingBodyFilter;
 import org.zalando.logbook.core.WithoutBodyStrategy;
 import org.zalando.logbook.httpclient.LogbookHttpRequestInterceptor;
 import org.zalando.logbook.httpclient.LogbookHttpResponseInterceptor;
+import org.zalando.logbook.json.JacksonJsonFieldBodyFilter;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 import org.zalando.logbook.openfeign.FeignLogbookLogger;
 import org.zalando.logbook.servlet.FormRequestMode;
@@ -75,7 +77,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.zalando.logbook.autoconfigure.LogbookAutoConfiguration.JakartaServletFilterConfiguration.newFilter;
 import static org.zalando.logbook.core.BodyFilters.defaultValue;
-import static org.zalando.logbook.core.BodyFilters.truncate;
 import static org.zalando.logbook.core.HeaderFilters.replaceHeaders;
 import static org.zalando.logbook.core.QueryFilters.replaceQuery;
 
@@ -161,7 +162,7 @@ public class LogbookAutoConfiguration {
         final List<String> parameters = properties.getObfuscate().getParameters();
         return parameters.isEmpty() ?
                 QueryFilters.defaultValue() :
-                replaceQuery(new HashSet<>(parameters)::contains, "XXX");
+                replaceQuery(new HashSet<>(parameters)::contains, properties.getObfuscate().getReplacement());
     }
 
     @API(status = INTERNAL)
@@ -173,7 +174,7 @@ public class LogbookAutoConfiguration {
 
         return headers.isEmpty() ?
                 HeaderFilters.defaultValue() :
-                replaceHeaders(headers, "XXX");
+                replaceHeaders(headers, properties.getObfuscate().getReplacement());
     }
 
     @API(status = INTERNAL)
@@ -184,7 +185,7 @@ public class LogbookAutoConfiguration {
         return paths.isEmpty() ?
                 PathFilter.none() :
                 paths.stream()
-                        .map(path -> PathFilters.replace(path, "XXX"))
+                        .map(path -> PathFilters.replace(path, properties.getObfuscate().getReplacement()))
                         .reduce(PathFilter::merge)
                         .orElseGet(PathFilter::none);
     }
@@ -192,15 +193,31 @@ public class LogbookAutoConfiguration {
     @API(status = INTERNAL)
     @Bean
     @ConditionalOnMissingBean(BodyFilter.class)
-    public BodyFilter bodyFilter() {
+    @ConditionalOnProperty(value = "logbook.filters.body.default-enabled", havingValue = "true", matchIfMissing = true)
+    public BodyFilter defaultBodyFilter() {
+        return defaultValue();
+    }
+
+    @API(status = INTERNAL)
+    @Bean
+    @ConditionalOnMissingBean(TruncatingBodyFilter.class)
+    @ConditionalOnProperty("logbook.write.max-body-size")
+    public BodyFilter truncatingBodyFilter() {
         final LogbookProperties.Write write = properties.getWrite();
         final int maxBodySize = write.getMaxBodySize();
 
-        if (maxBodySize < 0) {
-            return defaultValue();
-        }
+        return new TruncatingBodyFilter(maxBodySize);
+    }
 
-        return BodyFilter.merge(defaultValue(), truncate(maxBodySize));
+    @API(status = INTERNAL)
+    @Bean
+    @ConditionalOnMissingBean(JacksonJsonFieldBodyFilter.class)
+    @ConditionalOnProperty("logbook.obfuscate.json-body-fields")
+    public BodyFilter jsonBodyFieldsFilter() {
+        final LogbookProperties.Obfuscate obfuscate = properties.getObfuscate();
+        final List<String> jsonBodyFields = obfuscate.getJsonBodyFields();
+
+        return new JacksonJsonFieldBodyFilter(jsonBodyFields, obfuscate.getReplacement());
     }
 
     @API(status = INTERNAL)

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
@@ -27,6 +27,8 @@ public final class LogbookProperties {
         private final List<String> headers = new ArrayList<>();
         private final List<String> parameters = new ArrayList<>();
         private final List<String> paths = new ArrayList<>();
+        private final List<String> jsonBodyFields = new ArrayList<>();
+        private final String replacement = "XXX";
     }
 
     @Getter

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
@@ -23,12 +23,13 @@ public final class LogbookProperties {
     private final Filter filter = new Filter();
 
     @Getter
+    @Setter
     public static class Obfuscate {
         private final List<String> headers = new ArrayList<>();
         private final List<String> parameters = new ArrayList<>();
         private final List<String> paths = new ArrayList<>();
         private final List<String> jsonBodyFields = new ArrayList<>();
-        private final String replacement = "XXX";
+        private String replacement = "XXX";
     }
 
     @Getter

--- a/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -33,6 +33,20 @@
           "value": "without-body"
         }
       ]
+    },
+    {
+      "name": "logbook.filter.form-request-mode",
+      "values": [
+        {
+          "value": "BODY"
+        },
+        {
+          "value": "PARAMETER"
+        },
+        {
+          "value": "OFF"
+        }
+      ]
     }
   ],
   "properties": [
@@ -71,6 +85,72 @@
       "type": "java.lang.Boolean",
       "defaultValue": false,
       "description": "Enables/disables additional decompression process for HttpClient with gzip encoded body (to logging purposes only)."
+    },
+    {
+      "name": "logbook.include",
+      "type": "java.util.List<java.lang.String>",
+      "defaultValue": [],
+      "description": "Include only certain URLs (if defined)."
+    },
+    {
+      "name": "logbook.exclude",
+      "type": "java.util.List<java.lang.String>",
+      "defaultValue": [],
+      "description": "Exclude certain URLs (overrides logbook.include)."
+    },
+    {
+      "name": "logbook.obfuscate.headers",
+      "type": "java.util.List<java.lang.String>",
+      "defaultValue": ["Authorization"],
+      "description": "HTTP headers to be obfuscated."
+    },
+    {
+      "name": "logbook.obfuscate.paths",
+      "type": "java.util.List<java.lang.String>",
+      "defaultValue": [],
+      "description": "HTTP paths to be obfuscated. Accepts patterns in the form /myApp/orders/{secret}/order."
+    },
+    {
+      "name": "logbook.obfuscate.parameters",
+      "type": "java.util.List<java.lang.String>",
+      "defaultValue": ["access_token"],
+      "description": "HTTP query parameter names to be obfuscated."
+    },
+    {
+      "name": "logbook.obfuscate.replacement",
+      "type": "java.lang.String",
+      "defaultValue": "XXX",
+      "description": "A value to be used instead of an obfuscated one."
+    },
+    {
+      "name": "logbook.obfuscate.json-body-fields",
+      "type": "java.util.List<java.lang.String>",
+      "defaultValue": [],
+      "description": "List of JSON body fields to be obfuscated."
+    },
+    {
+      "name": "logbook.write.max-body-size",
+      "type": "java.lang.Integer",
+      "defaultValue": -1,
+      "description": "Max body size before it's truncated."
+    },
+    {
+      "name": "logbook.write.chunk-size",
+      "type": "java.lang.Integer",
+      "defaultValue": 0,
+      "description": "Split log lines into smaller chunks of size up-to `chunk-size`."
+    },
+    {
+      "name": "logbook.filter.form-request-mode",
+      "type": "java.lang.String",
+      "defaultValue": "BODY",
+      "description": "Determines how form requests are handled."
+    },
+    {
+      "name": "logbook.filters.body.default-enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables/disables default body filter."
     }
   ]
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JsonBodyFieldsTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JsonBodyFieldsTest.java
@@ -1,33 +1,56 @@
 package org.zalando.logbook.autoconfigure;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.zalando.logbook.BodyFilter;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.HttpRequest;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.test.MockHttpRequest;
 
-import java.util.List;
+import java.io.IOException;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.skyscreamer.jsonassert.JSONCompare.compareJSON;
 
-@LogbookTest(properties = "logbook.obfuscate.json-body-fields = name,city")
+@LogbookTest(profiles = "body_fields")
 class JsonBodyFieldsTest {
 
     @Autowired
-    private List<BodyFilter> bodyFilters;
+    private Logbook logbook;
 
-    private BodyFilter bodyFilter;
+    @MockBean
+    private HttpLogWriter writer;
 
     @BeforeEach
     void setUp() {
-        bodyFilter = bodyFilters.stream().reduce(BodyFilter.none(), BodyFilter::merge);
+        doReturn(true).when(writer).isActive();
     }
 
     @Test
-    void shouldObfuscateConfiguredJsonFields() {
-        final String body = "{\"name\":\"John\", \"city\":\"Berlin\", \"color\":\"blue\"}";
-        final String filtered = bodyFilter.filter("application/json", body);
+    void shouldFilterRequestBody() throws IOException, JSONException {
+        final HttpRequest request = MockHttpRequest.create()
+                .withBodyAsString("{ \"first_name\": \"Jonny\", \"details\": { \"last_name\": \"Pepp\", \"field\":\"value\" } }")
+                .withContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        assertThat(filtered).isEqualTo("{\"name\":\"XXX\",\"city\":\"XXX\",\"color\":\"blue\"}");
+        logbook.process(request).write();
+
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer).write(any(Precorrelation.class), captor.capture());
+        final String message = captor.getValue();
+
+        String body = new JSONObject(message).getJSONObject("body").toString();
+
+        compareJSON(body, "{ \"first_name\": \"XXX\", \"details\": { \"last_name\": \"XXX\", \"field\":\"value\" } }", JSONCompareMode.LENIENT);
     }
 
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JsonBodyFieldsTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JsonBodyFieldsTest.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@LogbookTest(properties = "logbook.write.max-body-size = 20")
-class WriteBodyMaxSizeTest {
+@LogbookTest(properties = "logbook.obfuscate.json-body-fields = name,city")
+class JsonBodyFieldsTest {
 
     @Autowired
     private List<BodyFilter> bodyFilters;
@@ -23,18 +23,11 @@ class WriteBodyMaxSizeTest {
     }
 
     @Test
-    void shouldUseBodyMaxSizeFilter() {
-        final String body = "{\"foo\":\"someLongMessage\"}";
+    void shouldObfuscateConfiguredJsonFields() {
+        final String body = "{\"name\":\"John\", \"city\":\"Berlin\", \"color\":\"blue\"}";
         final String filtered = bodyFilter.filter("application/json", body);
 
-        assertThat(filtered).isEqualTo("{\"foo\":\"someLongMess...");
+        assertThat(filtered).isEqualTo("{\"name\":\"XXX\",\"city\":\"XXX\",\"color\":\"blue\"}");
     }
 
-    @Test
-    void shouldUseBodyMaxSizeOverDefaultFilter() {
-        final String body = "{\"open_id\":\"someLongSecret\",\"foo\":\"bar\"}";
-        final String filtered = bodyFilter.filter("application/json", body);
-
-        assertThat(filtered).isEqualTo("{\"open_id\":\"XXX\",\"fo...");
-    }
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyCustomTest.java
@@ -31,7 +31,7 @@ class ObfuscateBodyCustomTest {
     private HttpLogWriter writer;
 
     @MockBean
-    @Qualifier("defaultBodyFilter")
+    @Qualifier("bodyFilter")
     private BodyFilter bodyFilter;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyCustomTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.zalando.logbook.BodyFilter;
 import org.zalando.logbook.HttpLogWriter;
@@ -30,6 +31,7 @@ class ObfuscateBodyCustomTest {
     private HttpLogWriter writer;
 
     @MockBean
+    @Qualifier("defaultBodyFilter")
     private BodyFilter bodyFilter;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteBodyMaxSizeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteBodyMaxSizeTest.java
@@ -1,11 +1,9 @@
 package org.zalando.logbook.autoconfigure;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.zalando.logbook.BodyFilter;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,14 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WriteBodyMaxSizeTest {
 
     @Autowired
-    private List<BodyFilter> bodyFilters;
-
+    @Qualifier("truncatingBodyFilter")
     private BodyFilter bodyFilter;
-
-    @BeforeEach
-    void setUp() {
-        bodyFilter = bodyFilters.stream().reduce(BodyFilter.none(), BodyFilter::merge);
-    }
 
     @Test
     void shouldUseBodyMaxSizeFilter() {
@@ -35,6 +27,6 @@ class WriteBodyMaxSizeTest {
         final String body = "{\"open_id\":\"someLongSecret\",\"foo\":\"bar\"}";
         final String filtered = bodyFilter.filter("application/json", body);
 
-        assertThat(filtered).isEqualTo("{\"open_id\":\"XXX\",\"fo...");
+        assertThat(filtered).isEqualTo("{\"open_id\":\"someLong...");
     }
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteNoBodyMaxSizeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteNoBodyMaxSizeTest.java
@@ -2,6 +2,7 @@ package org.zalando.logbook.autoconfigure;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.zalando.logbook.BodyFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WriteNoBodyMaxSizeTest {
 
     @Autowired
+    @Qualifier("bodyFilter")
     private BodyFilter bodyFilter;
 
     @Test

--- a/logbook-spring-boot-autoconfigure/src/test/resources/application-body_fields.yml
+++ b/logbook-spring-boot-autoconfigure/src/test/resources/application-body_fields.yml
@@ -1,0 +1,5 @@
+logbook:
+  obfuscate:
+    json-body-fields:
+    - first_name
+    - last_name

--- a/logbook-spring-boot-autoconfigure/src/test/resources/application-replacement.yaml
+++ b/logbook-spring-boot-autoconfigure/src/test/resources/application-replacement.yaml
@@ -1,0 +1,5 @@
+logbook:
+  obfuscate:
+    json-body-fields:
+      - name
+    replacement: ZZZ


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make JSON body fields obfuscation configuration in Spring Boot applications via properties.
`JacksonJsonFieldBodyFilter` is initialized when `logbook.obfuscate.json-body-fields` property is defined. 


This change set also includes:
- separate default body filter from truncating so that it's possible to use truncating body filter if they define custom body filters.
- add configuration descriptions to spring's configuration-metadata.json file to show hints in IDEs when configuring logbook
- Introduced a property to disable the default logbook filter via configuration
- Introduced a configuration property to define obfuscation replacement string

## Motivation and Context
Relates to: 
- #1266
- #1506
- #1202

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
