### PR TITLE
Log webclient request on response errors

### DIFF
--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunction.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunction.java
@@ -1,6 +1,5 @@
 package org.zalando.logbook.spring.webflux;
 
-import io.netty.handler.timeout.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import org.apiguardian.api.API;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
@@ -35,12 +34,8 @@ public class LogbookExchangeFilterFunction implements ExchangeFilterFunction {
                         .body((outputMessage, context) -> request.body().insert(new BufferingClientHttpRequest(outputMessage, clientRequest), context))
                         .build()
                 )
-                .doOnError(throwingConsumer(throwable -> {
-                            if (throwable.getCause() instanceof TimeoutException) {
-                                requestWritingStage.write();
-                            }
-                        }
-                )).flatMap(throwingFunction(response -> {
+                .doOnError(throwingConsumer(throwable -> requestWritingStage.write()))
+                .flatMap(throwingFunction(response -> {
                     Logbook.ResponseProcessingStage responseProcessingStage = requestWritingStage.write();
 
                     ClientResponse clientResponse = new ClientResponse(response);

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
@@ -62,7 +62,7 @@ class LogbookExchangeFilterFunctionTest {
         serverWithoutChunkEncoding.start();
         when(writer.isActive()).thenReturn(true);
 
-        HttpClient httpClient = HttpClient.create().responseTimeout(Duration.ofMillis(200));
+        HttpClient httpClient = HttpClient.create().responseTimeout(Duration.ofMillis(1000));
         client = WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .baseUrl(server.baseUrl())
@@ -94,7 +94,7 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldLogEmptyResponseWithTransferEncodingChunked() throws IOException {
-        server.stubFor(get("/empty-chunked").willReturn(aResponse().withStatus(400)));
+        server.stubFor(get("/empty-chunked").willReturn(aResponse().withStatus(4000)));
 
         assertThatThrownBy(() -> client
                 .get()

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
@@ -22,6 +22,7 @@ import org.zalando.logbook.test.TestStrategy;
 import reactor.netty.http.client.HttpClient;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -61,8 +62,9 @@ class LogbookExchangeFilterFunctionTest {
         serverWithoutChunkEncoding.start();
         when(writer.isActive()).thenReturn(true);
 
+        HttpClient httpClient = HttpClient.create().responseTimeout(Duration.ofMillis(200));
         client = WebClient.builder()
-                .clientConnector(new ReactorClientHttpConnector(HttpClient.create()))
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .baseUrl(server.baseUrl())
                 .filter(new LogbookExchangeFilterFunction(logbook))
                 .codecs(it -> it.customCodecs().register(new Jackson2JsonEncoder(new ObjectMapper())))
@@ -126,6 +128,26 @@ class LogbookExchangeFilterFunctionTest {
                 .bodyValue("Hello, world!")
                 .retrieve()
                 .bodyToMono(String.class)
+                .block();
+
+        final String message = captureRequest();
+
+        assertThat(message)
+                .startsWith("Outgoing Request:")
+                .contains(format("POST %s/discard HTTP/1.1", server.baseUrl()))
+                .contains("Hello, world!");
+    }
+
+    @Test
+    void shouldLogRequestOnTimeout() throws IOException {
+        server.stubFor(post("/discard").willReturn(aResponse().withStatus(200).withFixedDelay(1000)));
+
+        client.post()
+                .uri("/discard")
+                .bodyValue("Hello, world!")
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorComplete()
                 .block();
 
         final String message = captureRequest();

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
@@ -94,7 +94,7 @@ class LogbookExchangeFilterFunctionTest {
 
     @Test
     void shouldLogEmptyResponseWithTransferEncodingChunked() throws IOException {
-        server.stubFor(get("/empty-chunked").willReturn(aResponse().withStatus(4000)));
+        server.stubFor(get("/empty-chunked").willReturn(aResponse().withStatus(400)));
 
         assertThatThrownBy(() -> client
                 .get()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When WebClient's call times out, the request is not logged together with the response, as both operations are delayed by the callback approach.  I'm calling a `requestWritingStage.write();` on timeouts errors. 

## Motivation and Context
#1876

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
