### PR TITLE
Use writeTo() to buffer HttpEntity in httpclient

### DIFF
--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/HttpEntities.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/HttpEntities.java
@@ -7,9 +7,9 @@ import lombok.experimental.UtilityClass;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.apache.http.util.EntityUtils.toByteArray;
 
 @UtilityClass
 final class HttpEntities {
@@ -19,7 +19,9 @@ final class HttpEntities {
     }
 
     Copy copy(final HttpEntity entity) throws IOException {
-        final byte[] body = toByteArray(entity);
+        final ByteArrayOutputStream os = new ByteArrayOutputStream();
+        entity.writeTo(os);
+        final byte[] body = os.toByteArray();
 
         final ByteArrayEntity copy = new ByteArrayEntity(body);
         copy.setChunked(entity.isChunked());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use `HttpEntity.writeTo()` instead of relying on `EntityUtils.toByteArray()` to copy the `OutputStream` of the HttpEntity.

## Motivation and Context

With a change in Spring Framework 6.1, HttpComponentsClientHttpRequest has an internal class [BodyEntity](https://github.com/spring-projects/spring-framework/blob/e870912fa2d4d05830ac476903eecaf6e907ca49/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java#L120), that is meant to not cache an `OutputStream`, but to provide a callback, that's used when the `OutputStream` is required. The [getContent()](https://github.com/spring-projects/spring-framework/blob/e870912fa2d4d05830ac476903eecaf6e907ca49/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java#L146) method throws `UnsupportedOperationException`.

With this change, I'm using the `writeTo()` method to copy the `OutputStream`, as for Logbook, buffering the stream is required.

Addresses https://github.com/zalando/logbook/issues/1734 
Related PR - https://github.com/zalando/logbook/pull/1701

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
