### PR TITLE
Update Release Script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Extract Release Notes
+      uses: ffurrer2/extract-release-notes@v1.16.0
+      id: notes
     - name: Create Release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
         draft: false
         prerelease: ${{ contains(github.ref, 'RC') }}
+        body: ${{ steps.notes.outputs.release_notes }}

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 : "${1?"Usage: $0 <[pre]major|[pre]minor|[pre]patch|prerelease>"}"
-: "${CHANGELOG_GITHUB_TOKEN?"Needs CHANGELOG_GITHUB_TOKEN env var"}"
+: "${CHANGELOG_GITHUB_TOKEN?"Needs CHANGELOG_GITHUB_TOKEN env var (access token with repo scopes)"}"
 
 ./mvnw scm:check-local-modification
 
@@ -13,15 +13,16 @@ release=$(semver "${current}" -i "$1" --preid RC)
 next=$(semver "${release}" -i minor)
 
 ./mvnw versions:set -D newVersion="${release}"
+
+docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v "$(pwd)":/usr/local/src/your-app \
+    githubchangeloggenerator/github-changelog-generator -u zalando -p logbook --future-release ${release}
+
 git commit -am "Release ${release}"
+
 ./mvnw clean deploy scm:tag -P release -D tag="${release}" -D pushChanges=false -D skipTests -D dependency-check.skip
 
 ./mvnw versions:set -D newVersion="${next}-SNAPSHOT"
 
-git push --atomic origin main "${release}"
-
-docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v "$(pwd)":/usr/local/src/your-app \
-    githubchangeloggenerator/github-changelog-generator -u zalando -p logbook
 git commit -am "Development ${next}-SNAPSHOT"
 
-git push
+git push --atomic origin main "${release}"


### PR DESCRIPTION
## Description

* Update CHANGELOG as part of the "release" commit of the version being released
* Publish only once at the end of the release flow
* Add CHANGELOG diff to Github Release

## Motivation and Context

Better release experience for publishers (less risk) and better release consumer experience

## Checklist:
- [x] I have updated the documentation accordingly.
