### PR TITLE
Allow using precise floats in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,17 @@ a JSON response body will **not** be escaped and represented as a string:
 }
 ```
 
+
+> [!NOTE]  
+> Logbook is using [BodyFilters](#Filtering) to inline json payload or to find fields for obfuscation. 
+> Filters for JSON bodies are using Jackson, which comes with a defect of dropping off precision from floating point 
+> numbers (see [FasterXML/jackson-core/issues/984](https://github.com/FasterXML/jackson-core/issues/984)).
+> 
+> This can be changed by setting the `usePreciseFloats` flag to true in the filter respective filters.
+> 
+> E.g. `new CompactingJsonBodyFilter(true)` will keep the precision of floating point numbers.
+
+
 ##### Common Log Format
 
 The Common Log Format ([CLF](https://httpd.apache.org/docs/trunk/logs.html#common)) is a standardized text file format used by web servers when generating server log files. The format is supported via

--- a/logbook-json/src/main/java/org/zalando/logbook/json/CompactingJsonBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/CompactingJsonBodyFilter.java
@@ -21,6 +21,10 @@ public final class CompactingJsonBodyFilter implements BodyFilter {
 
     private final JsonCompactor compactor;
 
+    public CompactingJsonBodyFilter(final boolean usePreciseFloats) {
+        this(new ParsingJsonCompactor(usePreciseFloats));
+    }
+
     public CompactingJsonBodyFilter() {
         this(new ParsingJsonCompactor());
     }

--- a/logbook-json/src/main/java/org/zalando/logbook/json/JacksonJsonFieldBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/JacksonJsonFieldBodyFilter.java
@@ -29,11 +29,20 @@ public class JacksonJsonFieldBodyFilter implements BodyFilter {
     private final String replacement;
     private final Set<String> fields;
     private final JsonFactory factory;
+    private final boolean usePreciseFloats;
 
-    public JacksonJsonFieldBodyFilter(final Collection<String> fieldNames, final String replacement, final JsonFactory factory) {
+    public JacksonJsonFieldBodyFilter(final Collection<String> fieldNames,
+                                      final String replacement,
+                                      final JsonFactory factory,
+                                      final boolean usePreciseFloats) {
         this.fields = new HashSet<>(fieldNames); // thread safe for reading
         this.replacement = replacement;
         this.factory = factory;
+        this.usePreciseFloats = usePreciseFloats;
+    }
+
+    public JacksonJsonFieldBodyFilter(final Collection<String> fieldNames, final String replacement, final JsonFactory factory) {
+        this(fieldNames, replacement, factory, false);
     }
 
     public JacksonJsonFieldBodyFilter(final Collection<String> fieldNames, final String replacement) {
@@ -54,7 +63,11 @@ public class JacksonJsonFieldBodyFilter implements BodyFilter {
                 JsonToken nextToken;
                 while ((nextToken = parser.nextToken()) != null) {
 
-                    generator.copyCurrentEvent(parser);
+                    if (usePreciseFloats) {
+                        generator.copyCurrentEventExact(parser);
+                    } else {
+                        generator.copyCurrentEvent(parser);
+                    }
                     if (nextToken == JsonToken.FIELD_NAME && fields.contains(parser.currentName())) {
                         nextToken = parser.nextToken();
                         generator.writeString(replacement);

--- a/logbook-json/src/main/java/org/zalando/logbook/json/ParsingJsonCompactor.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/ParsingJsonCompactor.java
@@ -11,12 +11,23 @@ final class ParsingJsonCompactor implements JsonCompactor {
 
     private final JsonFactory factory;
 
+    private final boolean usePreciseFloats;
+
+    public ParsingJsonCompactor(final JsonFactory factory, final boolean usePreciseFloats) {
+        this.factory = factory;
+        this.usePreciseFloats = usePreciseFloats;
+    }
+
+    public ParsingJsonCompactor(final boolean usePreciseFloats) {
+        this(new JsonFactory(), usePreciseFloats);
+    }
+
     public ParsingJsonCompactor() {
         this(new JsonFactory());
     }
 
     public ParsingJsonCompactor(final JsonFactory factory) {
-        this.factory = factory;
+        this(factory, false);
     }
 
     @Override
@@ -27,7 +38,11 @@ final class ParsingJsonCompactor implements JsonCompactor {
                 final JsonGenerator generator = factory.createGenerator(output)) {
 
             while (parser.nextToken() != null) {
-                generator.copyCurrentEvent(parser);
+                if (usePreciseFloats) {
+                    generator.copyCurrentEventExact(parser);
+                } else {
+                    generator.copyCurrentEvent(parser);
+                }
             }
 
             generator.flush();

--- a/logbook-json/src/main/java/org/zalando/logbook/json/PrettyPrintingJsonBodyFilter.java
+++ b/logbook-json/src/main/java/org/zalando/logbook/json/PrettyPrintingJsonBodyFilter.java
@@ -20,9 +20,16 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 public final class PrettyPrintingJsonBodyFilter implements BodyFilter {
 
     private final JsonFactory factory;
+    private final boolean usePreciseFloats;
+
+    public PrettyPrintingJsonBodyFilter(final JsonFactory factory,
+                                        final boolean usePreciseFloats) {
+        this.factory = factory;
+        this.usePreciseFloats = usePreciseFloats;
+    }
 
     public PrettyPrintingJsonBodyFilter(final JsonFactory factory) {
-        this.factory = factory;
+        this(factory, false);
     }
 
     public PrettyPrintingJsonBodyFilter() {
@@ -52,7 +59,11 @@ public final class PrettyPrintingJsonBodyFilter implements BodyFilter {
             generator.useDefaultPrettyPrinter();
 
             while (parser.nextToken() != null) {
-                generator.copyCurrentEvent(parser);
+                if (usePreciseFloats) {
+                    generator.copyCurrentEventExact(parser);
+                } else {
+                    generator.copyCurrentEvent(parser);
+                }
             }
 
             generator.flush();

--- a/logbook-json/src/test/java/org/zalando/logbook/json/CompactingJsonBodyFilterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/CompactingJsonBodyFilterTest.java
@@ -12,12 +12,14 @@ class CompactingJsonBodyFilterTest {
     /*language=JSON*/
     private final String pretty = "{\n" +
             "  \"root\": {\n" +
-            "    \"child\": \"text\"\n" +
+            "    \"child\": \"text\",\n" +
+            "    \"float_child\" : 0.40000000000000002" +
             "  }\n" +
             "}";
 
     /*language=JSON*/
-    private final String compacted = "{\"root\":{\"child\":\"text\"}}";
+    private final String compacted = "{\"root\":{\"child\":\"text\",\"float_child\":0.4}}";
+    private final String compactedWithPreciseFloat = "{\"root\":{\"child\":\"text\",\"float_child\":0.40000000000000002}}";
 
     @Test
     void shouldIgnoreEmptyBody() {
@@ -48,6 +50,13 @@ class CompactingJsonBodyFilterTest {
     void shouldTransformValidJsonRequestWithCompatibleContentType() {
         final String filtered = unit.filter("application/custom+json", pretty);
         assertThat(filtered).isEqualTo(compacted);
+    }
+
+    @Test
+    void shouldPreserveBigFloatOnCopy() {
+        final String filtered = new CompactingJsonBodyFilter(true)
+                .filter("application/custom+json", pretty);
+        assertThat(filtered).isEqualTo(compactedWithPreciseFloat);
     }
 
     @Test

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JacksonJsonFieldBodyFilterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JacksonJsonFieldBodyFilterTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.json;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -7,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -73,6 +75,14 @@ public class JacksonJsonFieldBodyFilterTest {
         final String invalid = valid.substring(0, valid.length() - 1);
         final String filtered = getFilter("cars").filter("application/xml", invalid);
         assertThat(filtered).contains("Ford");
+    }
+
+    @Test
+    public void shouldPreserveBigFloatOnCopy() throws Exception {
+        final String string = getResource("/student.json").trim();
+        final JacksonJsonFieldBodyFilter filter = new JacksonJsonFieldBodyFilter(Collections.emptyList(), "XXX", new JsonFactory(), true);
+        final String filtered = filter.filter("application/json", string);
+        assertThat(filtered).contains("\"debt\":123450.40000000000000002");
     }
 
     private String getResource(final String path) throws IOException {

--- a/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/JsonHttpLogFormatterTest.java
@@ -204,12 +204,13 @@ final class JsonHttpLogFormatterTest {
     void shouldEmbedCustomJsonRequestBody(final HttpLogFormatter unit) throws IOException {
         final HttpRequest request = MockHttpRequest.create()
                 .withContentType("application/custom+json")
-                .withBodyAsString("{\"name\":\"Bob\"}");
+                .withBodyAsString("{\"name\":\"Bob\", \"float_value\": 0.40000000000000002 }");
 
         final String json = unit.format(new SimplePrecorrelation("", systemUTC()), request);
 
         with(json)
-                .assertEquals("$.body.name", "Bob");
+                .assertEquals("$.body.name", "Bob")
+                .assertEquals("$.body.float_value", 0.40000000000000002);
     }
 
     @ParameterizedTest

--- a/logbook-json/src/test/java/org/zalando/logbook/json/PrettyPrintingJsonBodyFilterTest.java
+++ b/logbook-json/src/test/java/org/zalando/logbook/json/PrettyPrintingJsonBodyFilterTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.json;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.zalando.logbook.BodyFilter;
@@ -16,13 +17,23 @@ class PrettyPrintingJsonBodyFilterTest {
     private final String pretty = Stream.of(
             "{",
             "  \"root\" : {",
-            "    \"child\" : \"text\"",
+            "    \"child\" : \"text\",",
+            "    \"float_child\" : 0.4",
+            "  }",
+            "}"
+    ).collect(Collectors.joining(System.lineSeparator()));
+
+    private final String compactedWithPreciseFloat = Stream.of(
+            "{",
+            "  \"root\" : {",
+            "    \"child\" : \"text\",",
+            "    \"float_child\" : 0.40000000000000002",
             "  }",
             "}"
     ).collect(Collectors.joining(System.lineSeparator()));
 
     /*language=JSON*/
-    private final String compacted = "{\"root\":{\"child\":\"text\"}}";
+    private final String compacted = "{\"root\":{\"child\":\"text\", \"float_child\": 0.40000000000000002 }}";
 
     @Test
     void shouldIgnoreEmptyBody() {
@@ -66,6 +77,13 @@ class PrettyPrintingJsonBodyFilterTest {
         final BodyFilter bodyFilter = new PrettyPrintingJsonBodyFilter(new ObjectMapper());
         final String filtered = bodyFilter.filter("application/json", compacted);
         assertThat(filtered).isEqualTo(pretty);
+    }
+
+    @Test
+    void shouldPreserveBigFloatOnCopy() {
+        final String filtered = new PrettyPrintingJsonBodyFilter(new JsonFactory(), true)
+                .filter("application/json", compacted);
+        assertThat(filtered).isEqualTo(compactedWithPreciseFloat);
     }
 
 }

--- a/logbook-json/src/test/resources/student.json
+++ b/logbook-json/src/test/resources/student.json
@@ -20,5 +20,6 @@
     "Science": 1.9,
     "PE": 4.0
   },
-  "nickname": null
+  "nickname": null,
+  "debt": 123450.40000000000000002
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR allows using precise floats in logs. 

Several JSON body filters in Logbook use `JsonGenerator` to reconstruct the payload.  
[generator.copyCurrentEvent](https://github.com/FasterXML/jackson-core/blob/0d2b0f39200d466f49f1abb06d9027053d41483d/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java#L2515) method has a flaw when writing float numbers. This may result in logging a different float value than the actual value that was in the payload.

With this change, I'm adding an optional boolean flag to all JSON body filters to use [copyCurrentEventExact](https://github.com/FasterXML/jackson-core/blob/0d2b0f39200d466f49f1abb06d9027053d41483d/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java#L2515) instaed. That may come with a performance impact (not sure how significant).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/zalando/logbook/issues/1993

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
