### PR TITLE
Call close() on closeable ClientHttpResponse within BufferingClientHttpResponseWrapper.java

### DIFF
--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapper.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapper.java
@@ -47,8 +47,9 @@ public class BufferingClientHttpResponseWrapper implements ClientHttpResponse {
             body.close();
         } catch (IOException e){
             throw new RuntimeException(e);
+        } finally {
+            delegate.close();
         }
-        delegate.close();
     }
 
     @Override

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapperTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/BufferingClientHttpResponseWrapperTest.java
@@ -84,6 +84,7 @@ class BufferingClientHttpResponseWrapperTest {
         doThrow(new IOException()).when(inputStream).close();
 
         assertThrows(RuntimeException.class, () -> wrapper.close());
+        verify(delegate).close();
     }
 
     @Test


### PR DESCRIPTION
Clear resources

## Description
On exception and close operation, only 1 of 2 close-able resources are closed.

## Motivation and Context
It looks like it could lead to memory leak.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
