### PR TITLE
Fixed appender name

### DIFF
--- a/logbook-jmh/src/main/resources/logback.xml
+++ b/logbook-jmh/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
 
-    <appender name="STANDARD" class="org.zalando.logbook.jmh.NOPAppender">
+    <appender name="STANDARD" class="org.zalando.logbook.benchmark.jmh.NOPAppender">
     </appender>
 
     <root level="TRACE">


### PR DESCRIPTION
Fixed appender name.

## Description
This change sets appender name to the correct one.

## Motivation and Context
It fixes exception when running tests:
`ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type org.zalando.logbook.jmh.NOPAppender`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
