### PR TITLE
feat(logbook-spring-boot-autoconfigure): header include/exclude filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,11 +1051,15 @@ logbook:
          - GET
          - POST
       - path: /actuator/**
+      - headers:
+          host: api-gateway
     exclude:
       - path: /actuator/health
       - path: /api/admin/**
         methods: 
          - POST
+      - headers:
+          host: localhost
   filter.enabled: true
   secure-filter.enabled: true
   format.style: http

--- a/README.md
+++ b/README.md
@@ -1059,7 +1059,7 @@ logbook:
         methods: 
          - POST
       - headers:
-          host: localhost
+          host: *
   filter.enabled: true
   secure-filter.enabled: true
   format.style: http

--- a/logbook-core/src/main/java/org/zalando/logbook/core/Conditions.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/Conditions.java
@@ -100,8 +100,8 @@ public final class Conditions {
             @Nonnull final String key,
             final String value) {
 
-        if (Objects.isNull(value)){
-            return withoutHeader(key);
+        if ("*".equals(value)){
+            return header(key, $ -> true);
         }
         return header(key, value);
     }

--- a/logbook-core/src/main/java/org/zalando/logbook/core/Conditions.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/Conditions.java
@@ -7,8 +7,10 @@ import org.zalando.logbook.RequestURI;
 import org.zalando.logbook.common.Glob;
 import org.zalando.logbook.common.MediaTypeQuery;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -92,6 +94,16 @@ public final class Conditions {
 
     public static <T extends HttpMessage> Predicate<T> withoutHeader(final String key) {
         return message -> !message.getHeaders().containsKey(key);
+    }
+
+    public static <T extends HttpRequest> Predicate<T> conditionalHeader(
+            @Nonnull final String key,
+            final String value) {
+
+        if (Objects.isNull(value)){
+            return withoutHeader(key);
+        }
+        return header(key, value);
     }
 
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/core/ConditionsTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/ConditionsTest.java
@@ -195,9 +195,10 @@ final class ConditionsTest {
 
     @Test
     void matchesConditionalHeaderWithoutHeader() {
-        final MockHttpRequest request = this.request;
+        final MockHttpRequest request = this.request
+                .withHeaders(HttpHeaders.of("Authorization", "anything"));
 
-        final Predicate<HttpRequest> unit = conditionalHeader("Authorization", null);
+        final Predicate<HttpRequest> unit = conditionalHeader("Authorization", "*");
 
         assertThat(unit.test(request)).isTrue();
     }

--- a/logbook-core/src/test/java/org/zalando/logbook/core/ConditionsTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/ConditionsTest.java
@@ -10,13 +10,7 @@ import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.zalando.logbook.core.Conditions.contentType;
-import static org.zalando.logbook.core.Conditions.exclude;
-import static org.zalando.logbook.core.Conditions.header;
-import static org.zalando.logbook.core.Conditions.requestTo;
-import static org.zalando.logbook.core.Conditions.requestWithMethod;
-import static org.zalando.logbook.core.Conditions.withoutContentType;
-import static org.zalando.logbook.core.Conditions.withoutHeader;
+import static org.zalando.logbook.core.Conditions.*;
 
 final class ConditionsTest {
 
@@ -185,6 +179,35 @@ final class ConditionsTest {
                 .withHeaders(HttpHeaders.of("Authorization", ""));
 
         final Predicate<HttpMessage> unit = withoutHeader("Authorization");
+
+        assertThat(unit.test(request)).isFalse();
+    }
+
+    @Test
+    void matchesConditionalHeader() {
+        final MockHttpRequest request = this.request
+                .withHeaders(HttpHeaders.of("Authorization", "authorization"));
+
+        final Predicate<HttpRequest> unit = conditionalHeader("Authorization", "authorization");
+
+        assertThat(unit.test(request)).isTrue();
+    }
+
+    @Test
+    void matchesConditionalHeaderWithoutHeader() {
+        final MockHttpRequest request = this.request;
+
+        final Predicate<HttpRequest> unit = conditionalHeader("Authorization", null);
+
+        assertThat(unit.test(request)).isTrue();
+    }
+
+    @Test
+    void doesNotMatchConditionalHeader() {
+        final MockHttpRequest request = this.request
+                .withHeaders(HttpHeaders.of("Authorization", "auth"));
+
+        final Predicate<HttpRequest> unit = conditionalHeader("Authorization", "authorization");
 
         assertThat(unit.test(request)).isFalse();
     }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookProperties.java
@@ -13,7 +13,9 @@ import org.zalando.logbook.servlet.FormRequestMode;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
@@ -94,6 +96,6 @@ public final class LogbookProperties {
     public static class LogbookPredicate {
         private String path;
         private List<String> methods = new ArrayList<>();
+        private Map<String, String> headers = new HashMap<>();
     }
-
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/IncludeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/IncludeTest.java
@@ -4,15 +4,17 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.verification.VerificationMode;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.zalando.logbook.HttpRequest;
-import org.zalando.logbook.Logbook;
+import org.zalando.logbook.*;
 import org.zalando.logbook.test.MockHttpRequest;
 
 import java.io.IOException;
@@ -21,89 +23,176 @@ import java.util.function.Predicate;
 
 import static ch.qos.logback.classic.Level.TRACE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.zalando.logbook.core.Conditions.exclude;
-import static org.zalando.logbook.core.Conditions.requestTo;
+import static org.mockito.Mockito.*;
+import static org.zalando.logbook.core.Conditions.*;
 
-@LogbookTest(profiles = "include", imports = IncludeTest.Config.class)
 class IncludeTest {
 
-    private final Logger logger = (Logger) LoggerFactory.getLogger(Logbook.class);
+    @Nested
+    @LogbookTest(profiles = "include", imports = IncludeTest.PathConfig.class)
+    class IncludePathTest {
 
-    private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-    private final List<ILoggingEvent> logsList = listAppender.list;
+        private final Logger logger = (Logger) LoggerFactory.getLogger(Logbook.class);
 
-    {
-        logger.setLevel(TRACE);
-        listAppender.start();
-        logger.addAppender(listAppender);
-    }
+        private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        private final List<ILoggingEvent> logsList = listAppender.list;
 
-    @TestConfiguration
-    public static class Config {
-        @Bean
-        public Predicate<HttpRequest> condition() {
-            return exclude(requestTo("/api/admin/**"));
+        {
+            logger.setLevel(TRACE);
+            listAppender.start();
+            logger.addAppender(listAppender);
         }
+
+        @Autowired
+        private Logbook logbook;
+
+        @BeforeEach
+        void setUp() {
+            logsList.clear();
+        }
+
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "'/api/admin', 'GET', false",
+                "'/api/admin/users', 'GET', false",
+                "'/internal-api', 'GET', false",
+                "'/internal-api/users', 'GET', false",
+                "'/api', 'GET', true",
+                "'/api/users', 'GET', true",
+                "'/another-api', 'GET', true",
+                "'/another-api', 'PUT', true",
+                "'/another-api', 'POST', true",
+                "'/another-api', 'DELETE', true",
+                "'/yet-another-api', 'DELETE', true",
+                "'/yet-another-api', 'PUT', true",
+                "'/yet-another-api', 'GET', false",
+                "'/yet-another-api', 'POST', false",
+                "'/api', 'DELETE', true",
+                "'/api', 'PUT', true",
+
+        })
+        void shouldExcludeExpectedRequests(String path, String method, boolean shouldLog) throws IOException {
+            logbook.process(request(path).withMethod(method)).write();
+
+            assertThat(logsList).hasSize(shouldLog ? 1 : 0);
+        }
+
+        @Test
+        void shouldExcludeAdminWithQueryParameters() throws IOException {
+            logbook.process(request("/api/admin").withQuery("debug=true")).write();
+
+            assertThat(logsList).isEmpty();
+        }
+
+        @Test
+        void shouldExcludeInternalApiWithQueryParameters() throws IOException {
+            logbook.process(request("/internal-api").withQuery("debug=true")).write();
+
+            assertThat(logsList).isEmpty();
+        }
+
+        @Test
+        void shouldNotExcludeApiWithParameter() throws IOException {
+            logbook.process(request("/api").withQuery("debug=true")).write();
+
+            assertThat(logsList).hasSize(1);
+        }
+
     }
 
-    @Autowired
-    private Logbook logbook;
+    @Nested
+    @LogbookTest(imports = IncludeTest.HeaderConfig.class)
+    class IncludeHeaderTest {
 
-    @BeforeEach
-    void setUp() {
-        logsList.clear();
+        @Autowired
+        private Logbook logbook;
+
+        @MockBean
+        private HttpLogWriter writer;
+
+        @BeforeEach
+        void setUp() {
+            doReturn(true).when(writer).isActive();
+        }
+
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "'host', 'localhost', true",
+                "'host', '127.0.0.1', false",
+                "'host', '', false",
+                "'localhost', 'localhost', false",
+        })
+        void shouldExcludeExpectedRequests(String key, String value, boolean shouldLog) throws IOException {
+            logbook.process(request("/api").withHeaders(HttpHeaders.of(key, value))).write();
+
+            VerificationMode verificationMode = shouldLog ? atLeastOnce() : never();
+
+            verify(writer, verificationMode).write(any(Precorrelation.class), any());
+        }
+
     }
 
+    @Nested
+    @LogbookTest(imports = IncludeTest.WildcardHeaderConfig.class)
+    class IncludeWildcardHeaderTest {
 
-    @ParameterizedTest
-    @CsvSource(value = {
-            "'/api/admin', 'GET', false",
-            "'/api/admin/users', 'GET', false",
-            "'/internal-api', 'GET', false",
-            "'/internal-api/users', 'GET', false",
-            "'/api', 'GET', true",
-            "'/api/users', 'GET', true",
-            "'/another-api', 'GET', true",
-            "'/another-api', 'PUT', true",
-            "'/another-api', 'POST', true",
-            "'/another-api', 'DELETE', true",
-            "'/yet-another-api', 'DELETE', true",
-            "'/yet-another-api', 'PUT', true",
-            "'/yet-another-api', 'GET', false",
-            "'/yet-another-api', 'POST', false",
-            "'/api', 'DELETE', true",
-            "'/api', 'PUT', true",
+        @Autowired
+        private Logbook logbook;
 
-    })
-    void shouldExcludeExpectedRequests(String path, String method, boolean shouldLog) throws IOException {
-        logbook.process(request(path).withMethod(method)).write();
+        @MockBean
+        private HttpLogWriter writer;
 
-        assertThat(logsList).hasSize(shouldLog ? 1 : 0);
-    }
+        @BeforeEach
+        void setUp() {
+            doReturn(true).when(writer).isActive();
+        }
 
-    @Test
-    void shouldExcludeAdminWithQueryParameters() throws IOException {
-        logbook.process(request("/api/admin").withQuery("debug=true")).write();
 
-        assertThat(logsList).isEmpty();
-    }
+        @ParameterizedTest
+        @CsvSource(value = {
+                "'host', 'localhost', true",
+                "'host', '127.0.0.1', true",
+                "'host', '', true",
+                "'hosts', 'localhost', false",
+                "'hosts', '', false",
+        })
+        void shouldExcludeExpectedRequests(String key, String value, boolean shouldLog) throws IOException {
+            logbook.process(request("/api").withHeaders(HttpHeaders.of(key, value))).write();
 
-    @Test
-    void shouldExcludeInternalApiWithQueryParameters() throws IOException {
-        logbook.process(request("/internal-api").withQuery("debug=true")).write();
+            VerificationMode verificationMode = shouldLog ? atLeastOnce() : never();
 
-        assertThat(logsList).isEmpty();
-    }
+            verify(writer, verificationMode).write(any(Precorrelation.class), any());
+        }
 
-    @Test
-    void shouldNotExcludeApiWithParameter() throws IOException {
-        logbook.process(request("/api").withQuery("debug=true")).write();
-
-        assertThat(logsList).hasSize(1);
     }
 
     private MockHttpRequest request(final String path) {
         return MockHttpRequest.create().withPath(path);
     }
 
+    @TestConfiguration
+    public static class PathConfig {
+        @Bean
+        public Predicate<HttpRequest> condition() {
+            return exclude(requestTo("/api/admin/**"));
+        }
+    }
+
+    @TestConfiguration
+    public static class HeaderConfig {
+        @Bean
+        public Predicate<HttpRequest> condition() {
+            return conditionalHeader("host", "localhost");
+        }
+    }
+
+    @TestConfiguration
+    static class WildcardHeaderConfig {
+        @Bean
+        public Predicate<HttpRequest> requestCondition() {
+            return conditionalHeader("host", "*");
+        }
+    }
 }

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/IncludeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/IncludeTest.java
@@ -124,7 +124,7 @@ class IncludeTest {
                 "'host', '', false",
                 "'localhost', 'localhost', false",
         })
-        void shouldExcludeExpectedRequests(String key, String value, boolean shouldLog) throws IOException {
+        void shouldIncludeExpectedRequests(String key, String value, boolean shouldLog) throws IOException {
             logbook.process(request("/api").withHeaders(HttpHeaders.of(key, value))).write();
 
             VerificationMode verificationMode = shouldLog ? atLeastOnce() : never();
@@ -158,7 +158,7 @@ class IncludeTest {
                 "'hosts', 'localhost', false",
                 "'hosts', '', false",
         })
-        void shouldExcludeExpectedRequests(String key, String value, boolean shouldLog) throws IOException {
+        void shouldIncludeExpectedRequests(String key, String value, boolean shouldLog) throws IOException {
             logbook.process(request("/api").withHeaders(HttpHeaders.of(key, value))).write();
 
             VerificationMode verificationMode = shouldLog ? atLeastOnce() : never();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added header filtering capability to `logbook-spring-boot-autoconfigure` module.

## Description
<!--- Describe your changes in detail -->
Added header filtering capability to `logbook-spring-boot-autoconfigure` module for spring-boot autoconfiguration.
Example of usage:
```
logbook.predicate.exclude[0].path=/actuator/**
logbook.predicate.exclude[1].headers.host=localhost
```
This configuration will create predicate that will log requests that wont contain `/actuator/**` path in url or 
header with key `host` and value `localhost`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'd like to filter out some request/response logs by header values.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
