### PR TITLE
Support entityDetails with negative content length

### DIFF
--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
@@ -3,6 +3,7 @@ package org.zalando.logbook.httpclient5;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentLengthStrategy;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
@@ -104,11 +105,11 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
 
         @Override
         public State buffer(EntityDetails entityDetails, ByteBuffer body) {
-            int bufferSize = (int) entityDetails.getContentLength();
-            if (bufferSize < 0) {
-                bufferSize = body.remaining();
+            int contentLength = (int) entityDetails.getContentLength();
+            if (contentLength == ContentLengthStrategy.CHUNKED) {
+                contentLength = body.remaining();
             }
-            byte[] buffer = new byte[bufferSize];
+            byte[] buffer = new byte[contentLength];
             ByteBufferUtils.fixedSizeCopy(body, buffer);
             return new Buffering(buffer);
         }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
@@ -104,7 +104,11 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
 
         @Override
         public State buffer(EntityDetails entityDetails, ByteBuffer body) {
-            byte[] buffer = new byte[(int) entityDetails.getContentLength()];
+            int bufferSize = (int) entityDetails.getContentLength();
+            if (bufferSize < 0) {
+                bufferSize = body.remaining();
+            }
+            byte[] buffer = new byte[bufferSize];
             ByteBufferUtils.fixedSizeCopy(body, buffer);
             return new Buffering(buffer);
         }

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/RemoteResponseTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/RemoteResponseTest.java
@@ -2,6 +2,7 @@ package org.zalando.logbook.httpclient5;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.impl.BasicEntityDetails;
 import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -71,6 +73,12 @@ final class RemoteResponseTest {
     void shouldReadBodyIfPresent() throws IOException {
         assertThat(new String(unit.withBody().getBody(), UTF_8)).isEqualTo("Hello, world!");
         assertThat(new String(EntityUtils.toByteArray(delegate.getEntity()), UTF_8)).isEqualTo("Hello, world!");
+    }
+
+    @Test
+    void shouldReadBodyIfPresentAndEntityDetailsShowNegativeContentLength() throws IOException {
+        final RemoteResponse underTest = new RemoteResponse(delegate, new BasicEntityDetails(-1, ContentType.TEXT_PLAIN), ByteBuffer.wrap("Hello, world!".getBytes(UTF_8)));
+        assertThat(new String(underTest.withBody().getBody(), UTF_8)).isEqualTo("Hello, world!");
     }
 
     @Test


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<In case of chunked transfer encoding, org.apache.hc.core5.http.impl.DefaultContentLengthStrategy uses -1 as the content length of a org.apache.hc.core5.http.HttpMessage. Which later passed in org.apache.hc.core5.http.EntityDetails. This is later causes an `java.lang.NegativeArraySizeException: -1` exception as Logobook tried to determine the buffer size for the body.

The suggested fix falls back to java.nio.Buffer.remaining() to determine the size of the buffer, when Content Length is negative.


## Motivation and Context

#2009

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
