### PR TITLE
Use Grizzly instead of JDK-HTTP to improve test speed by 15X

### DIFF
--- a/logbook-jaxrs/pom.xml
+++ b/logbook-jaxrs/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-jdk-http</artifactId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/logbook-jaxrs/pom.xml
+++ b/logbook-jaxrs/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -56,16 +56,6 @@
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.ws.rs</groupId>
-                    <artifactId>jakarta.ws.rs-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use Grizzly instead of JDK-HTTP to improve JAX-RS module test speed by 15X

## Description
<!--- Describe your changes in detail -->
The JDK-HTTP test server is notoriously slow. This PR replaces it with the much faster Grizzly2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Before (jdk-http) - Almost 32 seconds
![image](https://github.com/user-attachments/assets/15070493-f526-4f1a-a601-168b01574911)

### After (grizzly2) - Less than 2.0 seconds
![image](https://github.com/user-attachments/assets/048b159c-aa25-4163-b727-cc9d32650372)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
