### PR TITLE
Improve CI build speed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         java-version: 17
         cache: 'maven'
     - name: Compile
-      run: ./mvnw clean package -DskipTests
+      run: ./mvnw package -DskipTests -pl logbook-servlet -am
     - name: Test
       run: ./mvnw verify -P "${{ matrix.profile }}" -B
     - name: Coverage

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,10 +40,8 @@ jobs:
         distribution: temurin
         java-version: 17
         cache: 'maven'
-    - name: Compile
-      run: ./mvnw package -DskipTests -pl logbook-servlet -am
-    - name: Test
-      run: ./mvnw verify -P "${{ matrix.profile }}" -B
+    - name: Compile & test
+      run: ./build.sh
     - name: Coverage
       if: github.event_name != 'pull_request'
       run: ./mvnw -P coverage coveralls:report -B -D repoToken=${{ secrets.COVERALLS_TOKEN }}

--- a/build.sh
+++ b/build.sh
@@ -10,19 +10,28 @@ INSTALL_CMD="./mvnw install -DskipTests -Djacoco.skip=true"
 # Flags to track selected options
 COMPILE=false
 NO_TEST_INSTALL=false
+PACKAGE=false
 
 # Parse options
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+        --package|-p) PACKAGE=true ;;
         --compile|-c) COMPILE=true ;;
         --no-test-install|-i) NO_TEST_INSTALL=true ;;
         -ci|-ic) COMPILE=true; NO_TEST_INSTALL=true ;;
+        -cp|-pc) PACKAGE=true; COMPILE=true ;;
+        -ip|-pi) PACKAGE=true; NO_TEST_INSTALL=true ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
     shift
 done
 
 # Execute commands based on the flags
+if $PACKAGE; then
+    echo "Running package..."
+    eval "$PACKAGE_CMD"
+fi
+
 if $COMPILE; then
     echo "Running compile..."
     eval "$COMPILE_CMD"
@@ -33,7 +42,7 @@ if $NO_TEST_INSTALL; then
     eval "$INSTALL_CMD"
 fi
 
-if ! $COMPILE && ! $NO_TEST_INSTALL; then
+if ! $COMPILE && ! $NO_TEST_INSTALL && ! $PACKAGE; then
     echo "Running default commands..."
     eval "$PACKAGE_CMD"
     eval "$VERIFY_CMD"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Define default commands
+COMPILE_CMD="./mvnw compile"
+PACKAGE_CMD="./mvnw package -DskipTests -pl logbook-servlet -am"
+VERIFY_CMD="./mvnw verify -B"
+INSTALL_CMD="./mvnw install -DskipTests -Djacoco.skip=true"
+
+# Flags to track selected options
+COMPILE=false
+NO_TEST_INSTALL=false
+
+# Parse options
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --compile|-c) COMPILE=true ;;
+        --no-test-install|-i) NO_TEST_INSTALL=true ;;
+        -ci|-ic) COMPILE=true; NO_TEST_INSTALL=true ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Execute commands based on the flags
+if $COMPILE; then
+    echo "Running compile..."
+    eval "$COMPILE_CMD"
+fi
+
+if $NO_TEST_INSTALL; then
+    echo "Running install without tests..."
+    eval "$INSTALL_CMD"
+fi
+
+if ! $COMPILE && ! $NO_TEST_INSTALL; then
+    echo "Running default commands..."
+    eval "$PACKAGE_CMD"
+    eval "$VERIFY_CMD"
+fi


### PR DESCRIPTION
Improve CI build speed by not running Maven package for the whole project. Using the past execution statistics, the build used to take `5 mins`, which is now improved to `3 mins` :slightly_smiling_face: 

## Description
Due to the Maven shade plugin for `logbook-servlet` module, we need to run package once without running tests, and then run verify.
This can be improved by limiting the package step to the `logbook-servlet` module only (plus its dependencies)

## Motivation and Context
This is a minor change to the CI build step, and improves the build speed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
