### PR TITLE
Improve performance of query filters (especially on large bodies)

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/core/QueryFilters.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/QueryFilters.java
@@ -3,12 +3,13 @@ package org.zalando.logbook.core;
 import org.apiguardian.api.API;
 import org.zalando.logbook.QueryFilter;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.compile;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -45,7 +46,6 @@ public final class QueryFilters {
         return replaceQuery(name::equals, replacementFunction);
     }
 
-
     @API(status = EXPERIMENTAL)
     public static QueryFilter replaceQuery(
             final Predicate<String> predicate, final String replacement) {
@@ -57,55 +57,54 @@ public final class QueryFilters {
     public static QueryFilter replaceQuery(
             final Predicate<String> predicate, final UnaryOperator<String> replacementFunction) {
 
-        final Pattern pattern = compile("(?<name>[^&]*?)=(?<value>[^&]*)");
+        return query -> processParsedQueryParams(query, (String paramName, String paramValue) -> {
+            if (paramValue == null) {
+                return paramName;
+            } else {
+                String newValue = predicate.test(paramName) ? replacementFunction.apply(paramValue) : paramValue;
 
-        return query -> {
-            final Matcher matcher = pattern.matcher(query);
-            final StringBuffer result = new StringBuffer(query.length());
-
-            while (matcher.find()) {
-                if (predicate.test(matcher.group("name"))) {
-                    matcher.appendReplacement(result, "${name}");
-                    result.append('=');
-                    result.append(replacementFunction.apply(matcher.group("value")));
-                } else {
-                    matcher.appendReplacement(result, "$0");
-                }
+                return paramName + "=" + newValue;
             }
-            matcher.appendTail(result);
-
-            return result.toString();
-        };
+        });
     }
 
     @API(status = EXPERIMENTAL)
     public static QueryFilter removeQuery(final String name) {
         final Predicate<String> predicate = name::equals;
-        final Pattern pattern = compile("&?(?<name>[^&]+?)=(?:[^&]*)");
 
-        return query -> {
-            final Matcher matcher = pattern.matcher(query);
-            final StringBuffer result = new StringBuffer(query.length());
-
-            while (matcher.find()) {
-                if (predicate.test(matcher.group("name"))) {
-                    matcher.appendReplacement(result, "");
-                } else {
-                    matcher.appendReplacement(result, "$0");
-                }
+        return query -> processParsedQueryParams(query, (String paramName, String paramValue) -> {
+            if (predicate.test(paramName)) {
+                return null; // indicate removal
+            } else {
+                return paramName + "=" + paramValue;
             }
-            matcher.appendTail(result);
-
-            final String output = result.toString();
-
-            if (output.startsWith("&")) {
-                // ideally this case would be covered by the regex, but
-                // I wasn't able to make it work
-                return output.substring(1);
-            }
-
-            return output;
-        };
+        });
     }
 
+    private static String processParsedQueryParams(String query, BiFunction<String, String, String> nameValueHandler) {
+        final List<String> result = new ArrayList<>();
+
+        // see https://url.spec.whatwg.org/#urlencoded-parsing
+        StringTokenizer tokenizer = new StringTokenizer(query, "&");
+        while (tokenizer.hasMoreTokens()) {
+            String token = tokenizer.nextToken();
+            int equalsIndex = token.indexOf('=');
+
+            // a token does not always contain an '=', if not the token is the name
+            String newParam;
+            if (equalsIndex == -1) {
+                newParam = nameValueHandler.apply(token, null);
+            } else {
+                String name = token.substring(0, equalsIndex);
+                String value = token.substring(equalsIndex + 1);
+                newParam = nameValueHandler.apply(name, value);
+            }
+
+            if (newParam != null) {
+                result.add(newParam);
+            }
+        }
+
+        return String.join("&", result);
+    }
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/core/QueryFiltersTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/QueryFiltersTest.java
@@ -37,6 +37,9 @@ final class QueryFiltersTest {
             "active&name=Alice,active&name=XXX",
             "name=Alice&active&age=5,name=XXX&active&age=5",
             "name=Alice&secret=123,name=XXX&secret=XXX",
+            "secret&name,secret&name",
+            "=secret&=name,=secret&=name",
+            "secret=&name=,secret=XXX&name=XXX",
     })
     @ParameterizedTest
     void shouldReplaceMatchingQueryParameters(
@@ -57,6 +60,7 @@ final class QueryFiltersTest {
             "sort=price&q=boots&direction=asc,sort=price&direction=asc",
             "sort=price&direction=asc,sort=price&direction=asc",
             "q=boots&test=true&q=boots,test=true",
+            "q&q=1&q=2&q=3&test=true&q=4&q=5,'test=true'",
             "q=1&q=2&q=3,''",
             "'',''"
     })


### PR DESCRIPTION
Fixes: #1838

<!--- Provide a general summary of your changes in the Title above -->
Rewrite two `QueryFilter`s with an implementation based on `StringTokenizer` rather than a possible `O(n^2)` regex (for more information see the linked issue).

## Description
I've looked at the description for a `application/x-www-form-urlencoded` encoded body here: https://url.spec.whatwg.org/#urlencoded-parsing and tried to follow those lines. I did *not* put in the percentage encoding, since that wasn't in the current implementation and I didn't want to break backwards compatibility.

I've added a few test cases that weren't covered (and also not all handled correctly in the previous implementation), but I think they are rather obscure. Where normally you have `key=value`, it's also possible to just have `key`, if there is no `=` there, `key` is treated as the key and there is no value. Also `key=` and `=value` are allowed even, resulting in an empty key or empty value respectively. 

## Motivation and Context
Fixes #1838 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
