### PR TITLE
Return original HTTP attributes from webflux ServerHttpRequest

### DIFF
--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerRequest.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerRequest.java
@@ -7,6 +7,7 @@ import org.springframework.util.MimeType;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.Origin;
+import org.zalando.logbook.attributes.HttpAttributes;
 
 import jakarta.annotation.Nullable;
 import java.io.IOException;
@@ -92,6 +93,11 @@ final class ServerRequest implements HttpRequest {
         return Optional.ofNullable(request.getHeaders().getContentType())
                 .map(MimeType::getCharset)
                 .orElse(UTF_8);
+    }
+
+    @Override
+    public HttpAttributes getAttributes() {
+        return new HttpAttributes(request.getAttributes());
     }
 
     @Override

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/ServerRequestUnitTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/ServerRequestUnitTest.java
@@ -4,13 +4,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
-public class ServerRequestUnitTest {
+class ServerRequestUnitTest {
 
     @Test
     void shouldBeEmptyIfPortIsNegative() {
@@ -21,4 +23,25 @@ public class ServerRequestUnitTest {
         assertThat(request.getPort()).isEmpty();
     }
 
+    @Test
+    void shouldReturnAttributesIfPresent() {
+        Map<String, Object> expectedAttributes = new HashMap<>();
+        expectedAttributes.put("foo", "bar");
+        expectedAttributes.put("userId", 12345);
+
+        ServerHttpRequest mock = mock(ServerHttpRequest.class);
+        when(mock.getAttributes()).thenReturn(expectedAttributes);
+
+        ServerRequest request = new ServerRequest(mock);
+        assertEquals(expectedAttributes, request.getAttributes());
+    }
+
+    @Test
+    void shouldReturnEmptyAttributesIfNone() {
+        ServerHttpRequest mock = mock(ServerHttpRequest.class);
+        when(mock.getAttributes()).thenReturn(new HashMap<>());
+
+        ServerRequest request = new ServerRequest(mock);
+        assertThat(request.getAttributes()).isEmpty();
+    }
 }


### PR DESCRIPTION
## Description
The current implementation of [`ServerRequest`](https://github.com/zalando/logbook/blob/main/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/ServerRequest.java) from `org.zalando.logbook.spring.webflux` returns an empty attribute map, regardless of whether any attributes are present (see [`HttpRequest`](https://github.com/zalando/logbook/blob/main/logbook-api/src/main/java/org/zalando/logbook/HttpRequest.java#L40)).

This improvement exposes the Spring server request attributes through `ServerRequest.getAttributes()`.

## Motivation and Context
In a Spring Boot application, I would like to pass a `userId` inside a `WebFilter` using `HttpAttributes`, and then later retrieve this value in `LogbookWebFilter` via an `AttributeExtractor` in order to include it in the logs. However, in my current setup, the `HttpAttributes` are always empty when accessed through the extractor.

See: [zalando/logbook#2175](https://github.com/zalando/logbook/issues/2175)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 