### PR TITLE
Fix hints from configuration-metadata.json

### DIFF
--- a/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,4 +1,31 @@
 {
+  "groups": [
+    {
+      "name": "logbook",
+      "type": "org.zalando.logbook.autoconfigure.LogbookProperties",
+      "sourceType": "org.zalando.logbook.autoconfigure.LogbookProperties"
+    },
+    {
+      "name": "logbook.predicate",
+      "type": "org.zalando.logbook.autoconfigure.LogbookProperties$PredicateProperties",
+      "sourceType": "org.zalando.logbook.autoconfigure.LogbookProperties"
+    },
+    {
+      "name": "logbook.obfuscate",
+      "type": "org.zalando.logbook.autoconfigure.LogbookProperties$Obfuscate",
+      "sourceType": "org.zalando.logbook.autoconfigure.LogbookProperties"
+    },
+    {
+      "name": "logbook.write",
+      "type": "org.zalando.logbook.autoconfigure.LogbookProperties$Write",
+      "sourceType": "org.zalando.logbook.autoconfigure.LogbookProperties"
+    },
+    {
+      "name": "logbook.filter",
+      "type": "org.zalando.logbook.autoconfigure.LogbookProperties$Filter",
+      "sourceType": "org.zalando.logbook.autoconfigure.LogbookProperties"
+    }
+  ],
   "hints": [
     {
       "name": "logbook.format.style",
@@ -173,7 +200,7 @@
     },
     {
       "name": "logbook.filter.form-request-mode",
-      "type": "java.lang.String",
+      "type": "org.zalando.logbook.servlet.FormRequestMode",
       "defaultValue": "BODY",
       "description": "Determines how form requests are handled."
     },
@@ -182,6 +209,12 @@
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Enables/disables default body filter."
+    },
+    {
+      "name": "logbook.attribute-extractors",
+      "type": "java.util.List<org.zalando.logbook.autoconfigure.LogbookProperties.ExtractorProperty>",
+      "defaultValue": [],
+      "description": "A list of attribute extractors to use."
     },
     {
       "name": "logbook.attribute-extractors.type",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- remove `additional` from the name of `META-INF/additional-spring-configuration-metadata.json ` as it's the only metadata file of the project.
- add groups to help IDEs identifying types of configuration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes should fix the issue where IDEs are unable to provide meaningful hints to uses about logbook configuration properties.

Addresses https://github.com/zalando/logbook/issues/1574

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
