### PR TITLE
Bump json-path to 2.9.0 to address CVE-2023-51074

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -18,5 +18,8 @@
 
         <!-- vulnerability is in reserved state. No mitigation has been released yet -->
         <cve>CVE-2023-4586</cve>
+
+        <!-- fixed with json-path 2.9.0 but is still reported. Suppressing as false positive -->
+        <cve>CVE-2023-51074</cve>
     </suppress>
 </suppressions>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -29,7 +29,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jackson.version>2.16.0</jackson.version>
-        <json-path.version>2.8.0</json-path.version>
+        <json-path.version>2.9.0</json-path.version>
         <kotlin.version>1.9.21</kotlin.version>
         <ktor.version>2.3.7</ktor.version>
         <netty.version>4.1.101.Final</netty.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bump json-path to 2.9.0



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
json-path v2.8.0 was discovered to contain a stack overflow via the Criteria.parse() method ([CVE-2023-51074](https://github.com/advisories/GHSA-pfh2-hfmq-phg5))


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
