### PR TITLE
Fix logging of large response bodies in httpclient5 implementation LogbookHttpAsyncResponseConsumer

### DIFF
--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
@@ -1,5 +1,7 @@
 package org.zalando.logbook.httpclient5;
 
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.EntityDetails;
@@ -12,6 +14,7 @@ import org.zalando.logbook.Logbook.ResponseProcessingStage;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
@@ -20,13 +23,15 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsyncResponseConsumer<T> {
 
     private final AsyncResponseConsumer<T> consumer;
+    private final Function<T, byte[]> bodyExtractor;
     private final boolean decompressResponse;
     private HttpResponse response;
     private EntityDetails entityDetails;
     private ResponseProcessingStage stage;
 
-    public LogbookHttpAsyncResponseConsumer(final AsyncResponseConsumer<T> consumer, boolean decompressResponse) {
+    public LogbookHttpAsyncResponseConsumer(final AsyncResponseConsumer<T> consumer, final Function<T, byte[]> bodyExtractor, final boolean decompressResponse) {
         this.consumer = consumer;
+        this.bodyExtractor = bodyExtractor;
         this.decompressResponse = decompressResponse;
     }
 
@@ -41,17 +46,12 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
         this.stage = find(context);
         if (entityDetails == null) {
             processStage(response, null, null);
+            delegate().consumeResponse(response, entityDetails, context, resultCallback);
         } else {
             this.response = response;
             this.entityDetails = entityDetails;
+            delegate().consumeResponse(response, entityDetails, context, new LogbookFutureCallback(resultCallback));
         }
-        delegate().consumeResponse(response, entityDetails, context, resultCallback);
-    }
-
-    @Override
-    public void consume(ByteBuffer src) throws IOException {
-        processStage(this.response, this.entityDetails, src);
-        delegate().consume(src);
     }
 
     private void processStage(final HttpResponse response, final EntityDetails entityDetails, final ByteBuffer src) {
@@ -69,5 +69,19 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
 
     private ResponseProcessingStage find(final HttpContext context) {
         return (ResponseProcessingStage) context.getAttribute(Attributes.STAGE);
+    }
+
+    @RequiredArgsConstructor
+    private final class LogbookFutureCallback implements FutureCallback<T> {
+
+        @Delegate
+        private final FutureCallback<T> delegate;
+
+        @Override
+        public void completed(final T result) {
+            final byte[] body = bodyExtractor.apply(result);
+            processStage(response, entityDetails, body != null ? ByteBuffer.wrap(body) : null);
+            delegate.completed(result);
+        }
     }
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
@@ -80,7 +80,7 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
         @Override
         public void completed(final T result) {
             final byte[] body = bodyExtractor.apply(result);
-            processStage(response, entityDetails, body != null ? ByteBuffer.wrap(body) : null);
+            processStage(response, entityDetails, ByteBuffer.wrap(body));
             delegate.completed(result);
         }
     }

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
@@ -237,7 +237,8 @@ abstract class AbstractHttpTest {
 
     @Test
     void shouldHandleLargeChunkedResponseBody() throws IOException, ExecutionException, InterruptedException {
-        final byte[] largeBody = new byte[80 * 1024];
+        final int size = 80 * 1024;
+        final byte[] largeBody = new byte[size];
         Arrays.fill(largeBody, (byte) 'A');
 
         server.stubFor(get("/").willReturn(aResponse()
@@ -249,18 +250,19 @@ abstract class AbstractHttpTest {
 
         assertThat(response.getCode()).isEqualTo(200);
         assertThat(response.getEntity()).isNotNull();
-        assertThat(EntityUtils.toByteArray(response.getEntity())).hasSize(80 * 1024);
+        assertThat(EntityUtils.toByteArray(response.getEntity())).hasSize(size);
 
         final String message = captureResponse();
 
         assertThat(message)
                 .startsWith("Incoming Response:")
-                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain");
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", "A".repeat(size));
     }
 
     @Test
     void shouldHandleLargeNonChunkedResponseBody() throws IOException, ExecutionException, InterruptedException {
-        final byte[] largeBody = new byte[80 * 1024];
+        final int size = 80 * 1024;
+        final byte[] largeBody = new byte[size];
         Arrays.fill(largeBody, (byte) 'A');
 
         nonChunkedServer.stubFor(get("/").willReturn(aResponse()
@@ -272,13 +274,13 @@ abstract class AbstractHttpTest {
 
         assertThat(response.getCode()).isEqualTo(200);
         assertThat(response.getEntity()).isNotNull();
-        assertThat(EntityUtils.toByteArray(response.getEntity())).hasSize(80 * 1024);
+        assertThat(EntityUtils.toByteArray(response.getEntity())).hasSize(size);
 
         final String message = captureResponse();
 
         assertThat(message)
                 .startsWith("Incoming Response:")
-                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain");
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", "A".repeat(size));
     }
 
     private ClassicHttpResponse sendAndReceive() throws InterruptedException, ExecutionException, IOException {

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
@@ -19,12 +19,14 @@ import org.zalando.logbook.test.TestStrategy;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.Options.ChunkedEncodingPolicy.NEVER;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +42,9 @@ abstract class AbstractHttpTest {
 
     final WireMockServer server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
 
+    final WireMockServer nonChunkedServer = new WireMockServer(options().dynamicPort().gzipDisabled(true)
+            .useChunkedTransferEncoding(NEVER));
+
     final HttpLogWriter writer = mock(HttpLogWriter.class);
 
     protected final Logbook logbook = Logbook.builder()
@@ -50,12 +55,14 @@ abstract class AbstractHttpTest {
     @BeforeEach
     void defaultBehaviour() {
         server.start();
+        nonChunkedServer.start();
         when(writer.isActive()).thenReturn(true);
     }
 
     @AfterEach
     void tearDown() {
         server.stop();
+        nonChunkedServer.stop();
     }
 
     @Test
@@ -228,10 +235,65 @@ abstract class AbstractHttpTest {
                 .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", "Hello, dude!");
     }
 
-    private void sendAndReceive() throws InterruptedException, ExecutionException, IOException {
-        sendAndReceive(null);
+    @Test
+    void shouldHandleLargeChunkedResponseBody() throws IOException, ExecutionException, InterruptedException {
+        final byte[] largeBody = new byte[80 * 1024];
+        Arrays.fill(largeBody, (byte) 'A');
+
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody(largeBody)));
+
+        final ClassicHttpResponse response = sendAndReceive();
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(response.getEntity()).isNotNull();
+        assertThat(EntityUtils.toByteArray(response.getEntity())).hasSize(80 * 1024);
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain");
     }
 
-    protected abstract ClassicHttpResponse sendAndReceive(@Nullable String body)
+    @Test
+    void shouldHandleLargeNonChunkedResponseBody() throws IOException, ExecutionException, InterruptedException {
+        final byte[] largeBody = new byte[80 * 1024];
+        Arrays.fill(largeBody, (byte) 'A');
+
+        nonChunkedServer.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody(largeBody)));
+
+        final ClassicHttpResponse response = sendAndReceive(nonChunkedServer);
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(response.getEntity()).isNotNull();
+        assertThat(EntityUtils.toByteArray(response.getEntity())).hasSize(80 * 1024);
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain");
+    }
+
+    private ClassicHttpResponse sendAndReceive() throws InterruptedException, ExecutionException, IOException {
+        return sendAndReceive((String) null);
+    }
+
+    protected ClassicHttpResponse sendAndReceive(@Nullable String body)
+            throws IOException, ExecutionException, InterruptedException {
+        return sendAndReceive(server, body);
+    }
+
+    private ClassicHttpResponse sendAndReceive(WireMockServer server) throws InterruptedException, ExecutionException, IOException {
+        return sendAndReceive(server, null);
+    }
+
+    protected abstract ClassicHttpResponse sendAndReceive(WireMockServer server, @Nullable String body)
             throws IOException, ExecutionException, InterruptedException;
 }

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
@@ -53,7 +53,7 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
 
         AtomicReference<String> responseRef = new AtomicReference<>(null);
         CountDownLatch latch = new CountDownLatch(1);
-        HttpResponse response = client.execute(SimpleRequestProducer.create(builder.build()), new LogbookHttpAsyncResponseConsumer<>(SimpleResponseConsumer.create(), true), HttpClientContext.create(), getCallback(responseRef, latch)).get();
+        HttpResponse response = client.execute(SimpleRequestProducer.create(builder.build()), new LogbookHttpAsyncResponseConsumer<>(SimpleResponseConsumer.create(), SimpleHttpResponse::getBodyBytes, true), HttpClientContext.create(), getCallback(responseRef, latch)).get();
 
         BasicClassicHttpResponse httpResponse = new BasicClassicHttpResponse(response.getCode(), response.getReasonPhrase());
         latch.await(5, SECONDS);

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient5;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
@@ -42,7 +43,7 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
     }
 
     @Override
-    protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws ExecutionException, InterruptedException {
+    protected ClassicHttpResponse sendAndReceive(final WireMockServer server, @Nullable final String body) throws ExecutionException, InterruptedException {
         SimpleRequestBuilder builder;
         if (body == null) {
             builder = SimpleRequestBuilder.get(server.baseUrl());

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpExecHandlerTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient5;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -37,7 +38,7 @@ class LogbookHttpExecHandlerTest extends AbstractHttpTest {
 
     @Override
     @SuppressWarnings("deprecation")
-    protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws IOException {
+    protected ClassicHttpResponse sendAndReceive(final WireMockServer server, @Nullable final String body) throws IOException {
         if (body == null) {
             return client.execute(new HttpGet(server.baseUrl()));
         } else {

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpInterceptorsTest.java
@@ -1,5 +1,6 @@
 package org.zalando.logbook.httpclient5;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -28,7 +29,7 @@ public final class LogbookHttpInterceptorsTest extends AbstractHttpTest {
 
     @Override
     @SuppressWarnings("deprecation")
-    protected ClassicHttpResponse sendAndReceive(@Nullable final String body) throws IOException {
+    protected ClassicHttpResponse sendAndReceive(final WireMockServer server, @Nullable final String body) throws IOException {
         if (body == null) {
             return client.execute(new HttpGet(server.baseUrl()));
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current implementation of httpclient5 `LogbookHttpAsyncResponseConsumer` is incorrectly handling large response bodies (over 8192 bytes). This fix addresses this issue.

## Motivation and Context
httpclient5 changed its model to reactive/nio comparing to httpclient. In the new approach, `AsyncResponseConsumer` receives raw http chunks in `consume(ByteBuffer)` contrary to the old `responseCompleted(HttpContext)` which received full response.

This caused logbook to call `Sink.write()` on each http chunk it received. This worked fine for small response bodies but is causing errors for large responses.

This fix addresses this issue by using `FutureCallback<T> resultCallback` which allows logbook to log entire response once at the end of response processing. Unfortunately, since the delegate is a generic interface, additional `Function<T, byte[]> bodyExtractor` is required which causes the new constructor of `LogbookHttpAsyncResponseConsumer` to be incompatible with the old version (additional parameter is required).

I could try to think of some kind of workaround, but I believe it would make the implementation difficult to understand the maintain. I consider the current implementation incomplete/incorrect, therefore it's ok in my opinion to introduce this breaking change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
