### PR TITLE
Logbook fault tolerancy

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/core/DefaultLogbook.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/DefaultLogbook.java
@@ -57,7 +57,7 @@ final class DefaultLogbook implements Logbook {
 
                 return new DefaultRequestWritingStage(strategy, precorrelation, processedRequest, filteredRequest);
             } catch (RuntimeException e) {
-                log.info("Unable to prepare request for logging", e);
+                log.warn("Unable to prepare request for logging. Will skip the request & response logging step.", e);
                 return Stages.noop();
             }
         } else {

--- a/logbook-core/src/main/java/org/zalando/logbook/core/DefaultLogbook.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/DefaultLogbook.java
@@ -143,7 +143,7 @@ final class DefaultLogbook implements Logbook {
             try {
                 strategy.write(precorrelation, filteredRequest, sink);
             } catch (RuntimeException e) {
-                log.info("Unable to log request", e);
+                log.warn("Unable to log request. Will skip the request & response logging step.", e);
                 return Stages.noop();
             }
 
@@ -152,7 +152,7 @@ final class DefaultLogbook implements Logbook {
 
         @Override
         public ResponseWritingStage process(final HttpResponse originalResponse) throws IOException {
-            final HttpResponse processedResponse = DefaultLogbook.this.strategy.process(filteredRequest, originalResponse);
+            final HttpResponse processedResponse = this.strategy.process(filteredRequest, originalResponse);
 
             return () -> {
                 try {
@@ -161,7 +161,7 @@ final class DefaultLogbook implements Logbook {
                     final HttpResponse filteredResponse = responseFilter.filter(response);
                     strategy.write(precorrelation.correlate(), filteredRequest, filteredResponse, sink);
                 } catch (RuntimeException e) {
-                    log.info("Unable to log response", e);
+                    log.warn("Unable to log response. Will skip the response logging step.", e);
                 }
             };
         }

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumer.java
@@ -44,10 +44,10 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
             if (stage != null) {
                 stage.process(new RemoteResponse(response, decompressResponse)).write();
             } else {
-                log.trace("Unable to log response: ResponseProcessingStage is null in HttpContext");
+                log.warn("Unable to log response: ResponseProcessingStage is null in HttpContext. Will skip the response logging step.");
             }
         } catch (final IOException e) {
-            log.trace("Unable to log response: {}", e.getClass());
+            log.warn("Unable to log response. Will skip the response logging step.", e);
         }
 
         delegate().responseCompleted(context);

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpRequestInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpRequestInterceptor.java
@@ -29,7 +29,7 @@ public final class LogbookHttpRequestInterceptor implements HttpRequestIntercept
             final ResponseProcessingStage stage = logbook.process(request).write();
             context.setAttribute(Attributes.STAGE, stage);
         } catch (Exception e) {
-            log.trace("Unable to log request: {}", e.getClass());
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
         }
     }
 

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpRequestInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpRequestInterceptor.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import static org.apiguardian.api.API.Status.STABLE;
 
 @API(status = STABLE)
+@Slf4j
 public final class LogbookHttpRequestInterceptor implements HttpRequestInterceptor {
 
     private final Logbook logbook;
@@ -22,9 +24,13 @@ public final class LogbookHttpRequestInterceptor implements HttpRequestIntercept
 
     @Override
     public void process(final HttpRequest httpRequest, final HttpContext context) throws IOException {
-        final LocalRequest request = new LocalRequest(httpRequest);
-        final ResponseProcessingStage stage = logbook.process(request).write();
-        context.setAttribute(Attributes.STAGE, stage);
+        try {
+            final LocalRequest request = new LocalRequest(httpRequest);
+            final ResponseProcessingStage stage = logbook.process(request).write();
+            context.setAttribute(Attributes.STAGE, stage);
+        } catch (Exception e) {
+            log.trace("Unable to log request: {}", e.getClass());
+        }
     }
 
 }

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
@@ -37,7 +37,7 @@ public final class LogbookHttpResponseInterceptor implements HttpResponseInterce
         try {
             doProcess(original, context);
         } catch (Exception e) {
-            log.trace("Unable to log response: {}", e.getClass());
+            log.warn("Unable to log response. Will skip the response logging step.", e);
         }
     }
 
@@ -46,7 +46,7 @@ public final class LogbookHttpResponseInterceptor implements HttpResponseInterce
         if (stage != null) {
             stage.process(new RemoteResponse(original, decompressResponse)).write();
         } else {
-            log.trace("Unable to log response: ResponseProcessingStage is null in HttpContext");
+            log.warn("Unable to log response: ResponseProcessingStage is null in HttpContext. Will skip the response logging step.");
         }
     }
 

