### PR TITLE
bugfix: ktor server plugin http codes propagation

### DIFF
--- a/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/LogbookServer.kt
+++ b/logbook-ktor-server/src/main/kotlin/org/zalando/logbook/server/LogbookServer.kt
@@ -56,7 +56,7 @@ private suspend fun handleCallRespond(
     responseProcessingStageKey: AttributeKey<ResponseProcessingStage>
 ) {
     val responseProcessingStage = call.attributes[responseProcessingStageKey]
-    val response = ServerResponse(call.response)
+    val response = ServerResponse(call.response, body)
     val responseWritingStage = responseProcessingStage.process(response)
     if (response.shouldBuffer() && body is ByteArrayContent) {
         response.buffer(body.bytes())

--- a/logbook-ktor-server/src/test/kotlin/org/zalando/logbook/server/ServerResponseUnitTest.kt
+++ b/logbook-ktor-server/src/test/kotlin/org/zalando/logbook/server/ServerResponseUnitTest.kt
@@ -23,12 +23,27 @@ internal class ServerResponseUnitTest {
                 listOf("application/json; charset=us-ascii")
         })
 
-        val response = ServerResponse(resp)
+        val response = ServerResponse(resp, HttpStatusCode.MovedPermanently)
         assertThat(response.status).isEqualTo(202)
         assertThat(response.contentType).isEqualTo("application/json")
         assertThat(response.charset).isEqualTo(US_ASCII)
+    }
 
+    @Test
+    fun `should extract status from body if response status is null`() {
+        val resp = mock(ApplicationResponse::class.java)
         `when`(resp.status()).thenReturn(null)
+
+        val response = ServerResponse(resp, HttpStatusCode.NotFound)
+        assertThat(response.status).isEqualTo(404)
+    }
+
+    @Test
+    fun `should set default status to 200 if body is not HttpStatusCode and response status is null`() {
+        val resp = mock(ApplicationResponse::class.java)
+        `when`(resp.status()).thenReturn(null)
+
+        val response = ServerResponse(resp, "Hello, world!")
         assertThat(response.status).isEqualTo(200)
     }
 }


### PR DESCRIPTION
## Description
While using of the library we found that our call responses are logged with incorrect status codes. Most of them are logged with 200, even if they shouldn't.

## Motivation and Context
We found that every time when we use `call.respond(HttpStatusCode)` in our ktor server the problem appears. It works the same for the default 404 handlers [here](https://github.com/ktorio/ktor/blob/7fe92611582d6774c322c9ed538ddc5e8d2f8ac6/ktor-server/ktor-server-core/common/src/io/ktor/server/engine/BaseApplicationEngine.kt#L107)

Appeared that ktor-server stores status in the body field in case of using `call.respond(HttpStatusCode)` method and handles this case [here](https://github.com/ktorio/ktor/blob/7fe92611582d6774c322c9ed538ddc5e8d2f8ac6/ktor-server/ktor-server-core/common/src/io/ktor/server/http/content/DefaultTransform.kt#L27)

The PR propagates the body to the `ServerResponse` constructor and covers these cases, so we can see the real status in the logbook functionality.

To reproduce this bug you can use [this repo](https://github.com/shilenkoalexander/logbook-ktor-server-status-bug-reproduction) and run requests from [requests.http](https://github.com/shilenkoalexander/logbook-ktor-server-status-bug-reproduction/blob/master/requests.http) file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
