### PR TITLE
Upgrade httpclient5 to 5.6

### DIFF
--- a/logbook-httpclient5/pom.xml
+++ b/logbook-httpclient5/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5</version>
+            <version>5.6</version>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
@@ -255,8 +255,8 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
 
     private boolean isGzip() {
         if (entityDetails != null) {
-            final String contentType = entityDetails.getContentType();
-            return contentType != null && isGzipHeaderRepresentation(contentType);
+            final String contentEncoding = entityDetails.getContentEncoding();
+            return contentEncoding != null && isGzipHeaderRepresentation(contentEncoding);
         } else if (response.containsHeader("Content-Encoding")) {
             Header[] headers = response.getHeaders("Content-Encoding");
             return Arrays.stream(headers).map(NameValuePair::getValue).anyMatch(this::isGzipHeaderRepresentation);

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/RemoteResponse.java
@@ -10,6 +10,7 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.Origin;
@@ -253,18 +254,21 @@ final class RemoteResponse implements org.zalando.logbook.HttpResponse {
     }
 
     private boolean isGzip() {
-        if (response.containsHeader("Content-Encoding")) {
+        if (entityDetails != null) {
+            final String contentType = entityDetails.getContentType();
+            return contentType != null && isGzipHeaderRepresentation(contentType);
+        } else if (response.containsHeader("Content-Encoding")) {
             Header[] headers = response.getHeaders("Content-Encoding");
-            return Arrays.stream(headers).anyMatch(this::isGzipHeaderRepresentation);
+            return Arrays.stream(headers).map(NameValuePair::getValue).anyMatch(this::isGzipHeaderRepresentation);
         }
         return false;
     }
 
-    private boolean isGzipHeaderRepresentation(Header header) {
-        if ("gzip".equalsIgnoreCase(header.getValue())) {
+    private boolean isGzipHeaderRepresentation(final String contentEncoding) {
+        if ("gzip".equalsIgnoreCase(contentEncoding)) {
             return true;
         } else {
-            return "x-gzip".equalsIgnoreCase(header.getValue());
+            return "x-gzip".equalsIgnoreCase(contentEncoding);
         }
     }
 

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/RemoteResponseTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/RemoteResponseTest.java
@@ -172,6 +172,69 @@ final class RemoteResponseTest {
         assertThat(new String(response.withBody().getBody())).isNotEqualTo(json);
     }
 
+    @Test
+    void shouldDecompressCompressedGzipBodyBeforeReturnContentEncodingHeaderInEntityDetails() throws IOException {
+        String json = "{\"data\": \"data\"}";
+        byte[] compressed = compress(json.getBytes(StandardCharsets.UTF_8));
+
+        BasicHttpEntity basicEntity = new BasicHttpEntity(
+                new ByteArrayInputStream(compressed),
+                -1,
+                ContentType.APPLICATION_JSON,
+                "gzip",
+                true
+        );
+
+        BasicClassicHttpResponse underTest = new BasicClassicHttpResponse(200, "Ok");
+        RemoteResponse response = new RemoteResponse(underTest, basicEntity, ByteBuffer.wrap(compressed), true);
+        underTest.setEntity(basicEntity);
+        underTest.addHeader("Content-Type", "application/json;charset=utf-8");
+
+        assertThat(new String(response.withBody().getBody())).isEqualTo(json);
+    }
+
+    @Test
+    void shouldNotDecompressCompressedBodyContentEncodingHeaderIsNotPresentInEntityDetails() throws IOException {
+        String json = "{\"data\": \"data\"}";
+        byte[] compressed = compress(json.getBytes(StandardCharsets.UTF_8));
+
+        BasicHttpEntity basicEntity = new BasicHttpEntity(
+                new ByteArrayInputStream(compressed),
+                -1,
+                ContentType.APPLICATION_JSON,
+                null,
+                true
+        );
+
+        BasicClassicHttpResponse underTest = new BasicClassicHttpResponse(200, "Ok");
+        RemoteResponse response = new RemoteResponse(underTest, basicEntity, ByteBuffer.wrap(compressed), true);
+        underTest.setEntity(basicEntity);
+        underTest.addHeader("Content-Type", "application/json;charset=utf-8");
+
+        assertThat(new String(response.withBody().getBody())).isNotEqualTo(json);
+    }
+
+    @Test
+    void shouldNotDecompressCompressedBodyContentEncodingHeaderWithUnknownEncodingInEntityDetails() throws IOException {
+        String json = "{\"data\": \"data\"}";
+        byte[] compressed = compress(json.getBytes(StandardCharsets.UTF_8));
+
+        BasicHttpEntity basicEntity = new BasicHttpEntity(
+                new ByteArrayInputStream(compressed),
+                -1,
+                ContentType.APPLICATION_JSON,
+                "unknown",
+                true
+        );
+
+        BasicClassicHttpResponse underTest = new BasicClassicHttpResponse(200, "Ok");
+        RemoteResponse response = new RemoteResponse(underTest, basicEntity, ByteBuffer.wrap(compressed), true);
+        underTest.setEntity(basicEntity);
+        underTest.addHeader("Content-Type", "application/json;charset=utf-8");
+
+        assertThat(new String(response.withBody().getBody())).isNotEqualTo(json);
+    }
+
     static byte[] compress(byte[] data) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (GZIPOutputStream gzipOut = new GZIPOutputStream(outputStream)) {


### PR DESCRIPTION
* leverage transparent content decompression for async transport
* fallback to custom decompression for other transports

The custom decompression was originally introduced in https://github.com/zalando/logbook/pull/2192. [The library starts to support transparent decompression with 5.6 for the async transport](https://github.com/apache/httpcomponents-client/blob/2c36560fad44ad15ed3d93d44caf7bdd16840bb4/RELEASE_NOTES.txt#L20-L21). Once merge, we can rebase https://github.com/zalando/logbook/pull/2297.

The existing test harness covers the case well already (verifying that the custom decompression only kicks in when needed), as we can see in the build failures of https://github.com/zalando/logbook/pull/2297.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
- [ ] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