--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpResponseInterceptor.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.nio.client.HttpAsyncClient;
@@ -19,6 +20,7 @@ import static org.apiguardian.api.API.Status.STABLE;
  * @see LogbookHttpAsyncResponseConsumer
  */
 @API(status = STABLE)
+@Slf4j
 public final class LogbookHttpResponseInterceptor implements HttpResponseInterceptor {
 
     private final boolean decompressResponse;
@@ -32,8 +34,20 @@ public final class LogbookHttpResponseInterceptor implements HttpResponseInterce
 
     @Override
     public void process(final HttpResponse original, final HttpContext context) throws IOException {
+        try {
+            doProcess(original, context);
+        } catch (Exception e) {
+            log.trace("Unable to log response: {}", e.getClass());
+        }
+    }
+
+    private void doProcess(HttpResponse original, HttpContext context) throws IOException {
         final ResponseProcessingStage stage = find(context);
-        stage.process(new RemoteResponse(original, decompressResponse)).write();
+        if (stage != null) {
+            stage.process(new RemoteResponse(original, decompressResponse)).write();
+        } else {
+            log.trace("Unable to log response: ResponseProcessingStage is null in HttpContext");
+        }
     }
 
     private ResponseProcessingStage find(final HttpContext context) {

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumerTest.java
@@ -22,7 +22,6 @@ import org.zalando.logbook.test.TestStrategy;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.concurrent.ExecutionException;
 
 import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
@@ -31,10 +30,10 @@ import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.apache.http.nio.client.methods.HttpAsyncMethods.create;
 import static org.apache.http.nio.client.methods.HttpAsyncMethods.createConsumer;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest {
@@ -83,7 +82,7 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
     }
 
     @Test
-    void shouldWrapIOException() throws IOException {
+    void shouldNotPropagateException() throws IOException {
         final HttpAsyncResponseConsumer<HttpResponse> unit = new LogbookHttpAsyncResponseConsumer<>(createConsumer(), false);
 
         final BasicHttpContext context = new BasicHttpContext();
@@ -95,8 +94,9 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
 
         doThrow(new IOException()).when(last).write();
 
-        assertThrows(UncheckedIOException.class, () ->
-                unit.responseCompleted(context));
+        unit.responseCompleted(context);
+
+        verify(last).write();
     }
 
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
@@ -54,14 +54,14 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
 
     private void processStage(final HttpResponse response, final EntityDetails entityDetails, final ByteBuffer src) {
         if (stage == null) {
-            log.trace("Unable to log response: ResponseProcessingStage is null in HttpContext");
+            log.warn("Unable to log response: ResponseProcessingStage is null in HttpContext. Will skip the response logging step.");
             return;
         }
 
         try {
             stage.process(new RemoteResponse(response, entityDetails, src)).write();
         } catch (Exception e) {
-            log.trace("Unable to log response: {}", e.getClass());
+            log.warn("Unable to log response. Will skip the response logging step.", e);
         }
     }
 

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
@@ -36,7 +36,7 @@ public class LogbookHttpExecHandler implements ExecChainHandler {
             final LocalRequest localRequest = new LocalRequest(request, request.getEntity());
             stage = logbook.process(localRequest).write();
         } catch (Exception e) {
-            log.trace("Unable to log request: {}", e.getClass());
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
         }
         return stage;
     }
@@ -46,10 +46,10 @@ public class LogbookHttpExecHandler implements ExecChainHandler {
             try {
                 stage.process(new RemoteResponse(response)).write();
             } catch (Exception e) {
-                log.trace("Unable to log response: {}", e.getClass());
+                log.warn("Unable to log response. Will skip the response logging step.", e);
             }
         } else {
-            log.trace("Unable to log response: ResponseProcessingStage is null");
+            log.warn("Unable to log response: ResponseProcessingStage is null. Will skip the response logging step.");
         }
     }
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandler.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient5;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.ExecChainHandler;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -7,8 +8,10 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
 import org.zalando.logbook.Logbook;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
+@Slf4j
 public class LogbookHttpExecHandler implements ExecChainHandler {
 
     private final Logbook logbook;
@@ -19,13 +22,34 @@ public class LogbookHttpExecHandler implements ExecChainHandler {
 
     @Override
     public ClassicHttpResponse execute(final ClassicHttpRequest request, final ExecChain.Scope scope, final ExecChain execChain) throws IOException, HttpException {
-        final LocalRequest localRequest = new LocalRequest(request, request.getEntity());
-        final Logbook.ResponseProcessingStage stage = logbook.process(localRequest).write();
-
+        Logbook.ResponseProcessingStage stage = logRequest(request);
         final ClassicHttpResponse response = execChain.proceed(request, scope);
-
-        stage.process(new RemoteResponse(response)).write();
+        logResponse(stage, response);
 
         return response;
+    }
+
+    @Nullable
+    private Logbook.ResponseProcessingStage logRequest(final ClassicHttpRequest request) {
+        Logbook.ResponseProcessingStage stage = null;
+        try {
+            final LocalRequest localRequest = new LocalRequest(request, request.getEntity());
+            stage = logbook.process(localRequest).write();
+        } catch (Exception e) {
+            log.trace("Unable to log request: {}", e.getClass());
+        }
+        return stage;
+    }
+
+    private static void logResponse(@Nullable final Logbook.ResponseProcessingStage stage, final ClassicHttpResponse response) {
+        if (stage != null) {
+            try {
+                stage.process(new RemoteResponse(response)).write();
+            } catch (Exception e) {
+                log.trace("Unable to log response: {}", e.getClass());
+            }
+        } else {
+            log.trace("Unable to log response: ResponseProcessingStage is null");
+        }
     }
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpRequestInterceptor.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpRequestInterceptor.java
@@ -31,7 +31,7 @@ public final class LogbookHttpRequestInterceptor implements HttpRequestIntercept
             final ResponseProcessingStage stage = logbook.process(request).write();
             context.setAttribute(Attributes.STAGE, stage);
         } catch (Exception e) {
-            log.trace("Unable to log request: {}", e.getClass());
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
         }
     }
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpRequestInterceptor.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpRequestInterceptor.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient5;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
@@ -14,6 +15,7 @@ import java.io.IOException;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 @API(status = EXPERIMENTAL)
+@Slf4j
 public final class LogbookHttpRequestInterceptor implements HttpRequestInterceptor {
 
     private final Logbook logbook;
@@ -24,8 +26,12 @@ public final class LogbookHttpRequestInterceptor implements HttpRequestIntercept
 
     @Override
     public void process(HttpRequest httpRequest, EntityDetails entity, HttpContext context) throws HttpException, IOException {
-        LocalRequest request = new LocalRequest(httpRequest, entity);
-        final ResponseProcessingStage stage = logbook.process(request).write();
-        context.setAttribute(Attributes.STAGE, stage);
+        try {
+            LocalRequest request = new LocalRequest(httpRequest, entity);
+            final ResponseProcessingStage stage = logbook.process(request).write();
+            context.setAttribute(Attributes.STAGE, stage);
+        } catch (Exception e) {
+            log.trace("Unable to log request: {}", e.getClass());
+        }
     }
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpResponseInterceptor.java
@@ -29,7 +29,7 @@ public final class LogbookHttpResponseInterceptor implements HttpResponseInterce
         try {
             doProcess(original, context);
         } catch (Exception e) {
-            log.trace("Unable to log response: {}", e.getClass());
+            log.warn("Unable to log response. Will skip the response logging step.", e);
         }
     }
 
@@ -38,7 +38,7 @@ public final class LogbookHttpResponseInterceptor implements HttpResponseInterce
         if (stage != null) {
             stage.process(new RemoteResponse(original)).write();
         } else {
-            log.trace("Unable to log response: ResponseProcessingStage is null in HttpContext");
+            log.warn("Unable to log response: ResponseProcessingStage is null in HttpContext. Will skip the response logging step.");
         }
     }
 

