### PR TITLE
Use default coroutine context in ktor client

### DIFF
--- a/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/LogbookClient.kt
+++ b/logbook-ktor-client/src/main/kotlin/org/zalando/logbook/client/LogbookClient.kt
@@ -56,7 +56,7 @@ class LogbookClient(
 
             scope.receivePipeline.intercept(HttpReceivePipeline.After) { httpResponse ->
                 val (loggingContent, responseContent) = httpResponse.rawContent.split(httpResponse)
-                scope.launch(coroutineContext) {
+                scope.launch {
                     val responseProcessingStage = httpResponse.call.attributes[responseProcessingStageKey]
                     val clientResponse = ClientResponse(httpResponse)
                     val responseWritingStage = responseProcessingStage.process(clientResponse)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It appears that when nesting coroutine contexts via `scope.launch(coroutineContext) {}` LogbookClient may lead to deadlocks on big responses, as `loggingContent.discard()` uses blocking operations underneath and if other plugins interfered with the current coroutine scope.

When inheriting the scope it seems that the issue is resolved, as Dispatchers.IO is used and not [kotlinx.coroutines.BlockingEventLoop](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/src/EventLoop.kt) as the coroutine element.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
