### PR TITLE
Spring framework 4 compatibility

### DIFF
--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptor.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptor.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 @API(status = API.Status.EXPERIMENTAL)
 @AllArgsConstructor
-public final class LogbookClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+public class LogbookClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private final Logbook logbook;
 
@@ -24,9 +24,13 @@ public final class LogbookClientHttpRequestInterceptor implements ClientHttpRequ
 
         ClientHttpResponse response = new BufferingClientHttpResponseWrapper(execution.execute(request, body));
 
-        final HttpResponse httpResponse = new RemoteResponse(response);
+        final HttpResponse httpResponse = getHttpResponse(response);
         stage.process(httpResponse).write();
 
         return response;
+    }
+
+    protected HttpResponse getHttpResponse(ClientHttpResponse response) {
+        return new RemoteResponse(response);
     }
 }

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorBackwardCompatibility.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorBackwardCompatibility.java
@@ -1,0 +1,60 @@
+package org.zalando.logbook.spring;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.Logbook;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.zalando.logbook.spring.ReflectionUtil.resolveMethod;
+
+/**
+ * Supports sprint framework older than 6.2 (should support 4.X)
+ */
+public class LogbookClientHttpRequestInterceptorBackwardCompatibility extends LogbookClientHttpRequestInterceptor {
+    private final Method getStatusCodeMethod;
+    private final Method valueMethod;
+
+    public LogbookClientHttpRequestInterceptorBackwardCompatibility(Logbook logbook) {
+        this(logbook, ClientHttpResponse.class);
+    }
+
+    protected LogbookClientHttpRequestInterceptorBackwardCompatibility(Logbook logbook, Class<?> responseClass) {
+        super(logbook);
+        try {
+            getStatusCodeMethod = resolveMethod(responseClass, "getStatusCode");
+            valueMethod = resolveMethod(getStatusCodeMethod.getReturnType(), "value");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected HttpResponse getHttpResponse(ClientHttpResponse clientHttpResponse) {
+        final int statusCode = getStatus(clientHttpResponse);
+        return new RemoteResponse(clientHttpResponse) {
+            @Override
+            public int getStatus() {
+                return statusCode;
+            }
+        };
+    }
+
+    private int getStatus(ClientHttpResponse clientHttpResponse) {
+        try {
+            Object statusCode = getStatusCodeMethod.invoke(clientHttpResponse);
+            return (int) valueMethod.invoke(statusCode);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static LogbookClientHttpRequestInterceptorBackwardCompatibility of(Logbook logbook, Class<?> responseClass) {
+        return new LogbookClientHttpRequestInterceptorBackwardCompatibility(logbook, responseClass);
+    }
+
+    public static LogbookClientHttpRequestInterceptorBackwardCompatibility of(Logbook logbook) {
+        return new LogbookClientHttpRequestInterceptorBackwardCompatibility(logbook);
+    }
+}

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/ReflectionUtil.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/ReflectionUtil.java
@@ -1,0 +1,9 @@
+package org.zalando.logbook.spring;
+
+import java.lang.reflect.Method;
+
+public class ReflectionUtil {
+    public static Method resolveMethod(Class<?> responseClass, String methodName) throws NoSuchMethodException {
+        return responseClass.getMethod(methodName);
+    }
+}

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/RemoteResponse.java
@@ -18,7 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.zalando.fauxpas.FauxPas.throwingUnaryOperator;
 
 @AllArgsConstructor
-final class RemoteResponse implements HttpResponse {
+class RemoteResponse implements HttpResponse {
 
     private final AtomicReference<State> state = new AtomicReference<>(new Unbuffered());
     private final ClientHttpResponse response;
@@ -111,6 +111,7 @@ final class RemoteResponse implements HttpResponse {
         } catch (NoSuchMethodError e) {
             try {
                 // support spring-boot 2.x as fallback
+                // warning: this method will be removed in spring-framework 6.2
                 return response.getRawStatusCode();
             } catch (IOException ex) {
                 throw new RuntimeException(ex);

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorBackwardCompatibilityTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptorBackwardCompatibilityTest.java
@@ -1,0 +1,59 @@
+package org.zalando.logbook.spring;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.zalando.logbook.Logbook;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.zalando.logbook.spring.LogbookClientHttpRequestInterceptorBackwardCompatibility.of;
+import static org.zalando.logbook.spring.ReflectionUtil.resolveMethod;
+
+class LogbookClientHttpRequestInterceptorBackwardCompatibilityTest {
+
+    @Test
+    void getHttpResponseFromClientHttpResponse() {
+        assertThat(of(Logbook.create())
+                .getHttpResponse(new MockClientHttpResponse(new byte[0], HttpStatus.OK)).getStatus())
+                .isEqualTo(200);
+    }
+
+    @Test
+    void getHttpResponseFromMockClientHttpResponse() {
+        assertThat(of(Logbook.create(), MockClientHttpResponse.class)
+                .getHttpResponse(new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED)).getStatus())
+                .isEqualTo(401);
+    }
+
+    @Test
+    void getHttpResponse_throws() throws InvocationTargetException, IllegalAccessException {
+        try (MockedStatic<ReflectionUtil> utilities = Mockito.mockStatic(ReflectionUtil.class)) {
+            Method method = mock(Method.class);
+            doThrow(IllegalAccessException.class).when(method).invoke(any(Object.class));
+            utilities.when(() -> resolveMethod(any(Class.class), anyString())).thenReturn(method);
+
+            assertThrows(RuntimeException.class, () -> of(Logbook.create())
+                    .getHttpResponse(new MockClientHttpResponse(new byte[0], HttpStatus.OK)).getStatus());
+        }
+    }
+
+    @Test
+    void constructor_throws() {
+        try (MockedStatic<ReflectionUtil> utilities = Mockito.mockStatic(ReflectionUtil.class)) {
+            utilities.when(() -> resolveMethod(any(Class.class), anyString())).thenThrow(new NoSuchMethodException());
+
+            assertThrows(RuntimeException.class, () -> of(Logbook.create(), ClientHttpResponse.class));
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added a compatibility interceptor that should work with spring framework 4.X, 5.X and 6.X.
- I only altered the current classes to allow extending them enough to patch the status code, and discard the use of HttpStatusCode.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- I have to maintain an old spring framework 4 project, which can't be migrated. I can't use latest logbook. due to spring HttpStatusCode class missing, Intellij doesn't like it and prevent proper loading of the project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.

## Alternative solutions (ideas to review)
- Instead of this PR, I could remove spring dependency from logbook-parent, and add new sub-modules for each client version of spring (similar to httpclient/httpclient5). I can create extra sub-module for `logbook-spring4` and `logbook-spring5`, that way the tests would be on real framework without reflection shenanigans.
-- Optionally, for consistency, renaming logbook-spring to logbook-spring6?