--- a/logbook-okhttp/src/main/java/org/zalando/logbook/okhttp/LogbookInterceptor.java
+++ b/logbook-okhttp/src/main/java/org/zalando/logbook/okhttp/LogbookInterceptor.java
@@ -1,9 +1,11 @@
 package org.zalando.logbook.okhttp;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 import org.apiguardian.api.API;
+import org.jetbrains.annotations.Nullable;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
@@ -14,6 +16,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 @API(status = EXPERIMENTAL)
 @AllArgsConstructor
+@Slf4j
 public final class LogbookInterceptor implements Interceptor {
 
     private final Logbook logbook;
@@ -22,11 +25,34 @@ public final class LogbookInterceptor implements Interceptor {
     @Override
     public Response intercept(final Chain chain) throws IOException {
         final LocalRequest request = new LocalRequest(chain.request());
-        final ResponseProcessingStage stage = logbook.process(request).write();
+        final ResponseProcessingStage stage = logRequest(request);
         final RemoteResponse response = new RemoteResponse(chain.proceed(request.toRequest()));
-        stage.process(response).write();
+        logResponse(stage, response);
 
         return response.toResponse();
+    }
+
+    @Nullable
+    private ResponseProcessingStage logRequest(LocalRequest request) {
+        ResponseProcessingStage stage = null;
+        try {
+            stage = logbook.process(request).write();
+        } catch (Exception e) {
+            log.trace("Unable to log request: {}", e.getClass());
+        }
+        return stage;
+    }
+
+    private static void logResponse(@Nullable final Logbook.ResponseProcessingStage stage, final RemoteResponse response) {
+        if (stage != null) {
+            try {
+                stage.process(response).write();
+            } catch (Exception e) {
+                log.trace("Unable to log response: {}", e.getClass());
+            }
+        } else {
+            log.trace("Unable to log response: ResponseProcessingStage is null");
+        }
     }
 
 }

--- a/logbook-okhttp/src/main/java/org/zalando/logbook/okhttp/LogbookInterceptor.java
+++ b/logbook-okhttp/src/main/java/org/zalando/logbook/okhttp/LogbookInterceptor.java
@@ -38,7 +38,7 @@ public final class LogbookInterceptor implements Interceptor {
         try {
             stage = logbook.process(request).write();
         } catch (Exception e) {
-            log.trace("Unable to log request: {}", e.getClass());
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
         }
         return stage;
     }
@@ -48,10 +48,10 @@ public final class LogbookInterceptor implements Interceptor {
             try {
                 stage.process(response).write();
             } catch (Exception e) {
-                log.trace("Unable to log response: {}", e.getClass());
+                log.warn("Unable to log response. Will skip the response logging step.", e);
             }
         } else {
-            log.trace("Unable to log response: ResponseProcessingStage is null");
+            log.warn("Unable to log response: ResponseProcessingStage is null. Will skip the response logging step.");
         }
     }
 

