### PR TITLE
Revert "Bump kotlin.version from 2.3.10 to 2.3.20"

### DIFF
--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -23,7 +23,7 @@
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <json-path.version>2.10.0</json-path.version>
-        <kotlin.version>2.3.20</kotlin.version>
+        <kotlin.version>2.3.10</kotlin.version>
         <ktor.version>3.4.1</ktor.version>
         <netty.version>4.2.10.Final</netty.version>
         <reactor-netty.version>1.3.4</reactor-netty.version>


### PR DESCRIPTION
Reverts zalando/logbook#2265. See https://github.com/github/codeql/issues/21484