### PR TITLE
Close resources in FeignLogbookLogger

### DIFF
--- a/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/Utils.java
+++ b/logbook-openfeign/src/main/java/org/zalando/logbook/openfeign/Utils.java
@@ -1,0 +1,19 @@
+package org.zalando.logbook.openfeign;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class Utils {
+    private Utils() {
+    }
+
+    public static void ensureClosed(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {
+                // ignore
+            }
+        }
+    }
+}

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignLogbookLoggerUnitTest.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/FeignLogbookLoggerUnitTest.java
@@ -1,0 +1,64 @@
+package org.zalando.logbook.openfeign;
+
+import feign.Logger.Level;
+import feign.Request;
+import feign.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.test.TestStrategy;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class FeignLogbookLoggerUnitTest {
+
+    @Mock
+    private HttpLogWriter writer;
+    private Logbook logbook;
+
+    private FeignLogbookLogger logger;
+
+    @BeforeEach
+    void setup() {
+        logbook = Logbook.builder()
+                .strategy(new TestStrategy())
+                .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+                .build();
+        logger = new FeignLogbookLogger(logbook);
+    }
+
+    @Test
+    void responseBodyShouldBeClosedAfterRebuffer() throws IOException {
+        Request request =
+                Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8, null);
+        Response response = Response.builder()
+                .status(200)
+                .reason("OK")
+                .request(request)
+                .headers(Collections.emptyMap())
+                .body("some text", UTF_8)
+                .build();
+        Response.Body spyBody = spy(response.body());
+        response = response.toBuilder().body(spyBody).build();
+
+        logger.logRequest("someMethod()", Level.FULL, request);
+        Response rebufferedResponse =
+                logger.logAndRebufferResponse("someMethod()", Level.FULL, response, 100);
+
+        verify(spyBody).close();
+        assertThat(rebufferedResponse.body()).isNotSameAs(spyBody);
+    }
+}

--- a/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/UtilsTest.java
+++ b/logbook-openfeign/src/test/java/org/zalando/logbook/openfeign/UtilsTest.java
@@ -1,0 +1,27 @@
+package org.zalando.logbook.openfeign;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UtilsTest {
+
+    @Test
+    void ensureClosedShouldIgnoreCloseIoException() throws IOException {
+        Closeable closeable = mock(Closeable.class);
+        doThrow(new IOException()).when(closeable).close();
+
+        Utils.ensureClosed(closeable);
+    }
+
+    @Test
+    void ensureClosedShouldIgnoreNull() {
+        Utils.ensureClosed(null);
+    }
+}


### PR DESCRIPTION
Closes resources in FeignLogbookLogger to avoid http clients connections leak.

## Description
FeignLogbookLogger reads response data from original InputStream into byte array and creates copy of original Response based on read byte array.
But it doesn't close original InputStream and doesn't close original Response.body([close](https://github.com/OpenFeign/feign/blob/3b01a47f29b6b4bb6511121848546caef5724712/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java#L266) implementation for apache http 5 client). 

## Motivation and Context
For some feign client implementations it leads to connections leak. I experienced leak for feign + apache 5 http client with pool of connections.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
