### PR TITLE
Check for synchronization attribute to not be null

### DIFF
--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -84,7 +84,7 @@ public final class LogbookFilter implements HttpFilter {
 
     private void write(RemoteRequest request, LocalResponse response, ResponseWritingStage writing) throws IOException {
         final AtomicBoolean attribute = (AtomicBoolean) request.getAttribute(responseWritingStageSynchronizationName);
-        if (!attribute.getAndSet(true)) {
+        if (attribute != null && !attribute.getAndSet(true)) {
             try {
                 response.flushBuffer();
             } catch (IOException e) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

In rare cases when an async flow is enabled, LogbookFilter throws NPE because the synchronization attribute is missing in the request context. The root cause for such scenarios is not clear and happens rarely. The hypothesis is that it happens due to possible race conditions that happen when the calling client cancels the request and closes the connection. But it wasn't reproduced locally.

With this change the logging of the request & response will not happen in case of the flow described above.
## Motivation and Context
https://github.com/zalando/logbook/issues/2079

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
