### PR TITLE
use MockitoBean instead of MockBean

### DIFF
--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
@@ -12,7 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -44,7 +44,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @EnableAutoConfiguration(exclude = ErrorMvcAutoConfiguration.class)
 final class AsyncDispatchTest {
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     static class AsyncHttpServlet extends HttpServlet{

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/DeprecatedOnlyExcludeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/DeprecatedOnlyExcludeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.verification.VerificationMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Bean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -33,7 +33,7 @@ class DeprecatedOnlyExcludeTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/DeprecatedOnlyIncludeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/DeprecatedOnlyIncludeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.verification.VerificationMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Bean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -32,7 +32,7 @@ class DeprecatedOnlyIncludeTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ExcludeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ExcludeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.verification.VerificationMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Bean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -33,7 +33,7 @@ class ExcludeTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleCurlTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleCurlTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
@@ -23,7 +23,7 @@ class FormatStyleCurlTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleDefaultTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleDefaultTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
@@ -23,7 +23,7 @@ class FormatStyleDefaultTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleHttpTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleHttpTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
@@ -23,7 +23,7 @@ class FormatStyleHttpTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleSplunkTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/FormatStyleSplunkTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Precorrelation;
@@ -23,7 +23,7 @@ class FormatStyleSplunkTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JsonBodyFieldsTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/JsonBodyFieldsTest.java
@@ -8,8 +8,8 @@ import org.mockito.ArgumentCaptor;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.JSONCompareResult;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -30,7 +30,7 @@ class JsonBodyFieldsTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyCustomTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.BodyFilter;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -27,10 +27,10 @@ class ObfuscateBodyCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
-    @MockBean
+    @MockitoBean
     @Qualifier("bodyFilter")
     private BodyFilter bodyFilter;
 

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateHeadersCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateHeadersCustomTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -25,7 +25,7 @@ class ObfuscateHeadersCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateHeadersDefaultTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateHeadersDefaultTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -25,7 +25,7 @@ class ObfuscateHeadersDefaultTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateParametersCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateParametersCustomTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -24,7 +24,7 @@ class ObfuscateParametersCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateParametersDefaultTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateParametersDefaultTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -24,7 +24,7 @@ class ObfuscateParametersDefaultTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscatePathCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscatePathCustomTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -24,7 +24,7 @@ class ObfuscatePathCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscatePathDefaultTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscatePathDefaultTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -24,7 +24,7 @@ class ObfuscatePathDefaultTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateReplacementTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateReplacementTest.java
@@ -8,7 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.JSONCompareResult;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -30,7 +30,7 @@ class ObfuscateReplacementTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateRequestCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateRequestCustomTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -25,10 +25,10 @@ class ObfuscateRequestCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
-    @MockBean
+    @MockitoBean
     private RequestFilter requestFilter;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateResponseCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateResponseCustomTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.Correlation;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
@@ -25,10 +25,10 @@ class ObfuscateResponseCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
-    @MockBean
+    @MockitoBean
     private ResponseFilter responseFilter;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteBodyMaxSizeTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteBodyMaxSizeTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
@@ -27,7 +27,7 @@ class WriteBodyMaxSizeTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @BeforeEach

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteCustomTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/WriteCustomTest.java
@@ -2,7 +2,7 @@ package org.zalando.logbook.autoconfigure;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Logbook;
@@ -18,7 +18,7 @@ class WriteCustomTest {
     @Autowired
     private Logbook logbook;
 
-    @MockBean
+    @MockitoBean
     private HttpLogWriter writer;
 
     @Test

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookWebFilterTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookWebFilterTest.java
@@ -20,7 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -98,7 +98,7 @@ class LogbookWebFilterTest {
 
         private WebClient client;
 
-        @MockBean
+        @MockitoBean
         public HttpLogWriter writer;
 
         @LocalServerPort
@@ -315,7 +315,7 @@ class LogbookWebFilterTest {
 
         private WebClient client;
 
-        @MockBean
+        @MockitoBean
         public HttpLogWriter writer;
 
         @LocalServerPort


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
use MockitoBean instead of MockBean

## Motivation and Context
As `MockBean` is being deprecated it triggers build failures as `-Werror` is used

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