--- a/logbook-okhttp2/src/main/java/org/zalando/logbook/okhttp2/LogbookInterceptor.java
+++ b/logbook-okhttp2/src/main/java/org/zalando/logbook/okhttp2/LogbookInterceptor.java
@@ -36,7 +36,7 @@ public final class LogbookInterceptor implements Interceptor {
         try {
             stage = logbook.process(request).write();
         } catch (Exception e) {
-            log.trace("Unable to log request: {}", e.getClass());
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
         }
         return stage;
     }
@@ -46,10 +46,10 @@ public final class LogbookInterceptor implements Interceptor {
             try {
                 stage.process(response).write();
             } catch (Exception e) {
-                log.trace("Unable to log response: {}", e.getClass());
+                log.warn("Unable to log response. Will skip the response logging step.", e);
             }
         } else {
-            log.trace("Unable to log response: ResponseProcessingStage is null");
+            log.warn("Unable to log response: ResponseProcessingStage is null. Will skip the response logging step.");
         }
     }
 

--- a/logbook-okhttp2/src/main/java/org/zalando/logbook/okhttp2/LogbookInterceptor.java
+++ b/logbook-okhttp2/src/main/java/org/zalando/logbook/okhttp2/LogbookInterceptor.java
@@ -3,7 +3,9 @@ package org.zalando.logbook.okhttp2;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.Response;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
+import org.jetbrains.annotations.Nullable;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
@@ -13,6 +15,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 @API(status = EXPERIMENTAL)
 @AllArgsConstructor
