### PR TITLE
Attempt to write a response log when flushBuffer() fails

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -85,7 +85,11 @@ public final class LogbookFilter implements HttpFilter {
     private void write(RemoteRequest request, LocalResponse response, ResponseWritingStage writing) throws IOException {
         final AtomicBoolean attribute = (AtomicBoolean) request.getAttribute(responseWritingStageSynchronizationName);
         if (!attribute.getAndSet(true)) {
-            response.flushBuffer();
+            try {
+                response.flushBuffer();
+            } catch (IOException e) {
+                // ignore and try to log the response anyway
+            }
             writing.write();
         }
     }

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookFilterTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookFilterTest.java
@@ -1,9 +1,22 @@
 package org.zalando.logbook.servlet;
 
+import io.undertow.servlet.util.EmptyEnumeration;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Logbook;
 
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 final class LogbookFilterTest {
 
@@ -25,6 +38,30 @@ final class LogbookFilterTest {
     @Test
     void shouldCallDestroy() {
         new LogbookFilter().destroy();
+    }
+
+    @Test
+    void shouldHandleIOExceptionOnFlushBufferAndWriteResponse() throws Exception {
+        Logbook logbook = mock(Logbook.class);
+        Logbook.RequestWritingStage requestWritingStage = mock(Logbook.RequestWritingStage.class);
+        Logbook.ResponseWritingStage responseWritingStage = mock(Logbook.ResponseWritingStage    .class);
+        LogbookFilter filter = new LogbookFilter(logbook);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        when(logbook.process(any())).thenReturn(requestWritingStage);
+        when(requestWritingStage.write()).thenReturn(requestWritingStage);
+        when(requestWritingStage.process(any())).thenReturn(responseWritingStage);
+        when(request.getHeaderNames()).thenReturn(EmptyEnumeration.instance());
+        when(request.getDispatcherType()).thenReturn(DispatcherType.REQUEST);
+        when(request.getAttribute(any())).thenReturn(new AtomicBoolean(false));
+
+        doThrow(new IOException("Simulated IOException")).when(response).flushBuffer();
+
+        filter.doFilter(request, response, chain);
+
+        verify(responseWritingStage).write();
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In cases when a reactive client closes a connection, flushBuffer() operation may throw a "java.io.IOException: Broken pipe" exception, that in its own turn leads to a connection close, and `LogbookAsyncListener.onComplete` call. But as this happens AFTER `ServletResponse.freeResources()` is called (by HttpServerExchange.endExchange() in case of undertow, for example), the `responseWritingStageSynchronizationName` attribute is not present anymore in the response object, which leads to an NPE. This fix attempts to overcome this edge case, by trying to write the response anyway, even after the flush fails.


I wasn't able to add a reproducible unit test with MockMvc for this use case so far, but added an isolated one. Any suggestions are welcome

## Motivation and Context

#1963 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
