### PR TITLE
issues/1821 retrieve content-type from Ktor's OutgoingContent

### DIFF
--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
@@ -38,8 +38,8 @@ internal class ClientRequest(
         )
     }
 
-    override fun getContentType(): String? = request.contentType()?.let { it.toString().substringBefore(";") }
-        ?: (request.body as? OutgoingContent)?.contentType?.toString()
+    override fun getContentType(): String? = (request.contentType() ?: (request.body as? OutgoingContent)?.contentType)
+            ?.let { it.toString().substringBefore(";") }
     override fun getCharset(): Charset = request.charset() ?: UTF_8
     override fun getRemote(): String = "localhost"
     override fun getMethod(): String = request.method.value

--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
@@ -20,7 +20,7 @@ import org.zalando.logbook.HttpRequest
 import org.zalando.logbook.Origin
 import org.zalando.logbook.common.State
 import java.nio.charset.Charset
-import java.util.*
+import java.util.Optional
 import java.util.concurrent.atomic.AtomicReference
 
 internal class ClientRequest(

--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
@@ -9,17 +9,19 @@ import io.ktor.client.request.host
 import io.ktor.client.request.port
 import io.ktor.http.HttpProtocolVersion.Companion.HTTP_1_1
 import io.ktor.http.charset
+import io.ktor.http.content.OutgoingContent
 import io.ktor.http.contentType
 import io.ktor.http.encodedPath
 import io.ktor.util.toMap
+import kotlin.text.Charsets.UTF_8
+import org.zalando.logbook.ContentType.CONTENT_TYPE_HEADER
 import org.zalando.logbook.HttpHeaders
 import org.zalando.logbook.HttpRequest
 import org.zalando.logbook.Origin
 import org.zalando.logbook.common.State
 import java.nio.charset.Charset
-import java.util.Optional
+import java.util.*
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.text.Charsets.UTF_8
 
 internal class ClientRequest(
     private val request: HttpRequestBuilder,
@@ -28,8 +30,16 @@ internal class ClientRequest(
 
     override fun getProtocolVersion(): String = HTTP_1_1.toString()
     override fun getOrigin(): Origin = Origin.LOCAL
-    override fun getHeaders(): HttpHeaders = HttpHeaders.of(request.headers.build().toMap())
+    override fun getHeaders(): HttpHeaders = HttpHeaders.of(request.headers.build().toMap()).also {
+        // as Ktor removes the Content-Type header from the headers in the default transformers we need to add it back
+        // https://github.com/ktorio/ktor/blob/e789b015bd5169505df1c59ced0d2690026af523/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/DefaultTransform.kt#L55
+        if (it.contains(CONTENT_TYPE_HEADER).not() && request.body is OutgoingContent) return it.update(
+            CONTENT_TYPE_HEADER, (request.body as OutgoingContent).contentType?.toString()
+        )
+    }
+
     override fun getContentType(): String? = request.contentType()?.let { it.toString().substringBefore(";") }
+        ?: (request.body as? OutgoingContent)?.contentType?.toString()
     override fun getCharset(): Charset = request.charset() ?: UTF_8
     override fun getRemote(): String = "localhost"
     override fun getMethod(): String = request.method.value

--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/LogbookClient.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/LogbookClient.kt
@@ -9,7 +9,6 @@ import io.ktor.client.plugins.HttpClientPlugin
 import io.ktor.client.plugins.observer.wrapWithContent
 import io.ktor.client.request.HttpSendPipeline
 import io.ktor.client.statement.HttpReceivePipeline
-import io.ktor.http.content.ByteArrayContent
 import io.ktor.http.content.OutgoingContent
 import io.ktor.util.AttributeKey
 import io.ktor.util.InternalAPI
@@ -42,18 +41,15 @@ class LogbookClient(
             scope.sendPipeline.intercept(HttpSendPipeline.Monitoring) {
                 val request = ClientRequest(context)
                 val requestWritingStage = plugin.logbook.process(request)
-                val proceedWith = when {
-                    request.shouldBuffer() -> {
-                        val content = (it as OutgoingContent).readBytes(scope)
-                        request.buffer(content)
-                        ByteArrayContent(content)
-                    }
 
-                    else -> it
+                if (request.shouldBuffer()) {
+                    val content = (it as OutgoingContent).readBytes(scope)
+                    request.buffer(content)
                 }
+
                 val responseStage = requestWritingStage.write()
                 context.attributes.put(responseProcessingStageKey, responseStage)
-                proceedWith(proceedWith)
+                proceedWith(it)
             }
 
             scope.receivePipeline.intercept(HttpReceivePipeline.After) { httpResponse ->

--- a/logbook-ktor-client/src/test/kotlin/org/zalando/logbook/client/ClientRequestUnitTest.kt
+++ b/logbook-ktor-client/src/test/kotlin/org/zalando/logbook/client/ClientRequestUnitTest.kt
@@ -1,10 +1,13 @@
 package org.zalando.logbook.client
 
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.setBody
 import io.ktor.http.HttpHeaders
+import io.ktor.http.content.OutgoingContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.text.Charsets.US_ASCII
+import org.zalando.logbook.ContentType.CONTENT_TYPE_HEADER
 
 internal class ClientRequestUnitTest {
 
@@ -16,5 +19,21 @@ internal class ClientRequestUnitTest {
         val request = ClientRequest(req)
         assertThat(request.contentType).isEqualTo("application/json")
         assertThat(request.charset).isEqualTo(US_ASCII)
+    }
+
+    @Test
+    fun `should get content type from request body if not present in headers`() {
+        val req = HttpRequestBuilder().apply {
+            setBody(
+                object : OutgoingContent.ByteArrayContent() {
+                    override val contentType = io.ktor.http.ContentType.Application.Json
+                    override val contentLength = 0L
+                    override fun bytes() = ByteArray(0)
+                }
+            )
+        }
+        val request = ClientRequest(req)
+        assertThat(request.contentType).isEqualTo("application/json")
+        assertThat(request.headers.getFirst(CONTENT_TYPE_HEADER)).isEqualTo("application/json")
     }
 }

--- a/logbook-ktor-client/src/test/kotlin/org/zalando/logbook/client/LogbookClientTest.kt
+++ b/logbook-ktor-client/src/test/kotlin/org/zalando/logbook/client/LogbookClientTest.kt
@@ -1,5 +1,6 @@
 package org.zalando.logbook.client
 
+import io.ktor.server.application.Application
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
@@ -8,6 +9,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.contentType
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
@@ -54,17 +56,7 @@ internal class LogbookClientTest {
         }
     }
 
-    private val server = embeddedServer(CIO, port = port) {
-        routing {
-            post("/echo") {
-                call.respondText(call.receiveText())
-            }
-            post("/discard") {
-                call.receiveText()
-                call.respond(HttpStatusCode.OK)
-            }
-        }
-    }
+    private val server = embeddedServer(CIO, port = port, module = Application::stubApplicationModule)
 
     @BeforeEach
     internal fun setUp() {
@@ -162,6 +154,22 @@ internal class LogbookClientTest {
         }
     }
 
+    @Test
+    fun `should preserve Content-Type header`() {
+        sendAndReceive {
+            body = """{"property": "value"}"""
+            headers[org.zalando.logbook.ContentType.CONTENT_TYPE_HEADER] = "application/json"
+        }
+
+        val capturedRequest = captureRequest()
+        assertThat(capturedRequest)
+            .contains("Content-Type: application/json")
+
+        val capturedResponse = captureResponse()
+        assertThat(capturedResponse)
+            .contains("Content-Type: application/json")
+    }
+
     private fun sendAndReceive(uri: String = "/echo", block: HttpRequestBuilder.() -> Unit = {}): String {
         return runBlocking {
             client.post(urlString = "http://localhost:$port$uri") {
@@ -182,5 +190,17 @@ internal class LogbookClientTest {
             .forClass(String::class.java)
             .apply { verify(writer, timeout(1_000)).write(any(Correlation::class.java), capture()) }
             .value
+    }
+}
+
+fun Application.stubApplicationModule() {
+    routing {
+        post("/echo") {
+            call.respondText(call.receiveText(), call.request.contentType())
+        }
+        post("/discard") {
+            call.receiveText()
+            call.respond(HttpStatusCode.OK)
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding a logic to Ktor's ClientRequest class to retrieve `Content-Type` from `OutgoingContent` object, if it's not present in the request headers.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

addresses #1821

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
