### PR TITLE
Return 'none' body filter if list of to-be-filtered JSON field-names is empty

### DIFF
--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -260,7 +260,9 @@ public class LogbookAutoConfiguration {
     public BodyFilter jsonBodyFieldsFilter() {
         final LogbookProperties.Obfuscate obfuscate = properties.getObfuscate();
         final List<String> jsonBodyFields = obfuscate.getJsonBodyFields();
-
+        if (jsonBodyFields.isEmpty()) {
+            return BodyFilter.none();
+        }
         return new JacksonJsonFieldBodyFilter(jsonBodyFields, obfuscate.getReplacement());
     }
 

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyDefaultTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/ObfuscateBodyDefaultTest.java
@@ -1,0 +1,25 @@
+package org.zalando.logbook.autoconfigure;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.zalando.logbook.BodyFilter;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@LogbookTest
+class ObfuscateBodyDefaultTest {
+
+    @Autowired
+    @Qualifier("jsonBodyFieldsFilter")
+    private BodyFilter jsonBodyFieldsFilter;
+
+    @Test
+    void shouldNotFilterJsonBodiesIfEmptyObfuscateJsonBodyFieldNames() throws IOException, JSONException {
+        assertThat(jsonBodyFieldsFilter).isSameAs(BodyFilter.none());
+    }
+
+}


### PR DESCRIPTION
The Spring auto-configuration adds a body filter `JacksonJsonFieldBodyFilter` for JSON payloads without checking that there is actually some filtering to be performed.

## Description
The `LogbookProperties`  `Obfuscate` class `jsonBodyFields` field defaults to empty. 

Add empty check, if so return noop filter.

## Motivation and Context
Avoid unnecessary parse of JSON payloads.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
