### PR TITLE
Bring back default constructor to LogbookHttpResponseInterceptor

### DIFF
--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
@@ -23,6 +23,9 @@ public final class LogbookHttpResponseInterceptor implements HttpResponseInterce
 
     private final boolean decompressResponse;
 
+    public LogbookHttpResponseInterceptor() {
+        this(false);
+    }
     public LogbookHttpResponseInterceptor(boolean decompressResponse) {
         this.decompressResponse = decompressResponse;
     }

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsPutTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsPutTest.java
@@ -45,7 +45,7 @@ final class LogbookHttpInterceptorsPutTest {
 
     private final CloseableHttpClient client = HttpClientBuilder.create()
             .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
-            .addInterceptorFirst(new LogbookHttpResponseInterceptor(false))
+            .addInterceptorFirst(new LogbookHttpResponseInterceptor())
             .build();
 
     @AfterEach

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsTest.java
@@ -29,7 +29,7 @@ public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
 
     private final CloseableHttpClient client = HttpClientBuilder.create()
             .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
-            .addInterceptorFirst(new LogbookHttpResponseInterceptor(false))
+            .addInterceptorFirst(new LogbookHttpResponseInterceptor())
             .build();
 
     @AfterEach


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Was removed in https://github.com/zalando/logbook/pull/1505 and is an unnecessary breaking change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
