### PR TITLE
Keep Http Attributes in a FilteredResponse

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/core/FilteredHttpResponse.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/FilteredHttpResponse.java
@@ -1,24 +1,32 @@
 package org.zalando.logbook.core;
 
-import lombok.AllArgsConstructor;
+import java.io.IOException;
 import org.apiguardian.api.API;
 import org.zalando.logbook.BodyFilter;
 import org.zalando.logbook.ForwardingHttpResponse;
 import org.zalando.logbook.HeaderFilter;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpResponse;
-
-import java.io.IOException;
+import org.zalando.logbook.attributes.HttpAttributes;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(status = INTERNAL)
-@AllArgsConstructor
 final class FilteredHttpResponse implements ForwardingHttpResponse {
 
     private final HttpResponse response;
     private final HeaderFilter headerFilter;
     private final BodyFilter bodyFilter;
+    private final HttpAttributes attributes;
+
+    FilteredHttpResponse(final HttpResponse response,
+                         final HeaderFilter headerFilter,
+                         final BodyFilter bodyFilter) {
+        this.response = response;
+        this.headerFilter = headerFilter;
+        this.bodyFilter = bodyFilter;
+        this.attributes = response.getAttributes();
+    }
 
     @Override
     public HttpResponse delegate() {
@@ -55,4 +63,8 @@ final class FilteredHttpResponse implements ForwardingHttpResponse {
         return bodyFilter.filter(response.getContentType(), response.getBodyAsString());
     }
 
+    @Override
+    public HttpAttributes getAttributes() {
+        return attributes;
+    }
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/core/FilteredHttpResponseTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/FilteredHttpResponseTest.java
@@ -1,12 +1,15 @@
 package org.zalando.logbook.core;
 
+import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.attributes.HttpAttributes;
 import org.zalando.logbook.test.MockHttpResponse;
 
 import java.io.IOException;
 
+import static com.fasterxml.jackson.databind.type.LogicalType.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class FilteredHttpResponseTest {
@@ -15,7 +18,13 @@ final class FilteredHttpResponseTest {
             .withHeaders(HttpHeaders.empty()
                     .update("Authorization", "Bearer 9b7606a6-6838-11e5-8ed4-10ddb1ee7671")
                     .update("Accept", "text/plain"))
-            .withBodyAsString("My secret is s3cr3t"),
+            .withBodyAsString("My secret is s3cr3t")
+            .withHttpAttributes(new HttpAttributes(
+                    new HashMap<String, Object>() {{
+                        put("foo", "bar");
+                        put("fizz", "buzz");
+                    }}
+            )),
             HeaderFilters.authorization(),
             (contentType, body) -> body.replace("s3cr3t", "f4k3"));
 
@@ -51,6 +60,16 @@ final class FilteredHttpResponseTest {
     @Test
     void shouldFilterBodyContent() throws IOException {
         assertThat(new String(unit.getBody(), unit.getCharset())).isEqualTo("My secret is f4k3");
+    }
+
+    @Test
+    void shouldNotFilterAttributes() {
+        assertThat(unit.getAttributes()).isEqualTo(new HttpAttributes(
+                new HashMap<String, Object>() {{
+                    put("foo", "bar");
+                    put("fizz", "buzz");
+                }}
+        ));
     }
 
 }


### PR DESCRIPTION
This PR shall fix the issue that extracted HTTP Attributes are not logged in a filtered Response

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
