### PR TITLE
Switch from rest client driver to wiremcok

### DIFF
--- a/logbook-common/pom.xml
+++ b/logbook-common/pom.xml
@@ -20,10 +20,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.github.rest-driver</groupId>
-            <artifactId>rest-client-driver</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/logbook-httpclient/pom.xml
+++ b/logbook-httpclient/pom.xml
@@ -62,8 +62,9 @@
             <artifactId>slf4j-nop</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.rest-driver</groupId>
-            <artifactId>rest-client-driver</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncClientContextTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncClientContextTest.java
@@ -27,8 +27,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.apache.http.nio.client.methods.HttpAsyncMethods.create;
@@ -66,12 +64,9 @@ public final class LogbookHttpAsyncClientContextTest extends AbstractHttpTest {
 
     @Override
     protected HttpResponse sendAndReceive(@Nullable final String body) throws IOException, ExecutionException, InterruptedException {
-        driver.addExpectation(onRequestTo("/"),
-                giveResponse("Hello, world!", "text/plain"));
-
         final HttpUriRequest request;
 
-        final URI baseUri = URI.create(driver.getBaseUrl());
+        final URI baseUri = URI.create(server.baseUrl());
 
         if (body == null) {
             request = new HttpGet();

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpAsyncResponseConsumerTest.java
@@ -24,8 +24,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.apache.http.nio.client.methods.HttpAsyncMethods.create;
@@ -63,15 +61,12 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
 
     @Override
     protected HttpResponse sendAndReceive(@Nullable final String body) throws IOException, ExecutionException, InterruptedException {
-        driver.addExpectation(onRequestTo("/"),
-                giveResponse("Hello, world!", "text/plain"));
-
         final HttpUriRequest request;
 
         if (body == null) {
-            request = new HttpGet(driver.getBaseUrl());
+            request = new HttpGet(server.baseUrl());
         } else {
-            final HttpPost post = new HttpPost(driver.getBaseUrl());
+            final HttpPost post = new HttpPost(server.baseUrl());
             post.setEntity(new StringEntity(body));
             post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
             request = post;

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsPutTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsPutTest.java
@@ -1,7 +1,6 @@
 package org.zalando.logbook.httpclient;
 
-import com.github.restdriver.clientdriver.ClientDriver;
-import com.github.restdriver.clientdriver.ClientDriverFactory;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -17,10 +16,10 @@ import org.zalando.logbook.core.DefaultSink;
 
 import java.io.IOException;
 
-import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.PUT;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,12 +29,13 @@ import static org.mockito.Mockito.when;
 
 final class LogbookHttpInterceptorsPutTest {
 
-    private final ClientDriver driver = new ClientDriverFactory().createClientDriver();
+    private final WireMockServer server = new WireMockServer(options().dynamicPort());
 
     private final HttpLogWriter writer = mock(HttpLogWriter.class);
 
     @BeforeEach
     void defaultBehaviour() {
+        server.start();
         when(writer.isActive()).thenReturn(true);
     }
 
@@ -50,17 +50,17 @@ final class LogbookHttpInterceptorsPutTest {
 
     @AfterEach
     void stop() throws IOException {
+        server.stop();
         client.close();
     }
 
     @Test
     void shouldLogRequestWithoutBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(PUT), giveEmptyResponse());
+        server.stubFor(put("/").willReturn(aResponse().withStatus(200)));
 
-        driver.addExpectation(onRequestTo("/"),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200).withBody("Hello, world!")));
 
-        final HttpPut request = new HttpPut(driver.getBaseUrl());
+        final HttpPut request = new HttpPut(server.baseUrl());
 
         client.execute(request);
 
@@ -68,7 +68,7 @@ final class LogbookHttpInterceptorsPutTest {
 
         assertThat(message)
                 .startsWith("Outgoing Request:")
-                .contains(format("PUT http://localhost:%d/ HTTP/1.1", driver.getPort()))
+                .contains(format("PUT http://localhost:%d/ HTTP/1.1", server.port()))
                 .doesNotContain("Content-Type")
                 .doesNotContain("Hello, world!");
     }

--- a/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsTest.java
+++ b/logbook-httpclient/src/test/java/org/zalando/logbook/httpclient/LogbookHttpInterceptorsTest.java
@@ -15,10 +15,7 @@ import org.zalando.logbook.test.TestStrategy;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
-import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 
 public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
 
@@ -39,15 +36,12 @@ public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
 
     @Override
     protected HttpResponse sendAndReceive(@Nullable final String body) throws IOException {
-        driver.addExpectation(onRequestTo("/"),
-                giveResponse("Hello, world!", "text/plain"));
-
         if (body == null) {
-            return client.execute(new HttpGet(driver.getBaseUrl()));
+            return client.execute(new HttpGet(server.baseUrl()));
         } else {
-            final HttpPost post = new HttpPost(driver.getBaseUrl());
+            final HttpPost post = new HttpPost(server.baseUrl());
             post.setEntity(new StringEntity(body));
-            post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
+            post.setHeader(CONTENT_TYPE, "text/plain");
             return client.execute(post);
         }
     }

--- a/logbook-httpclient5/pom.xml
+++ b/logbook-httpclient5/pom.xml
@@ -40,8 +40,9 @@
             <artifactId>slf4j-nop</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.rest-driver</groupId>
-            <artifactId>rest-client-driver</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
@@ -118,11 +118,32 @@ abstract class AbstractHttpTest {
     }
 
     @Test
-    void shouldLogResponseWithBody() throws IOException, ExecutionException, InterruptedException, ParseException {
+    void shouldLogResponseWithChunkedBody() throws IOException, ExecutionException, InterruptedException, ParseException {
         server.stubFor(post("/").willReturn(aResponse()
                 .withStatus(200)
                 .withBody("Hello, world!")
                 .withHeader("Content-Type", "text/plain")));
+
+        final ClassicHttpResponse response = sendAndReceive("Hello, world!");
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(response.getEntity()).isNotNull();
+        assertThat(EntityUtils.toString(response.getEntity())).isEqualTo("Hello, world!");
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", "Hello, world!");
+    }
+
+    @Test
+    void shouldLogResponseWithBody() throws IOException, ExecutionException, InterruptedException, ParseException {
+        server.stubFor(post("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")
+                .withHeader("Content-Length", "13")));
 
         final ClassicHttpResponse response = sendAndReceive("Hello, world!");
 

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
@@ -22,8 +22,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
 
@@ -45,13 +45,11 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
 
     @Override
     protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws ExecutionException, InterruptedException {
-        driver.addExpectation(onRequestTo("/"), giveResponse("Hello, world!", "text/plain"));
-
         SimpleRequestBuilder builder;
         if (body == null) {
-            builder = SimpleRequestBuilder.get(driver.getBaseUrl());
+            builder = SimpleRequestBuilder.get(server.baseUrl());
         } else {
-            builder = SimpleRequestBuilder.post(driver.getBaseUrl()).setBody(body, TEXT_PLAIN).setHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN.toString());
+            builder = SimpleRequestBuilder.post(server.baseUrl()).setBody(body, TEXT_PLAIN).setHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN.toString());
         }
 
         AtomicReference<String> responseRef = new AtomicReference<>(null);

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
@@ -22,8 +22,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
 

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsTest.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
 
@@ -31,13 +29,10 @@ public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
     @Override
     @SuppressWarnings("deprecation")
     protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws IOException {
-        driver.addExpectation(onRequestTo("/"),
-                giveResponse("Hello, world!", "text/plain"));
-
         if (body == null) {
-            return client.execute(new HttpGet(driver.getBaseUrl()));
+            return client.execute(new HttpGet(server.baseUrl()));
         } else {
-            final HttpPost post = new HttpPost(driver.getBaseUrl());
+            final HttpPost post = new HttpPost(server.baseUrl());
             post.setEntity(new StringEntity(body));
             post.setHeader(CONTENT_TYPE, TEXT_PLAIN.toString());
             return client.execute(post);

--- a/logbook-okhttp/pom.xml
+++ b/logbook-okhttp/pom.xml
@@ -73,8 +73,9 @@
             <artifactId>slf4j-nop</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.rest-driver</groupId>
-            <artifactId>rest-client-driver</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/logbook-okhttp/src/test/java/org/zalando/logbook/okhttp/GzipInterceptorTest.java
+++ b/logbook-okhttp/src/test/java/org/zalando/logbook/okhttp/GzipInterceptorTest.java
@@ -38,11 +38,10 @@ final class GzipInterceptorTest {
             .addNetworkInterceptor(new GzipInterceptor())
             .build();
 
-    private final WireMockServer server = new WireMockServer(options().dynamicPort());
+    private WireMockServer server;
 
     @BeforeEach
     void defaultBehaviour() {
-        server.start();
         when(writer.isActive()).thenReturn(true);
     }
 
@@ -53,6 +52,8 @@ final class GzipInterceptorTest {
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
+        server = new WireMockServer(options().dynamicPort().gzipDisabled(false));
+        server.start();
         server.stubFor(get("/").willReturn(aResponse()
                         .withStatus(200)
                         .withBody(toByteArray(getResource("response.txt.gz").openStream()))
@@ -66,6 +67,8 @@ final class GzipInterceptorTest {
 
     @Test
     void shouldLogUncompressedResponseBodyAsIs() throws IOException {
+        server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
+        server.start();
         server.stubFor(get("/").willReturn(aResponse()
                 .withStatus(200)
                 .withBody("Hello, world!")

--- a/logbook-okhttp/src/test/java/org/zalando/logbook/okhttp/GzipInterceptorTest.java
+++ b/logbook-okhttp/src/test/java/org/zalando/logbook/okhttp/GzipInterceptorTest.java
@@ -1,10 +1,10 @@
 package org.zalando.logbook.okhttp;
 
-import com.github.restdriver.clientdriver.ClientDriver;
-import com.github.restdriver.clientdriver.ClientDriverFactory;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -15,10 +15,10 @@ import org.zalando.logbook.core.DefaultSink;
 
 import java.io.IOException;
 
-import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.GET;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponseAsBytes;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.google.common.io.ByteStreams.toByteArray;
 import static com.google.common.io.Resources.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,33 +38,45 @@ final class GzipInterceptorTest {
             .addNetworkInterceptor(new GzipInterceptor())
             .build();
 
-    private final ClientDriver driver = new ClientDriverFactory().createClientDriver();
+    private final WireMockServer server = new WireMockServer(options().dynamicPort());
 
     @BeforeEach
     void defaultBehaviour() {
+        server.start();
         when(writer.isActive()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
     }
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponseAsBytes(getResource("response.txt.gz").openStream(), "text/plain")
-                        .withHeader("Content-Encoding", "gzip"));
+        server.stubFor(get("/").willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(toByteArray(getResource("response.txt.gz").openStream()))
+                        .withHeader("Content-Encoding", "gzip")
+                        .withHeader("Content-Type", "text/plain"))
+
+        );
 
         execute();
     }
 
     @Test
     void shouldLogUncompressedResponseBodyAsIs() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         execute();
     }
 
     private void execute() throws IOException {
         final Response response = client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
 
         assertThat(response.body().string()).isEqualTo("Hello, world!");

--- a/logbook-okhttp/src/test/java/org/zalando/logbook/okhttp/LogbookInterceptorTest.java
+++ b/logbook-okhttp/src/test/java/org/zalando/logbook/okhttp/LogbookInterceptorTest.java
@@ -48,7 +48,7 @@ final class LogbookInterceptorTest {
             .addNetworkInterceptor(new LogbookInterceptor(logbook))
             .build();
 
-    private final WireMockServer server = new WireMockServer(options().dynamicPort());
+    private final WireMockServer server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
 
     @BeforeEach
     void defaultBehaviour() {
@@ -122,7 +122,7 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseForHeadRequest() throws IOException {
-        server.stubFor(head(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+        server.stubFor(head(urlEqualTo("/")).willReturn(aResponse().withStatus(204)));
 
         client.newCall(new Request.Builder()
                 .method("HEAD", null)
@@ -140,7 +140,7 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseWithoutBody() throws IOException {
-        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
+        server.stubFor(get("/").willReturn(aResponse().withStatus(204)));
 
         sendAndReceive();
 
@@ -155,7 +155,9 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
-        server.stubFor(get("/").willReturn(aResponse().withStatus(200).withBody("Hello, world!")));
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         final Response response = client.newCall(new Request.Builder()
                 .url(server.baseUrl())
@@ -185,7 +187,10 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldIgnoreBodies() throws IOException {
-        server.stubFor(post("/").withRequestBody(equalTo("Hello, world!")).willReturn(aResponse().withStatus(200).withBody("Hello, world!")));
+        server.stubFor(post("/").withRequestBody(equalTo("Hello, world!")).willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         final Response response = client.newCall(new Request.Builder()
                 .url(server.baseUrl())

--- a/logbook-okhttp2/pom.xml
+++ b/logbook-okhttp2/pom.xml
@@ -52,8 +52,9 @@
             <artifactId>slf4j-nop</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.rest-driver</groupId>
-            <artifactId>rest-client-driver</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/GzipInterceptorTest.java
+++ b/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/GzipInterceptorTest.java
@@ -16,9 +16,7 @@ import org.zalando.logbook.core.DefaultSink;
 import java.io.IOException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static com.google.common.io.Resources.getResource;
@@ -35,7 +33,7 @@ final class GzipInterceptorTest {
             .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
             .build();
 
-    private final WireMockServer server = new WireMockServer(options().dynamicPort());
+    private WireMockServer server;
     private final OkHttpClient client;
 
     GzipInterceptorTest() {
@@ -46,7 +44,6 @@ final class GzipInterceptorTest {
 
     @BeforeEach
     void defaultBehaviour() {
-        server.start();
         when(writer.isActive()).thenReturn(true);
     }
 
@@ -57,6 +54,8 @@ final class GzipInterceptorTest {
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
+        server = new WireMockServer(options().dynamicPort().gzipDisabled(false));
+        server.start();
         server.stubFor(get("/").willReturn(aResponse()
                 .withStatus(200)
                 .withBody(toByteArray(getResource("response.txt.gz").openStream()))
@@ -69,6 +68,8 @@ final class GzipInterceptorTest {
 
     @Test
     void shouldLogUncompressedResponseBodyAsIs() throws IOException {
+        server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
+        server.start();
         server.stubFor(get("/").willReturn(aResponse()
                 .withStatus(200)
                 .withBody("Hello, world!")

--- a/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/GzipInterceptorTest.java
+++ b/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/GzipInterceptorTest.java
@@ -1,10 +1,10 @@
 package org.zalando.logbook.okhttp2;
 
-import com.github.restdriver.clientdriver.ClientDriver;
-import com.github.restdriver.clientdriver.ClientDriverFactory;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -15,10 +15,12 @@ import org.zalando.logbook.core.DefaultSink;
 
 import java.io.IOException;
 
-import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.GET;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponseAsBytes;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.google.common.io.ByteStreams.toByteArray;
 import static com.google.common.io.Resources.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,7 +35,7 @@ final class GzipInterceptorTest {
             .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
             .build();
 
-    private final ClientDriver driver = new ClientDriverFactory().createClientDriver();
+    private final WireMockServer server = new WireMockServer(options().dynamicPort());
     private final OkHttpClient client;
 
     GzipInterceptorTest() {
@@ -44,29 +46,41 @@ final class GzipInterceptorTest {
 
     @BeforeEach
     void defaultBehaviour() {
+        server.start();
         when(writer.isActive()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
     }
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponseAsBytes(getResource("response.txt.gz").openStream(), "text/plain")
-                        .withHeader("Content-Encoding", "gzip"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody(toByteArray(getResource("response.txt.gz").openStream()))
+                .withHeader("Content-Encoding", "gzip")
+                .withHeader("Content-Type", "text/plain")
+        ));
 
         execute();
     }
 
     @Test
     void shouldLogUncompressedResponseBodyAsIs() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")
+        ));
 
         execute();
     }
 
     private void execute() throws IOException {
         final Response response = client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
 
         assertThat(response.body().string()).isEqualTo("Hello, world!");

--- a/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/LogbookInterceptorTest.java
+++ b/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/LogbookInterceptorTest.java
@@ -148,9 +148,7 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseWithoutBody() throws IOException {
-        server.stubFor(get("/").willReturn(aResponse()
-                .withStatus(200)
-                .withBody("")));
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200).withHeader("Content-Length", "0")));
 
         sendAndReceive();
 

--- a/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/LogbookInterceptorTest.java
+++ b/logbook-okhttp2/src/test/java/org/zalando/logbook/okhttp2/LogbookInterceptorTest.java
@@ -1,10 +1,10 @@
 package org.zalando.logbook.okhttp2;
 
-import com.github.restdriver.clientdriver.ClientDriver;
-import com.github.restdriver.clientdriver.ClientDriverFactory;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -18,12 +18,13 @@ import org.zalando.logbook.test.TestStrategy;
 
 import java.io.IOException;
 
-import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.GET;
-import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.HEAD;
-import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.POST;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
-import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.squareup.okhttp.MediaType.parse;
 import static com.squareup.okhttp.RequestBody.create;
 import static java.lang.String.format;
@@ -41,7 +42,7 @@ final class LogbookInterceptorTest {
 
     private final OkHttpClient client = new OkHttpClient();
 
-    private final ClientDriver driver = new ClientDriverFactory().createClientDriver();
+    private final WireMockServer server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
 
     LogbookInterceptorTest() {
         client.networkInterceptors().add(new LogbookInterceptor(Logbook.builder()
@@ -52,12 +53,18 @@ final class LogbookInterceptorTest {
 
     @BeforeEach
     void defaultBehaviour() {
+        server.start();
         when(writer.isActive()).thenCallRealMethod();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
     }
 
     @Test
     void shouldLogRequestWithoutBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET), giveEmptyResponse());
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
 
         sendAndReceive();
 
@@ -65,18 +72,18 @@ final class LogbookInterceptorTest {
 
         assertThat(message)
                 .startsWith("Outgoing Request:")
-                .contains(format("GET http://localhost:%d/ HTTP/1.1", driver.getPort()))
+                .contains(format("GET http://localhost:%d/ HTTP/1.1", server.port()))
                 .doesNotContainIgnoringCase("Content-Type")
                 .doesNotContain("Hello, world!");
     }
 
     @Test
     void shouldLogRequestWithBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(POST)
-                .withBody("Hello, world!", "text/plain"), giveEmptyResponse());
+        server.stubFor(post("/")
+                .withRequestBody(equalTo("Hello, world!")).willReturn(aResponse().withStatus(204)));
 
         client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .post(create(parse("text/plain"), "Hello, world!"))
                 .build()).execute();
 
@@ -84,7 +91,7 @@ final class LogbookInterceptorTest {
 
         assertThat(message)
                 .startsWith("Outgoing Request:")
-                .contains(format("POST http://localhost:%d/ HTTP/1.1", driver.getPort()))
+                .contains(format("POST http://localhost:%d/ HTTP/1.1", server.port()))
                 .containsIgnoringCase("Content-Type: text/plain")
                 .contains("Hello, world!");
     }
@@ -99,7 +106,7 @@ final class LogbookInterceptorTest {
     void shouldNotLogRequestIfInactive() throws IOException {
         when(writer.isActive()).thenReturn(false);
 
-        driver.addExpectation(onRequestTo("/").withMethod(GET), giveEmptyResponse());
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
 
         sendAndReceive();
 
@@ -108,8 +115,7 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseForNotModified() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveEmptyResponse().withStatus(304));
+        server.stubFor(get("/").willReturn(aResponse().withStatus(304)));
 
         sendAndReceive();
 
@@ -124,11 +130,11 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseForHeadRequest() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(HEAD), giveEmptyResponse());
+        server.stubFor(head(urlEqualTo("/")).willReturn(aResponse().withStatus(204)));
 
         client.newCall(new Request.Builder()
                 .method("HEAD", null)
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
 
         final String message = captureResponse();
@@ -142,7 +148,9 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseWithoutBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET), giveResponse("", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("")));
 
         sendAndReceive();
 
@@ -157,11 +165,13 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldLogResponseWithBody() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         final Response response = client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
 
         assertThat(response.body().string()).isEqualTo("Hello, world!");
@@ -185,7 +195,7 @@ final class LogbookInterceptorTest {
     void shouldNotLogResponseIfInactive() throws IOException {
         when(writer.isActive()).thenReturn(false);
 
-        driver.addExpectation(onRequestTo("/").withMethod(GET), giveEmptyResponse());
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
 
         sendAndReceive();
 
@@ -194,14 +204,13 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldIgnoreBodies() throws IOException {
-        driver.addExpectation(
-                onRequestTo("/")
-                        .withMethod(POST)
-                        .withBody("Hello, world!", "text/plain"),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(post("/").withRequestBody(equalTo("Hello, world!")).willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         final Response response = client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .addHeader("Ignore", "true")
                 .post(create(parse("text/plain"), "Hello, world!"))
                 .build()).execute();
@@ -213,7 +222,7 @@ final class LogbookInterceptorTest {
 
             assertThat(message)
                     .startsWith("Outgoing Request:")
-                    .contains(format("POST http://localhost:%d/ HTTP/1.1", driver.getPort()))
+                    .contains(format("POST http://localhost:%d/ HTTP/1.1", server.port()))
                     .containsIgnoringCase("Content-Type: text/plain")
                     .doesNotContain("Hello, world!");
         }
@@ -231,13 +240,15 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldNotInterruptRequestProcessingWhenLoggingFails() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         doThrow(new IOException("Writing request went wrong")).when(writer).write(any(Precorrelation.class), any());
 
         final Response response = client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
 
         assertThat(response.body().string()).isEqualTo("Hello, world!");
@@ -247,20 +258,22 @@ final class LogbookInterceptorTest {
 
     @Test
     void shouldNotInterruptResponseProcessingWhenLoggingFails() throws IOException {
-        driver.addExpectation(onRequestTo("/").withMethod(GET),
-                giveResponse("Hello, world!", "text/plain"));
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
 
         doThrow(new IOException("Writing response went wrong")).when(writer).write(any(Correlation.class), any());
 
         final Response response = client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
 
         final String message = captureRequest();
 
         assertThat(message)
                 .startsWith("Outgoing Request:")
-                .contains(format("GET http://localhost:%d/ HTTP/1.1", driver.getPort()))
+                .contains(format("GET http://localhost:%d/ HTTP/1.1", server.port()))
                 .doesNotContainIgnoringCase("Content-Type")
                 .doesNotContain("Hello, world!");
 
@@ -270,7 +283,7 @@ final class LogbookInterceptorTest {
 
     private void sendAndReceive() throws IOException {
         client.newCall(new Request.Builder()
-                .url(driver.getBaseUrl())
+                .url(server.baseUrl())
                 .build()).execute();
     }
 

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -236,28 +236,12 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.github.rest-driver</groupId>
-                <artifactId>rest-client-driver</artifactId>
-                <version>2.0.1</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-library</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock-standalone</artifactId>
                 <version>3.12.1</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Needed by json-path-assert and rest-client-driver... -->
+            <!-- Needed by json-path-assert -->
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>


### PR DESCRIPTION

## Description

In this PR I'm suggesting to switch from partially using rest-client-driver and partially using wiremock for tests, to only use wiremock.

This PR depends on https://github.com/zalando/logbook/pull/2143, as wiremock surfaced the same issue.

## Motivation and Context
- [rest-client-driver](https://github.com/rest-driver/rest-driver) is not actively supported.
- wiremock allows more flexibility

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