+@Slf4j
 public final class LogbookInterceptor implements Interceptor {
 
     private final Logbook logbook;
@@ -20,11 +23,34 @@ public final class LogbookInterceptor implements Interceptor {
     @Override
     public Response intercept(final Chain chain) throws IOException {
         final LocalRequest request = new LocalRequest(chain.request());
-        final ResponseProcessingStage stage = logbook.process(request).write();
+        final ResponseProcessingStage stage = logRequest(request);
         final RemoteResponse response = new RemoteResponse(chain.proceed(request.toRequest()));
-        stage.process(response).write();
+        logResponse(stage, response);
 
         return response.toResponse();
+    }
+
+    @Nullable
+    private ResponseProcessingStage logRequest(LocalRequest request) {
+        ResponseProcessingStage stage = null;
+        try {
+            stage = logbook.process(request).write();
+        } catch (Exception e) {
+            log.trace("Unable to log request: {}", e.getClass());
+        }
+        return stage;
+    }
+
+    private static void logResponse(@Nullable final Logbook.ResponseProcessingStage stage, final RemoteResponse response) {
+        if (stage != null) {
+            try {
+                stage.process(response).write();
+            } catch (Exception e) {
+                log.trace("Unable to log response: {}", e.getClass());
+            }
+        } else {
+            log.trace("Unable to log response: ResponseProcessingStage is null");
+        }
     }
 
 }

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptor.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptor.java
@@ -35,7 +35,7 @@ public final class LogbookClientHttpRequestInterceptor implements ClientHttpRequ
             final org.zalando.logbook.HttpRequest httpRequest = new LocalRequest(request, body);
             stage = logbook.process(httpRequest).write();
         } catch (Exception e) {
-            log.trace("Unable to log request: {}", e.getClass());
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
         }
         return stage;
     }
@@ -46,10 +46,10 @@ public final class LogbookClientHttpRequestInterceptor implements ClientHttpRequ
                 final RemoteResponse httpResponse = new RemoteResponse(response);
                 stage.process(httpResponse).write();
             } catch (Exception e) {
-                log.trace("Unable to log response: {}", e.getClass());
+                log.warn("Unable to log response. Will skip the response logging step.", e);
             }
         } else {
-            log.trace("Unable to log response: ResponseProcessingStage is null");
+            log.warn("Unable to log response: ResponseProcessingStage is null. Will skip the response logging step.");
         }
     }
 }

--- a/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptor.java
+++ b/logbook-spring/src/main/java/org/zalando/logbook/spring/LogbookClientHttpRequestInterceptor.java
@@ -1,32 +1,55 @@
 package org.zalando.logbook.spring;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Logbook;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 @API(status = API.Status.EXPERIMENTAL)
 @AllArgsConstructor
+@Slf4j
 public final class LogbookClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private final Logbook logbook;
 
     @Override
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
-        final org.zalando.logbook.HttpRequest httpRequest = new LocalRequest(request, body);
-        final Logbook.ResponseProcessingStage stage = logbook.process(httpRequest).write();
-
-        ClientHttpResponse response = new BufferingClientHttpResponseWrapper(execution.execute(request, body));
-
-        final HttpResponse httpResponse = new RemoteResponse(response);
-        stage.process(httpResponse).write();
+        final Logbook.ResponseProcessingStage stage = logRequest(request, body);
+        final ClientHttpResponse response = new BufferingClientHttpResponseWrapper(execution.execute(request, body));
+        logResponse(stage, response);
 
         return response;
+    }
+
+    @Nullable
+    private Logbook.ResponseProcessingStage logRequest(HttpRequest request, byte[] body) {
+        Logbook.ResponseProcessingStage stage = null;
+        try {
+            final org.zalando.logbook.HttpRequest httpRequest = new LocalRequest(request, body);
+            stage = logbook.process(httpRequest).write();
+        } catch (Exception e) {
+            log.trace("Unable to log request: {}", e.getClass());
+        }
+        return stage;
+    }
+
+    private static void logResponse(@Nullable final Logbook.ResponseProcessingStage stage, final ClientHttpResponse response) {
+        if (stage != null) {
+            try {
+                final RemoteResponse httpResponse = new RemoteResponse(response);
+                stage.process(httpResponse).write();
+            } catch (Exception e) {
+                log.trace("Unable to log response: {}", e.getClass());
+            }
+        } else {
+            log.trace("Unable to log response: ResponseProcessingStage is null");
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change introduces 2 different fallback mechanisms (possible overlapping): 
- in httpclient(5), okhttp(2) and spring interceptors. Where in case of exceptions, logbook will fall back to noop stage and will not fail the overall request/response processing by an application
- in `DefaultLogbook`.  Where request stage preparing method (`RequestWritingStage process(final HttpRequest originalRequest, final Strategy strategy)`), as well as request writing and response write methods of the `DefaultRequestWritingStage` (new inner class) will be intercepting all `RuntimeExceptions` and will not fail the request processing. This approach may be sufficient to cover the cases of library dependent interceptors.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As of now, when Logbook is causing RuntimeExceptions, it affects not only the ability to write the request/response logs, but prevents clients from operating normally. This should not be the case.

Related issues: https://github.com/zalando/logbook/issues/1693, https://github.com/zalando/logbook/issues/1702

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
