### PR TITLE
Fix for #1868 - make State subclasses real classes

### DIFF
--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientRequest.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference
 internal class ClientRequest(
     private val request: HttpRequestBuilder,
 ) : HttpRequest {
-    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered)
+    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered())
 
     override fun getProtocolVersion(): String = HTTP_1_1.toString()
     override fun getOrigin(): Origin = Origin.LOCAL

--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientResponse.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/ClientResponse.kt
@@ -19,7 +19,7 @@ import io.ktor.client.statement.HttpResponse as KtorResponse
 internal class ClientResponse(
     private val response: KtorResponse,
 ) : HttpResponse {
-    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered)
+    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered())
 
     override fun getProtocolVersion(): String = response.version.toString()
     override fun getOrigin(): Origin = Origin.REMOTE

--- a/logbook-ktor-client/src/test/kotlin/org/zalando/logbook/client/LogbookClientWithSinkTest.kt
+++ b/logbook-ktor-client/src/test/kotlin/org/zalando/logbook/client/LogbookClientWithSinkTest.kt
@@ -1,0 +1,126 @@
+package org.zalando.logbook.client
+
+import io.ktor.server.application.Application
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.post
+import io.ktor.http.*
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.contentType
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.util.InternalAPI
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.zalando.logbook.Correlation
+import org.zalando.logbook.HttpLogWriter
+import org.zalando.logbook.HttpRequest
+import org.zalando.logbook.HttpResponse
+import org.zalando.logbook.Logbook
+import org.zalando.logbook.Precorrelation
+import org.zalando.logbook.Sink
+import org.zalando.logbook.common.ExperimentalLogbookKtorApi
+import org.zalando.logbook.core.DefaultHttpLogFormatter
+import org.zalando.logbook.core.DefaultSink
+import org.zalando.logbook.test.TestStrategy
+import kotlin.math.sin
+
+@ExperimentalLogbookKtorApi
+@OptIn(InternalAPI::class)
+internal class LogbookClientWithSinkTest {
+
+    private val port = 8080
+    private val sink = mock(Sink::class.java)
+
+    private val testLogbook: Logbook = Logbook
+        .builder()
+        .strategy(TestStrategy())
+        .sink(sink)
+        .build()
+
+    private val client = HttpClient {
+        install(LogbookClient) {
+            logbook = testLogbook
+        }
+    }
+
+    private val server = embeddedServer(CIO, port = port, module = Application::stubApplicationModuleWithSink)
+
+    @BeforeEach
+    internal fun setUp() {
+        server.start(wait = false)
+        `when`(sink.isActive).thenReturn(true)
+        `when`(sink.writeBoth(any(), any(), any())).thenCallRealMethod()
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        server.stop(0, 5_000)
+    }
+
+    @Test
+    fun `Should log request and response`() {
+        val response = sendAndReceive() {
+            body = "ping"
+        }
+
+        assertThat(response).isNotBlank()
+
+        val capturedRequest = captureRequest()
+        assertThat(capturedRequest)
+            .isEqualTo("ping")
+
+        val capturedResponse = captureResponse()
+        assertThat(capturedResponse)
+            .isEqualTo("pong")
+    }
+
+
+    private fun sendAndReceive(uri: String = "/ping", block: HttpRequestBuilder.() -> Unit = {}): String {
+        return runBlocking {
+            client.post(urlString = "http://localhost:$port$uri") {
+                block()
+            }.body()
+        }
+    }
+
+    private fun captureRequest(): String {
+        return ArgumentCaptor
+            .forClass(HttpRequest::class.java)
+            .apply { verify(sink, timeout(1_000)).write(any(Correlation::class.java), capture(), any(HttpResponse::class.java)) }
+            .value
+            .bodyAsString
+    }
+
+    private fun captureResponse(): String? {
+        return ArgumentCaptor
+            .forClass(HttpResponse::class.java)
+            .apply { verify(sink, timeout(1_000)).write(any(Correlation::class.java), any(HttpRequest::class.java), capture()) }
+            .value
+            .bodyAsString
+    }
+}
+
+fun Application.stubApplicationModuleWithSink() {
+    routing {
+        post("/ping") {
+            call.respondText("pong", ContentType.Text.Plain)
+        }
+    }
+}

--- a/logbook-ktor-common/src/main/kotlin/org/zalando/logbook/common/State.kt
+++ b/logbook-ktor-common/src/main/kotlin/org/zalando/logbook/common/State.kt
@@ -6,18 +6,18 @@ sealed class State {
     open fun without(): State = this
     open fun buffer(content: ByteArray): State = this
 
-    object Buffering : State() {
+    class Buffering : State() {
         override fun without(): State = Ignoring(this)
         override fun buffer(content: ByteArray): State = apply { body = content }
     }
 
-    object Unbuffered : State() {
-        override fun with(): State = Offering
+    class Unbuffered : State() {
+        override fun with(): State = Offering()
     }
 
-    object Offering : State() {
-        override fun without(): State = Unbuffered
-        override fun buffer(content: ByteArray): State = Buffering.buffer(content)
+    class Offering : State() {
+        override fun without(): State = Unbuffered()
+        override fun buffer(content: ByteArray): State = Buffering().buffer(content)
     }
 
     class Ignoring(private val delegate: Buffering) : State() {

--- a/logbook-ktor-common/src/test/kotlin/org/zalando/logbook/ktor/common/StateUnitTest.kt
+++ b/logbook-ktor-common/src/test/kotlin/org/zalando/logbook/ktor/common/StateUnitTest.kt
@@ -11,7 +11,7 @@ internal class StateUnitTest {
 
     @Test
     fun `Should keep buffering when ignoring`() {
-        val state: AtomicReference<State> = AtomicReference(State.Offering)
+        val state: AtomicReference<State> = AtomicReference(State.Offering())
         state.updateAndGet { it.without() }
         state.updateAndGet { it.with() }
         state.updateAndGet { it.buffer(EMPTY_BODY) }
@@ -27,7 +27,7 @@ internal class StateUnitTest {
 
     @Test
     fun `Should not buffer when unbuffered`() {
-        val state: AtomicReference<State> = AtomicReference(State.Unbuffered)
+        val state: AtomicReference<State> = AtomicReference(State.Unbuffered())
         state.updateAndGet { it.with() }
         state.updateAndGet { it.without() }
         state.updateAndGet { it.buffer("foo".toByteArray()) }

--- a/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/ServerRequest.kt
+++ b/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/ServerRequest.kt
@@ -24,7 +24,7 @@ import kotlin.text.Charsets.UTF_8
 internal class ServerRequest(
     private val request: ApplicationRequest,
 ) : HttpRequest {
-    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered)
+    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered())
 
     override fun getProtocolVersion(): String = request.httpVersion
     override fun getOrigin(): Origin = Origin.REMOTE

--- a/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/ServerResponse.kt
+++ b/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/ServerResponse.kt
@@ -22,7 +22,7 @@ import kotlin.text.Charsets.UTF_8
 internal class ServerResponse(
     private val response: ApplicationResponse,
 ) : HttpResponse {
-    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered)
+    private val state: AtomicReference<State> = AtomicReference(State.Unbuffered())
 
     override fun getProtocolVersion(): String = response.call.request.httpVersion
     override fun getOrigin(): Origin = Origin.LOCAL


### PR DESCRIPTION
make State subclasses real classes (not objects, i.e. singletons) so that each request and response can have their own state instance

## Description
State subclasses are `object`s which make them singletons. Hence, all requests and responses share the same state instance. I think the subclasses should be `class`es, so that requests and responses have their own `State` instances.

## Motivation and Context
Please see #1868

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ?] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
