### PR TITLE
issues/1823 use full content type in Ktor's ServerRequest

### DIFF
--- a/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/ServerRequest.kt
+++ b/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/ServerRequest.kt
@@ -29,7 +29,7 @@ internal class ServerRequest(
     override fun getProtocolVersion(): String = request.httpVersion
     override fun getOrigin(): Origin = Origin.REMOTE
     override fun getHeaders(): HttpHeaders = HttpHeaders.of(request.headers.toMap())
-    override fun getContentType(): String? = request.contentType?.contentType
+    override fun getContentType(): String? = request.contentType?.toString()
     override fun getCharset(): Charset = request.contentType?.charset() ?: UTF_8
     override fun getRemote(): String = request.local.remoteHost
     override fun getMethod(): String = request.httpMethod.value

--- a/logbook-ktor-server/src/test/kotlin/org/zalando/logbook/server/ServerRequestTest.kt
+++ b/logbook-ktor-server/src/test/kotlin/org/zalando/logbook/server/ServerRequestTest.kt
@@ -1,0 +1,24 @@
+package org.zalando.logbook.server
+
+import io.ktor.http.HeadersImpl
+import io.ktor.http.HttpHeaders
+import io.ktor.server.request.ApplicationRequest
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class ServerRequestTest {
+
+    @Test
+    fun `Should return content type`() {
+        val applicationRequest = mock(ApplicationRequest::class.java)
+        `when`(applicationRequest.headers)
+                .thenReturn(HeadersImpl(mapOf(HttpHeaders.ContentType to listOf("application/json"))))
+
+        val req = ServerRequest(applicationRequest)
+
+        Assertions.assertThat(req.contentType)
+                .isEqualTo("application/json")
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ktor's ServerRequest was getting only the `type` part of the [ContentType](https://github.com/ktorio/ktor/blob/d5ae8e5641dea582fbe5ebb52577e7bdad2f5ad8/ktor-http/common/src/io/ktor/http/ContentTypes.kt#L15-L16), leaving the subtype out, while the subtype is needed by other Logbook components (e.g. json filters). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

addresses #1823 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
