### PR TITLE
suppress not applicable CVE

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -9,5 +9,8 @@
 
         <!-- https://github.com/FasterXML/jackson-databind/issues/3972 -->
         <cve>CVE-2023-35116</cve>
+
+        <!-- okhttp-4.11.0 - The vulernability is only in the brotli packages of okhttp, which are not used in this library -->
+        <cve>CVE-2023-3782</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
## Description

See https://github.com/square/okhttp/issues/7738 - right now NVD is mistakenly identifying `CVE-2023-3782` against all of okhttp, instead of just the `okhttp-brotli` package.

## Motivation and Context

unblock the build pipeline