### PR TITLE
Added LogbookCustomizer for Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,18 @@ public BodyFilter bodyFilter() {
 }
 ```
 
+If extra custom configuration is wanted, it is possible to implement a LogbookCustomizer bean, for example:
+
+```java
+@Bean
+public LogbookCustomizer customizer(Environment env) {
+  if (env.matchesProfiles("test")) {
+    return builder -> builder.strategy(new StatusAtLeastStrategy(0));
+  }
+  return builder -> {};
+}
+```
+
 Please refer to [`LogbookAutoConfiguration`](logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java)
 or the following table to see a list of possible integration points:
 

--- a/logbook-jmh/src/main/java/org/zalando/logbook/benchmark/LogbookState.java
+++ b/logbook-jmh/src/main/java/org/zalando/logbook/benchmark/LogbookState.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.State;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Sink;
 import org.zalando.logbook.autoconfigure.LogbookAutoConfiguration;
+import org.zalando.logbook.autoconfigure.LogbookCustomizer;
 import org.zalando.logbook.autoconfigure.LogbookProperties;
 import org.zalando.logbook.json.CompactingJsonBodyFilter;
 import org.zalando.logbook.logstash.LogstashLogbackSink;
@@ -28,15 +29,20 @@ public class LogbookState {
         final LogbookProperties properties = new LogbookProperties();
         final LogbookAutoConfiguration ac = new LogbookAutoConfiguration(properties);
 
-        autoconfigurationLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Collections.singletonList(ac.headerFilter()), Collections.singletonList(ac.pathFilter()), Collections.singletonList(ac.queryFilter()), Collections.singletonList(ac.bodyFilter()), Collections.singletonList(ac.requestFilter()), Collections.singletonList(ac.responseFilter()), ac.strategy(), null, ac.sink(ac.httpFormatter(), ac.writer()));
-
+        autoconfigurationLogbook = setup(ac.defaultLogbookConfiguration(ac.requestCondition(), ac.correlationId(), Collections.singletonList(ac.headerFilter()), Collections.singletonList(ac.pathFilter()), Collections.singletonList(ac.queryFilter()), Collections.singletonList(ac.bodyFilter()), Collections.singletonList(ac.requestFilter()), Collections.singletonList(ac.responseFilter()), ac.strategy(), null, ac.sink(ac.httpFormatter(), ac.writer())));
         final Sink sink = new LogstashLogbackSink(state.getJsonHttpLogFormatter());
 
-        autoconfigurationLogstashLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Collections.singletonList(ac.headerFilter()), Collections.singletonList(ac.pathFilter()), Collections.singletonList(ac.queryFilter()), List.of(ac.bodyFilter(), new CompactingJsonBodyFilter()), Collections.singletonList(ac.requestFilter()), Collections.singletonList(ac.responseFilter()), ac.strategy(), null, sink);
+        autoconfigurationLogstashLogbook = setup(ac.defaultLogbookConfiguration(ac.requestCondition(), ac.correlationId(), Collections.singletonList(ac.headerFilter()), Collections.singletonList(ac.pathFilter()), Collections.singletonList(ac.queryFilter()), List.of(ac.bodyFilter(), new CompactingJsonBodyFilter()), Collections.singletonList(ac.requestFilter()), Collections.singletonList(ac.responseFilter()), ac.strategy(), null, sink));
 
         final Sink noop = new LogstashLogbackSink(state.getNoopHttpLogFormatter());
 
-        noopHttpLogFormatterLogbook = ac.logbook(ac.requestCondition(), ac.correlationId(), Collections.singletonList(ac.headerFilter()), Collections.singletonList(ac.pathFilter()), Collections.singletonList(ac.queryFilter()), List.of(ac.bodyFilter(), new CompactingJsonBodyFilter()), Collections.singletonList(ac.requestFilter()), Collections.singletonList(ac.responseFilter()), ac.strategy(), null, noop);
+        noopHttpLogFormatterLogbook = setup(ac.defaultLogbookConfiguration(ac.requestCondition(), ac.correlationId(), Collections.singletonList(ac.headerFilter()), Collections.singletonList(ac.pathFilter()), Collections.singletonList(ac.queryFilter()), List.of(ac.bodyFilter(), new CompactingJsonBodyFilter()), Collections.singletonList(ac.requestFilter()), Collections.singletonList(ac.responseFilter()), ac.strategy(), null, noop));
+    }
+
+    private Logbook setup(LogbookCustomizer customizer) {
+        var builder = Logbook.builder();
+        customizer.customize(builder);
+        return builder.build();
     }
 
 

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookCustomizer.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookCustomizer.java
@@ -1,4 +1,8 @@
 package org.zalando.logbook.autoconfigure;
 
-public class LogbookCustomizer {
+import org.zalando.logbook.LogbookCreator;
+
+@FunctionalInterface
+public interface LogbookCustomizer {
+    void customize(LogbookCreator.Builder builder);
 }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookCustomizer.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookCustomizer.java
@@ -1,0 +1,4 @@
+package org.zalando.logbook.autoconfigure;
+
+public class LogbookCustomizer {
+}


### PR DESCRIPTION
## Description
Added LogbookCustomizer functional interface and implemented the standard usage pattern

## Motivation and Context
This gives the opportunity to have custom code to change the behavior of the builder. This is a common pattern already seen across many Spring components, giving the consuming application a lot of flexibility. 

Furthermore, the LogbookCreator.Builder is now a prototype bean, applying the standard customizers. This means that if the application wants two different LogBook instances, for example one instance for WebFlux and a slightly different instance used with WebClient, this is very easy to acheive.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I am a bit unsure if this is considered a breaking change. It changes methods marked as internal APIs, so I think it should be ok. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
