### PR TITLE
Fix missing scheme, host and port information when logging async requests made using HttpAsyncClient.

### DIFF
--- a/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpRequestInterceptor.java
+++ b/logbook-httpclient/src/main/java/org/zalando/logbook/httpclient/LogbookHttpRequestInterceptor.java
@@ -25,7 +25,7 @@ public final class LogbookHttpRequestInterceptor implements HttpRequestIntercept
     @Override
     public void process(final HttpRequest httpRequest, final HttpContext context) throws IOException {
         try {
-            final LocalRequest request = new LocalRequest(httpRequest);
+            final LocalRequest request = new LocalRequest(httpRequest, context);
             final ResponseProcessingStage stage = logbook.process(request).write();
             context.setAttribute(Attributes.STAGE, stage);
         } catch (Exception e) {

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncClientContextTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncClientContextTest.java
@@ -1,0 +1,108 @@
+package org.zalando.logbook.httpclient;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.apache.http.protocol.BasicHttpContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Logbook.ResponseProcessingStage;
+import org.zalando.logbook.Logbook.ResponseWritingStage;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.test.TestStrategy;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.http.entity.ContentType.TEXT_PLAIN;
+import static org.apache.http.nio.client.methods.HttpAsyncMethods.create;
+import static org.apache.http.nio.client.methods.HttpAsyncMethods.createConsumer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class LogbookHttpAsyncClientContextTest extends AbstractHttpTest {
+
+    private final Logbook logbook = Logbook.builder()
+            .strategy(new TestStrategy())
+            .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+            .build();
+
+    private final CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
+            .addInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
+            .build();
+
+    @SuppressWarnings("unchecked")
+    private final FutureCallback<HttpResponse> callback = mock(FutureCallback.class);
+    private final ResponseProcessingStage stage = mock(ResponseProcessingStage.class);
+
+    @BeforeEach
+    void start() {
+        client.start();
+    }
+
+    @AfterEach
+    void stop() throws IOException {
+        client.close();
+    }
+
+    @Override
+    protected HttpResponse sendAndReceive(@Nullable final String body) throws IOException, ExecutionException, InterruptedException {
+        driver.addExpectation(onRequestTo("/"),
+                giveResponse("Hello, world!", "text/plain"));
+
+        final HttpUriRequest request;
+
+        final URI baseUri = URI.create(driver.getBaseUrl());
+
+        if (body == null) {
+            request = new HttpGet();
+        } else {
+            final HttpPost post = new HttpPost();
+            post.setEntity(new StringEntity(body));
+            post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
+            request = post;
+        }
+
+        final HttpHost httpHost = new HttpHost(baseUri.getHost(), baseUri.getPort(), baseUri.getScheme());
+        return client.execute(create(httpHost, request),
+                new LogbookHttpAsyncResponseConsumer<>(createConsumer(), false), HttpClientContext.create(), callback).get();
+    }
+
+    @Test
+    void shouldNotPropagateException() throws IOException {
+        final HttpAsyncResponseConsumer<HttpResponse> unit = new LogbookHttpAsyncResponseConsumer<>(createConsumer(), false);
+
+        final BasicHttpContext context = new BasicHttpContext();
+        context.setAttribute(Attributes.STAGE, stage);
+
+        final ResponseWritingStage last = mock(ResponseWritingStage.class);
+
+        when(stage.process(any())).thenReturn(last);
+
+        doThrow(new IOException()).when(last).write();
+
+        unit.responseCompleted(context);
+
+        verify(last).write();
+    }
+
+}


### PR DESCRIPTION
We have been facing an issue when using logbook with elasticsearch java client. When sending a request to elasticsearch scheme, host and port information were not logged correctly e.g.
```json
{
    "origin": "local",
    "type": "request",
    "correlation": "909f8b5183d48220",
    "protocol": "HTTP/1.1",
    "remote": "localhost",
    "method": "POST",
    "uri": "null://null/XXX/_search?typed_keys=true&ignore_unavailable=true&expand_wildcards=&search_type=query_then_fetch",
    "host": null,
    "path": "/XXX/_search",
    "scheme": null,
    "port": null,
    "headers":
    {
        "Accept":
        [
            "application/vnd.elasticsearch+json; compatible-with=8"
        ],
        "Connection":
        [
            "Keep-Alive"
        ],
        "Content-Type":
        [
            "application/vnd.elasticsearch+json; compatible-with=8"
        ],
        "Host":
        [
            "127.0.0.1:59455"
        ],
        "Transfer-Encoding":
        [
            "chunked"
        ],
        "User-Agent":
        [
            "elastic-java/8.15.5 (Java/21)"
        ],
        "X-Elastic-Client-Meta":
        [
            "es=8.15.5,jv=21,t=8.15.5,hl=2,hc=4.1.5,kt=1.9"
        ]
    },
    "body": "XXX"
}
```
Issue was caused by the fact, that elasticsearch library when interacting with `HttpAsyncClient` was providing host information in the `HttpHost` parameter instead of as part of URI itself
Links to relevant code:
https://github.com/elastic/elasticsearch/blob/v8.15.5/client/rest/src/main/java/org/elasticsearch/client/RestClient.java#L300
https://github.com/elastic/elasticsearch/blob/v8.15.5/client/rest/src/main/java/org/elasticsearch/client/RestClient.java#L845


## Description
This PR adds support to extracting host information from `HttpContext` and fallsback to the existing solution, when such extraction cannot be made

## Motivation and Context
See description of the problem above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
