### PR TITLE
Request body only once in ChunkedSink

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/core/ChunkingSink.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/ChunkingSink.java
@@ -54,11 +54,12 @@ public final class ChunkingSink implements Sink {
     }
 
     private Stream<String> chunk(final HttpMessage message) throws IOException {
-        if (message.getBodyAsString().isEmpty()) {
+        final String body = message.getBodyAsString();
+        if (body.isEmpty()) {
             return Stream.of("");
         }
 
-        return stream(new ChunkingSpliterator(message.getBodyAsString(), minChunkSize, maxChunkSize), false);
+        return stream(new ChunkingSpliterator(body, minChunkSize, maxChunkSize), false);
     }
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As HttpMessage.getBodyAsString in some occasions may be a heavy operation, it's better to reduce number of times it's requested. In this changeset I remove the second invocation of the method in ChunkingSink.

## Motivation and Context
Addresses #1713

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
