### PR TITLE
feat: obfuscate refresh_token parameter in oauth request by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,14 +302,14 @@ e.g. *password*.
 
 Logbook supports different types of filters:
 
-| Type             | Operates on                    | Applies to | Default                                                                           |
-|------------------|--------------------------------|------------|-----------------------------------------------------------------------------------|
-| `QueryFilter`    | Query string                   | request    | `access_token`                                                                    |
-| `PathFilter`     | Path                           | request    | n/a                                                                               |
-| `HeaderFilter`   | Header (single key-value pair) | both       | `Authorization`                                                                   |
-| `BodyFilter`     | Content-Type and body          | both       | json: `access_token` and `refresh_token`<br> form: `client_secret` and `password` |
-| `RequestFilter`  | `HttpRequest`                  | request    | Replace binary, multipart and stream bodies.                                      |
-| `ResponseFilter` | `HttpResponse`                 | response   | Replace binary, multipart and stream bodies.                                      |
+| Type             | Operates on                    | Applies to | Default                                                                                            |
+|------------------|--------------------------------|------------|----------------------------------------------------------------------------------------------------|
+| `QueryFilter`    | Query string                   | request    | `access_token`                                                                                     |
+| `PathFilter`     | Path                           | request    | n/a                                                                                                |
+| `HeaderFilter`   | Header (single key-value pair) | both       | `Authorization`                                                                                    |
+| `BodyFilter`     | Content-Type and body          | both       | json: `access_token` and `refresh_token`<br> form: `client_secret`, `password` and `refresh_token` |
+| `RequestFilter`  | `HttpRequest`                  | request    | Replace binary, multipart and stream bodies.                                                       |
+| `ResponseFilter` | `HttpResponse`                 | response   | Replace binary, multipart and stream bodies.                                                       |
 
 `QueryFilter`, `PathFilter`, `HeaderFilter` and `BodyFilter` are relatively high-level and should cover all needs in ~90% of all
 cases. For more complicated setups one should fallback to the low-level variants, i.e. `RequestFilter` and `ResponseFilter`

--- a/logbook-core/src/main/java/org/zalando/logbook/core/BodyFilters.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/BodyFilters.java
@@ -33,6 +33,7 @@ public final class BodyFilters {
         final Set<String> properties = new HashSet<>();
         properties.add("client_secret");
         properties.add("password");
+        properties.add("refresh_token");
         return replaceFormUrlEncodedProperty(properties, "XXX");
     }
 

--- a/logbook-core/src/test/java/org/zalando/logbook/core/BodyFiltersTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/BodyFiltersTest.java
@@ -1,6 +1,8 @@
 package org.zalando.logbook.core;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.zalando.logbook.BodyFilter;
 
 import static java.util.Collections.singleton;
@@ -12,13 +14,14 @@ import static org.zalando.logbook.core.BodyFilters.truncate;
 
 final class BodyFiltersTest {
 
-    @Test
-    void filtersClientSecretByOauthRequestFilterByDefault() {
+    @ParameterizedTest
+    @ValueSource(strings = {"client_secret", "password", "refresh_token"})
+    void filtersParameterByOauthRequestFilterByDefault(String parameterName) {
         final BodyFilter unit = defaultValue();
 
-        final String actual = unit.filter("application/x-www-form-urlencoded", "client_secret=secret");
+        final String actual = unit.filter("application/x-www-form-urlencoded", parameterName + "=secret");
 
-        assertThat(actual).isEqualTo("client_secret=XXX");
+        assertThat(actual).isEqualTo(parameterName + "=XXX");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For [OAuth 2.0 Refresh Token Grant Type](https://oauth.net/2/grant-types/refresh-token/) the `refresh_token` is a required parameter and should be obfuscated by default `org.zalando.logbook.BodyFilter`. 

## Motivation and Context
The OAuth 2.0 Refresh Token is a sensitive token and should not be logged in plain text, same as `password` and `client_secret`.

This was already discussed [here](https://github.com/zalando/logbook/pull/366/files#r1860556847) but I'm not sure why this behavior was not added already at that time earlier.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
