### PR TITLE
Add HTTP/2 support to logbook-netty via Http2AwareHandlerRegistrar

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,27 +890,24 @@ httpServer.createContext(path,handler).getFilters().add(new LogbookFilter(logboo
 
 ### Netty
 
-The `logbook-netty` module contains:
-
-A `LogbookClientHandler` to be used with an `HttpClient`:
-
-```java
-HttpClient httpClient =
-        HttpClient.create()
-                .doOnConnected(
-                        (connection -> connection.addHandlerLast(new LogbookClientHandler(logbook)))
-                );
-```
-
-A `LogbookServerHandler` for use used with an `HttpServer`:
+The `logbook-netty` module contains `LogbookClientHandler` and `LogbookServerHandler`. Use
+`Http2AwareHandlerRegistrar` to register them — it handles both HTTP/1.1 and HTTP/2 (H2C and
+H2 over TLS) correctly:
 
 ```java
-HttpServer httpServer =
-        HttpServer.create()
-                .doOnConnection(
-                        connection -> connection.addHandlerLast(new LogbookServerHandler(logbook))
-                );
+HttpClient httpClient = Http2AwareHandlerRegistrar.installOnClient(HttpClient.create(), logbook);
 ```
+
+```java
+HttpServer httpServer = Http2AwareHandlerRegistrar.installOnServer(HttpServer.create(), logbook);
+```
+
+> **Note:** Do not use `doOnConnected` / `doOnConnection` with `pipeline().addLast()` for HTTP/2
+> setups. Under HTTP/2, Reactor Netty multiplexes streams onto child `Http2StreamChannel`s;
+> `Http2AwareHandlerRegistrar` uses the correct lifecycle hooks (`STREAM_CONFIGURED` for H2 stream
+> channels, `CONFIGURED` for HTTP/1.1) and `connection.addHandlerLast()` to insert before
+> `ReactiveBridge`. HTTP/1.1-only users may still use the old `doOnConnected` pattern, but
+> `Http2AwareHandlerRegistrar` is the recommended approach for all new code.
 
 #### Spring WebFlux
 

--- a/logbook-netty/pom.xml
+++ b/logbook-netty/pom.xml
@@ -42,6 +42,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>logbook-core</artifactId>
             <scope>test</scope>
@@ -55,6 +59,19 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
+            <version>${reactor-netty.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <version>${reactor-netty.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- keep reactor-netty shim for backward-compat, test-only -->
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrar.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrar.java
@@ -1,0 +1,64 @@
+package org.zalando.logbook.netty;
+
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import lombok.RequiredArgsConstructor;
+import org.apiguardian.api.API;
+import org.zalando.logbook.Logbook;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientState;
+import reactor.netty.http.server.HttpServer;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * Installs {@link LogbookClientHandler} and {@link LogbookServerHandler} on Reactor Netty
+ * connections, including HTTP/2 stream channels.
+ *
+ * <p>For HTTP/2 clients, uses {@link HttpClientState#STREAM_CONFIGURED} to install the handler
+ * on each virtual stream channel rather than the parent TCP connection. For HTTP/1.1 clients,
+ * {@link ConnectionObserver.State#CONFIGURED} is used when no {@link Http2ConnectionHandler}
+ * is detected in the pipeline.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * Http2AwareHandlerRegistrar registrar = new Http2AwareHandlerRegistrar(logbook);
+ * HttpClient client = HttpClient.create()
+ *     .observe(registrar.clientObserver());
+ * HttpServer server = HttpServer.create()
+ *     .childObserve(registrar.serverObserver());
+ * }</pre>
+ */
+@API(status = EXPERIMENTAL)
+@RequiredArgsConstructor
+public final class Http2AwareHandlerRegistrar {
+
+    private final Logbook logbook;
+
+    public ConnectionObserver clientObserver() {
+        return (connection, state) -> {
+            if (state == HttpClientState.STREAM_CONFIGURED) {
+                // H2 stream channel: install directly (stream channel is per-request)
+                connection.addHandlerLast(new LogbookClientHandler(logbook));
+            } else if (state == ConnectionObserver.State.CONFIGURED) {
+                // HTTP/1.1 connection: guard against parent H2 TCP channel and duplicate installs
+                final var pipeline = connection.channel().pipeline();
+                if (pipeline.get(Http2ConnectionHandler.class) == null
+                        && pipeline.get(LogbookClientHandler.class) == null) {
+                    connection.addHandlerLast(new LogbookClientHandler(logbook));
+                }
+            }
+        };
+    }
+
+    public ConnectionObserver serverObserver() {
+        return (connection, state) -> {
+            if (state == ConnectionObserver.State.CONFIGURED) {
+                final var pipeline = connection.channel().pipeline();
+                if (pipeline.get(LogbookServerHandler.class) == null) {
+                    connection.addHandlerLast(new LogbookServerHandler(logbook));
+                }
+            }
+        };
+    }
+}

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrar.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrar.java
@@ -1,7 +1,6 @@
 package org.zalando.logbook.netty;
 
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import lombok.RequiredArgsConstructor;
 import org.apiguardian.api.API;
 import org.zalando.logbook.Logbook;
 import reactor.netty.ConnectionObserver;
@@ -13,52 +12,41 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
  * Installs {@link LogbookClientHandler} and {@link LogbookServerHandler} on Reactor Netty
- * connections, including HTTP/2 stream channels.
- *
- * <p>For HTTP/2 clients, uses {@link HttpClientState#STREAM_CONFIGURED} to install the handler
- * on each virtual stream channel rather than the parent TCP connection. For HTTP/1.1 clients,
- * {@link ConnectionObserver.State#CONFIGURED} is used when no {@link Http2ConnectionHandler}
- * is detected in the pipeline.
+ * connections, supporting both HTTP/1.1 and HTTP/2 (including H2C).
  *
  * <p>Usage:
  * <pre>{@code
- * Http2AwareHandlerRegistrar registrar = new Http2AwareHandlerRegistrar(logbook);
- * HttpClient client = HttpClient.create()
- *     .observe(registrar.clientObserver());
- * HttpServer server = HttpServer.create()
- *     .childObserve(registrar.serverObserver());
+ * HttpClient client = Http2AwareHandlerRegistrar.installOnClient(HttpClient.create(), logbook);
+ * HttpServer server = Http2AwareHandlerRegistrar.installOnServer(HttpServer.create(), logbook);
  * }</pre>
  */
 @API(status = EXPERIMENTAL)
-@RequiredArgsConstructor
 public final class Http2AwareHandlerRegistrar {
 
-    private final Logbook logbook;
+    private Http2AwareHandlerRegistrar() {}
 
-    public ConnectionObserver clientObserver() {
-        return (connection, state) -> {
+    public static HttpClient installOnClient(final HttpClient httpClient, final Logbook logbook) {
+        return httpClient.observe((connection, state) -> {
             if (state == HttpClientState.STREAM_CONFIGURED) {
-                // H2 stream channel: install directly (stream channel is per-request)
                 connection.addHandlerLast(new LogbookClientHandler(logbook));
             } else if (state == ConnectionObserver.State.CONFIGURED) {
-                // HTTP/1.1 connection: guard against parent H2 TCP channel and duplicate installs
                 final var pipeline = connection.channel().pipeline();
                 if (pipeline.get(Http2ConnectionHandler.class) == null
                         && pipeline.get(LogbookClientHandler.class) == null) {
                     connection.addHandlerLast(new LogbookClientHandler(logbook));
                 }
             }
-        };
+        });
     }
 
-    public ConnectionObserver serverObserver() {
-        return (connection, state) -> {
+    public static HttpServer installOnServer(final HttpServer httpServer, final Logbook logbook) {
+        return httpServer.observe((connection, state) -> {
             if (state == ConnectionObserver.State.CONFIGURED) {
                 final var pipeline = connection.channel().pipeline();
                 if (pipeline.get(LogbookServerHandler.class) == null) {
                     connection.addHandlerLast(new LogbookServerHandler(logbook));
                 }
             }
-        };
+        });
     }
 }

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookClientHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookClientHandler.java
@@ -46,7 +46,7 @@ public final class LogbookClientHandler extends ChannelDuplexHandler {
         });
 
         runIf(message, HttpContent.class, content -> request.buffer(content.content()));
-        runIf(message, ByteBuf.class, request::buffer);
+        runIf(message, ByteBuf.class, buf -> { if (request != null) request.buffer(buf); });
 
         runIf(message, LastHttpContent.class, content ->
                 sequence.set(0, throwingRunnable(requestStage::write)));
@@ -60,12 +60,12 @@ public final class LogbookClientHandler extends ChannelDuplexHandler {
             final Object message) {
 
         runIf(message, HttpResponse.class, httpResponse -> {
-            this.response = new Response(REMOTE, httpResponse);
+            this.response = new Response(context, REMOTE, httpResponse);
             this.responseStage = requestStage.process(response);
         });
 
         runIf(message, HttpContent.class, content -> response.buffer(content.content()));
-        runIf(message, ByteBuf.class, response::buffer);
+        runIf(message, ByteBuf.class, buf -> { if (response != null) response.buffer(buf); });
 
         runIf(message, LastHttpContent.class, content ->
                 sequence.set(1, throwingRunnable(responseStage::write)));

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/LogbookServerHandler.java
@@ -46,7 +46,7 @@ public final class LogbookServerHandler extends ChannelDuplexHandler {
         });
 
         runIf(message, HttpContent.class, content -> request.buffer(content.content()));
-        runIf(message, ByteBuf.class, request::buffer);
+        runIf(message, ByteBuf.class, buf -> { if (request != null) request.buffer(buf); });
 
         runIf(message, LastHttpContent.class, content ->
                 sequence.set(0, throwingRunnable(requestStage::write)));
@@ -61,12 +61,12 @@ public final class LogbookServerHandler extends ChannelDuplexHandler {
             final ChannelPromise promise) {
 
         runIf(message, HttpResponse.class, httpResponse -> {
-            this.response = new Response(LOCAL, httpResponse);
+            this.response = new Response(context, LOCAL, httpResponse);
             this.responseStage = requestStage.process(response);
         });
 
         runIf(message, HttpContent.class, content -> response.buffer(content.content()));
-        runIf(message, ByteBuf.class, response::buffer);
+        runIf(message, ByteBuf.class, buf -> { if (response != null) response.buffer(buf); });
 
         runIf(message, LastHttpContent.class, content ->
                 sequence.set(1, throwingRunnable(responseStage::write)));

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Request.java
@@ -6,6 +6,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslHandler;
 import lombok.AllArgsConstructor;
 import org.zalando.logbook.HttpHeaders;
@@ -44,6 +46,9 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
 
     @Override
     public String getProtocolVersion() {
+        if (context.channel() instanceof Http2StreamChannel) {
+            return "HTTP/2.0";
+        }
         return request.protocolVersion().text();
     }
 
@@ -68,8 +73,10 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
 
     @Override
     public String getScheme() {
-        final SslHandler handler = context.channel().pipeline().get(SslHandler.class);
-        return handler == null ? "http" : "https";
+        final Channel lookup = context.channel().parent() != null
+            ? context.channel().parent()
+            : context.channel();
+        return lookup.pipeline().get(SslHandler.class) != null ? "https" : "http";
     }
 
     @Override
@@ -110,7 +117,11 @@ final class Request implements org.zalando.logbook.HttpRequest, HeaderSupport {
 
     @Override
     public HttpHeaders getHeaders() {
-        return copyOf(request.headers());
+        final io.netty.handler.codec.http.HttpHeaders raw = request.headers().copy();
+        raw.remove(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text());
+        raw.remove(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
+        raw.remove(HttpConversionUtil.ExtensionHeaderNames.PATH.text());
+        return copyOf(raw);
     }
 
     @Nullable

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Response.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Response.java
@@ -28,13 +28,9 @@ final class Response
     private final Origin origin;
     private final HttpResponse response;
 
-    Response(final Origin origin, final HttpResponse response) {
-        this(null, origin, response);
-    }
-
     @Override
     public String getProtocolVersion() {
-        if (context != null && context.channel() instanceof Http2StreamChannel) {
+        if (context.channel() instanceof Http2StreamChannel) {
             return "HTTP/2.0";
         }
         return response.protocolVersion().text();

--- a/logbook-netty/src/main/java/org/zalando/logbook/netty/Response.java
+++ b/logbook-netty/src/main/java/org/zalando/logbook/netty/Response.java
@@ -1,8 +1,11 @@
 package org.zalando.logbook.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import lombok.AllArgsConstructor;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.Origin;
@@ -21,11 +24,19 @@ final class Response
     private final AtomicReference<State> state =
             new AtomicReference<>(new Unbuffered());
 
+    private final ChannelHandlerContext context;
     private final Origin origin;
     private final HttpResponse response;
 
+    Response(final Origin origin, final HttpResponse response) {
+        this(null, origin, response);
+    }
+
     @Override
     public String getProtocolVersion() {
+        if (context != null && context.channel() instanceof Http2StreamChannel) {
+            return "HTTP/2.0";
+        }
         return response.protocolVersion().text();
     }
 
@@ -41,7 +52,11 @@ final class Response
 
     @Override
     public HttpHeaders getHeaders() {
-        return copyOf(response.headers());
+        final io.netty.handler.codec.http.HttpHeaders raw = response.headers().copy();
+        raw.remove(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text());
+        raw.remove(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
+        raw.remove(HttpConversionUtil.ExtensionHeaderNames.PATH.text());
+        return copyOf(raw);
     }
 
     @Nullable

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrarTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrarTest.java
@@ -4,10 +4,13 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.zalando.logbook.Logbook;
 import reactor.netty.Connection;
 import reactor.netty.ConnectionObserver;
+import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientState;
+import reactor.netty.http.server.HttpServer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -19,76 +22,98 @@ import static org.mockito.Mockito.when;
 class Http2AwareHandlerRegistrarTest {
 
     private final Logbook logbook = mock(Logbook.class);
-    private final Http2AwareHandlerRegistrar registrar = new Http2AwareHandlerRegistrar(logbook);
 
-    // --- Client observer tests ---
+    // --- Client tests ---
 
     @Test
     void shouldNotInstallClientHandlerOnH2TcpParentChannel() {
+        ConnectionObserver observer = captureClientObserver();
         Connection conn = mockConnectionWithHandler(Http2ConnectionHandler.class);
-        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        observer.onStateChange(conn, ConnectionObserver.State.CONFIGURED);
         verify(conn, never()).addHandlerLast(any(LogbookClientHandler.class));
     }
 
     @Test
     void shouldInstallClientHandlerOnHttp11Channel() {
+        ConnectionObserver observer = captureClientObserver();
         Connection conn = mockConnectionWithNoHandlers();
-        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        observer.onStateChange(conn, ConnectionObserver.State.CONFIGURED);
         verify(conn, times(1)).addHandlerLast(any(LogbookClientHandler.class));
     }
 
     @Test
     void shouldNotInstallClientHandlerTwiceOnKeepAliveHttp11Channel() {
+        ConnectionObserver observer = captureClientObserver();
         Connection conn = mockConnectionWithHandler(LogbookClientHandler.class);
-        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        observer.onStateChange(conn, ConnectionObserver.State.CONFIGURED);
         verify(conn, never()).addHandlerLast(any(LogbookClientHandler.class));
     }
 
     @Test
     void shouldInstallClientHandlerOnH2StreamChannel() {
+        ConnectionObserver observer = captureClientObserver();
         Connection conn = mockConnectionWithNoHandlers();
-        registrar.clientObserver().onStateChange(conn, HttpClientState.STREAM_CONFIGURED);
+        observer.onStateChange(conn, HttpClientState.STREAM_CONFIGURED);
         verify(conn, times(1)).addHandlerLast(any(LogbookClientHandler.class));
     }
 
     @Test
     void shouldIgnoreOtherClientStates() {
+        ConnectionObserver observer = captureClientObserver();
         Connection conn = mockConnectionWithNoHandlers();
-        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.DISCONNECTING);
+        observer.onStateChange(conn, ConnectionObserver.State.DISCONNECTING);
         verify(conn, never()).addHandlerLast(any());
     }
 
-    // --- Server observer tests ---
+    // --- Server tests ---
 
     @Test
     void shouldInstallServerHandlerOnNewConnection() {
+        ConnectionObserver observer = captureServerObserver();
         Connection conn = mockConnectionWithNoHandlers();
-        registrar.serverObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        observer.onStateChange(conn, ConnectionObserver.State.CONFIGURED);
         verify(conn, times(1)).addHandlerLast(any(LogbookServerHandler.class));
     }
 
     @Test
     void shouldNotInstallServerHandlerTwiceOnKeepAliveChannel() {
-        Connection conn = mockConnectionWithHandler(LogbookServerHandler.class);
-        // First call: handler not present (handled by fresh mock)
-        Connection freshConn = mockConnectionWithNoHandlers();
-        registrar.serverObserver().onStateChange(freshConn, ConnectionObserver.State.CONFIGURED);
+        ConnectionObserver observer = captureServerObserver();
 
-        // Second call: handler already present (keep-alive re-fire)
-        registrar.serverObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        Connection freshConn = mockConnectionWithNoHandlers();
+        observer.onStateChange(freshConn, ConnectionObserver.State.CONFIGURED);
+
+        Connection existingConn = mockConnectionWithHandler(LogbookServerHandler.class);
+        observer.onStateChange(existingConn, ConnectionObserver.State.CONFIGURED);
 
         verify(freshConn, times(1)).addHandlerLast(any(LogbookServerHandler.class));
-        verify(conn, never()).addHandlerLast(any(LogbookServerHandler.class));
+        verify(existingConn, never()).addHandlerLast(any(LogbookServerHandler.class));
     }
 
     @Test
     void shouldIgnoreOtherServerStates() {
+        ConnectionObserver observer = captureServerObserver();
         Connection conn = mockConnectionWithNoHandlers();
-        registrar.serverObserver().onStateChange(conn, ConnectionObserver.State.DISCONNECTING);
+        observer.onStateChange(conn, ConnectionObserver.State.DISCONNECTING);
         verify(conn, never()).addHandlerLast(any());
     }
 
     // --- helpers ---
+
+    private ConnectionObserver captureClientObserver() {
+        HttpClient base = mock(HttpClient.class);
+        ArgumentCaptor<ConnectionObserver> captor = ArgumentCaptor.forClass(ConnectionObserver.class);
+        when(base.observe(captor.capture())).thenReturn(mock(HttpClient.class));
+        Http2AwareHandlerRegistrar.installOnClient(base, logbook);
+        return captor.getValue();
+    }
+
+    private ConnectionObserver captureServerObserver() {
+        HttpServer base = mock(HttpServer.class);
+        ArgumentCaptor<ConnectionObserver> captor = ArgumentCaptor.forClass(ConnectionObserver.class);
+        when(base.observe(captor.capture())).thenReturn(mock(HttpServer.class));
+        Http2AwareHandlerRegistrar.installOnServer(base, logbook);
+        return captor.getValue();
+    }
 
     private Connection mockConnectionWithNoHandlers() {
         Connection conn = mock(Connection.class);

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrarTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/Http2AwareHandlerRegistrarTest.java
@@ -1,0 +1,115 @@
+package org.zalando.logbook.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Logbook;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.http.client.HttpClientState;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class Http2AwareHandlerRegistrarTest {
+
+    private final Logbook logbook = mock(Logbook.class);
+    private final Http2AwareHandlerRegistrar registrar = new Http2AwareHandlerRegistrar(logbook);
+
+    // --- Client observer tests ---
+
+    @Test
+    void shouldNotInstallClientHandlerOnH2TcpParentChannel() {
+        Connection conn = mockConnectionWithHandler(Http2ConnectionHandler.class);
+        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        verify(conn, never()).addHandlerLast(any(LogbookClientHandler.class));
+    }
+
+    @Test
+    void shouldInstallClientHandlerOnHttp11Channel() {
+        Connection conn = mockConnectionWithNoHandlers();
+        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        verify(conn, times(1)).addHandlerLast(any(LogbookClientHandler.class));
+    }
+
+    @Test
+    void shouldNotInstallClientHandlerTwiceOnKeepAliveHttp11Channel() {
+        Connection conn = mockConnectionWithHandler(LogbookClientHandler.class);
+        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        verify(conn, never()).addHandlerLast(any(LogbookClientHandler.class));
+    }
+
+    @Test
+    void shouldInstallClientHandlerOnH2StreamChannel() {
+        Connection conn = mockConnectionWithNoHandlers();
+        registrar.clientObserver().onStateChange(conn, HttpClientState.STREAM_CONFIGURED);
+        verify(conn, times(1)).addHandlerLast(any(LogbookClientHandler.class));
+    }
+
+    @Test
+    void shouldIgnoreOtherClientStates() {
+        Connection conn = mockConnectionWithNoHandlers();
+        registrar.clientObserver().onStateChange(conn, ConnectionObserver.State.DISCONNECTING);
+        verify(conn, never()).addHandlerLast(any());
+    }
+
+    // --- Server observer tests ---
+
+    @Test
+    void shouldInstallServerHandlerOnNewConnection() {
+        Connection conn = mockConnectionWithNoHandlers();
+        registrar.serverObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+        verify(conn, times(1)).addHandlerLast(any(LogbookServerHandler.class));
+    }
+
+    @Test
+    void shouldNotInstallServerHandlerTwiceOnKeepAliveChannel() {
+        Connection conn = mockConnectionWithHandler(LogbookServerHandler.class);
+        // First call: handler not present (handled by fresh mock)
+        Connection freshConn = mockConnectionWithNoHandlers();
+        registrar.serverObserver().onStateChange(freshConn, ConnectionObserver.State.CONFIGURED);
+
+        // Second call: handler already present (keep-alive re-fire)
+        registrar.serverObserver().onStateChange(conn, ConnectionObserver.State.CONFIGURED);
+
+        verify(freshConn, times(1)).addHandlerLast(any(LogbookServerHandler.class));
+        verify(conn, never()).addHandlerLast(any(LogbookServerHandler.class));
+    }
+
+    @Test
+    void shouldIgnoreOtherServerStates() {
+        Connection conn = mockConnectionWithNoHandlers();
+        registrar.serverObserver().onStateChange(conn, ConnectionObserver.State.DISCONNECTING);
+        verify(conn, never()).addHandlerLast(any());
+    }
+
+    // --- helpers ---
+
+    private Connection mockConnectionWithNoHandlers() {
+        Connection conn = mock(Connection.class);
+        Channel channel = mock(Channel.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(conn.channel()).thenReturn(channel);
+        when(channel.pipeline()).thenReturn(pipeline);
+        when(pipeline.get(Http2ConnectionHandler.class)).thenReturn(null);
+        when(pipeline.get(LogbookClientHandler.class)).thenReturn(null);
+        when(pipeline.get(LogbookServerHandler.class)).thenReturn(null);
+        return conn;
+    }
+
+    private <T extends io.netty.channel.ChannelHandler> Connection mockConnectionWithHandler(Class<T> handlerClass) {
+        Connection conn = mock(Connection.class);
+        Channel channel = mock(Channel.class);
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(conn.channel()).thenReturn(channel);
+        when(channel.pipeline()).thenReturn(pipeline);
+        T handler = mock(handlerClass);
+        when(pipeline.get(handlerClass)).thenReturn(handler);
+        return conn;
+    }
+}

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/LogbookClientHandlerTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/LogbookClientHandlerTest.java
@@ -1,6 +1,13 @@
 package org.zalando.logbook.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +30,7 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -207,6 +215,51 @@ final class LogbookClientHandlerTest {
                 .responseContent()
                 .aggregate()
                 .block();
+    }
+
+    @Test
+    void shouldNotThrowNpeWhenByteBufArrivesBeforeRequest() throws IOException {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookClientHandler(logbook));
+        ByteBuf buf = Unpooled.copiedBuffer("noise", UTF_8);
+        assertThatCode(() -> channel.writeInbound(buf)).doesNotThrowAnyException();
+        verify(writer, never()).write(any(Precorrelation.class), any());
+    }
+
+    @Test
+    void shouldNotThrowNpeWhenByteBufArrivesOnInboundBeforeResponse() {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookClientHandler(logbook));
+        ByteBuf buf = Unpooled.copiedBuffer("noise", UTF_8);
+        assertThatCode(() -> channel.writeInbound(buf)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldBufferOutboundByteBufWhenRequestIsAlreadySet() {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookClientHandler(logbook));
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/test");
+        channel.writeOutbound(httpRequest);
+        ByteBuf buf = Unpooled.copiedBuffer("body", UTF_8);
+        assertThatCode(() -> channel.writeOutbound(buf)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowNpeWhenOutboundByteBufArrivesBeforeRequest() {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookClientHandler(logbook));
+        ByteBuf buf = Unpooled.copiedBuffer("noise", UTF_8);
+        assertThatCode(() -> channel.writeOutbound(buf)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldBufferInboundByteBufWhenResponseIsAlreadySet() {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookClientHandler(logbook));
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/test");
+        channel.writeOutbound(httpRequest);
+        DefaultHttpResponse httpResponse = new DefaultHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        channel.writeInbound(httpResponse);
+        ByteBuf buf = Unpooled.copiedBuffer("body", UTF_8);
+        assertThatCode(() -> channel.writeInbound(buf)).doesNotThrowAnyException();
     }
 
 }

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/LogbookServerHandlerTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/LogbookServerHandlerTest.java
@@ -3,6 +3,8 @@ package org.zalando.logbook.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.EmptyByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -33,6 +35,7 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -239,6 +242,49 @@ final class LogbookServerHandlerTest {
 
         assertThat(responseMessage)
                 .startsWith("Outgoing Response:");
+    }
+
+    @Test
+    void shouldNotThrowNpeWhenByteBufArrivesBeforeRequest() throws IOException {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookServerHandler(logbook));
+        ByteBuf buf = Unpooled.copiedBuffer("noise", UTF_8);
+        assertThatCode(() -> channel.writeInbound(buf)).doesNotThrowAnyException();
+        verify(writer, never()).write(any(Precorrelation.class), any());
+    }
+
+    @Test
+    void shouldNotThrowNpeWhenOutboundByteBufArrivesBeforeResponse() {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookServerHandler(logbook));
+        ByteBuf buf = Unpooled.copiedBuffer("noise", UTF_8);
+        assertThatCode(() -> channel.writeOutbound(buf)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldBufferInboundByteBufWhenRequestIsAlreadySet() {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookServerHandler(logbook));
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.POST, "/echo");
+        channel.writeInbound(httpRequest);
+        ByteBuf buf = Unpooled.copiedBuffer("body", UTF_8);
+        assertThatCode(() -> channel.writeInbound(buf)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldBufferOutboundByteBufWhenResponseIsAlreadySet() throws IOException {
+        EmbeddedChannel channel = new EmbeddedChannel(new LogbookServerHandler(logbook));
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/echo");
+        channel.writeInbound(httpRequest);
+
+        FullHttpResponse httpResponse = mock(FullHttpResponse.class);
+        when(httpResponse.headers()).thenReturn(EmptyHttpHeaders.INSTANCE);
+        when(httpResponse.content()).thenReturn(new EmptyByteBuf(ByteBufAllocator.DEFAULT));
+        when(httpResponse.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+        when(httpResponse.status()).thenReturn(HttpResponseStatus.OK);
+        channel.writeOutbound(httpResponse);
+
+        ByteBuf buf = Unpooled.copiedBuffer("body", UTF_8);
+        assertThatCode(() -> channel.writeOutbound(buf)).doesNotThrowAnyException();
     }
 
     private void sendAndReceive() {

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/RequestUnitTest.java
@@ -5,14 +5,19 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.local.LocalAddress;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.SslHandler;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.codec.http.HttpMethod.GET;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -108,6 +113,103 @@ public class RequestUnitTest {
 
         Request remoteRequest = new Request(context, REMOTE, req);
         assertThat(remoteRequest.getRemote()).isEqualTo(null);
+    }
+
+    @Test
+    void shouldReturnHttp2ProtocolVersionOnHttp2StreamChannel() {
+        Http2StreamChannel streamChannel = mock(Http2StreamChannel.class);
+        when(streamChannel.parent()).thenReturn(null);
+        when(streamChannel.pipeline()).thenReturn(mock(ChannelPipeline.class));
+        when(streamChannel.remoteAddress()).thenReturn(LocalAddress.ANY);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(streamChannel);
+
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/");
+        when(req.headers()).thenReturn(new DefaultHttpHeaders());
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        Request request = new Request(ctx, REMOTE, req);
+        assertThat(request.getProtocolVersion()).isEqualTo("HTTP/2.0");
+    }
+
+    @Test
+    void shouldReturnHttpsSchemeWhenParentChannelHasSslHandler() {
+        Channel parentChannel = mock(Channel.class);
+        ChannelPipeline parentPipeline = mock(ChannelPipeline.class);
+        when(parentChannel.pipeline()).thenReturn(parentPipeline);
+        when(parentPipeline.get(SslHandler.class)).thenReturn(mock(SslHandler.class));
+
+        Channel streamChannel = mock(Channel.class);
+        when(streamChannel.parent()).thenReturn(parentChannel);
+        when(streamChannel.pipeline()).thenReturn(mock(ChannelPipeline.class));
+        when(streamChannel.remoteAddress()).thenReturn(LocalAddress.ANY);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(streamChannel);
+
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/");
+        when(req.headers()).thenReturn(new DefaultHttpHeaders());
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        Request request = new Request(ctx, REMOTE, req);
+        assertThat(request.getScheme()).isEqualTo("https");
+    }
+
+    @Test
+    void shouldReturnHttpSchemeWhenParentChannelHasNoSslHandler() {
+        Channel parentChannel = mock(Channel.class);
+        ChannelPipeline parentPipeline = mock(ChannelPipeline.class);
+        when(parentChannel.pipeline()).thenReturn(parentPipeline);
+        when(parentPipeline.get(SslHandler.class)).thenReturn(null);
+
+        Channel streamChannel = mock(Channel.class);
+        when(streamChannel.parent()).thenReturn(parentChannel);
+        when(streamChannel.pipeline()).thenReturn(mock(ChannelPipeline.class));
+        when(streamChannel.remoteAddress()).thenReturn(LocalAddress.ANY);
+
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(streamChannel);
+
+        HttpRequest req = mock(HttpRequest.class);
+        when(req.uri()).thenReturn("/");
+        when(req.headers()).thenReturn(new DefaultHttpHeaders());
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.protocolVersion()).thenReturn(HttpVersion.HTTP_1_1);
+
+        Request request = new Request(ctx, REMOTE, req);
+        assertThat(request.getScheme()).isEqualTo("http");
+    }
+
+    @Test
+    void shouldStripSyntheticHttp2HeadersFromGetHeaders() {
+        DefaultHttpRequest httpReq = new DefaultHttpRequest(HTTP_1_1, GET, "/");
+        httpReq.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
+        httpReq.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
+        httpReq.headers().add(HttpConversionUtil.ExtensionHeaderNames.PATH.text(), "/real");
+        httpReq.headers().add("content-type", "text/plain");
+        Request request = new Request(mockChannelHandlerContext(), REMOTE, httpReq);
+        org.zalando.logbook.HttpHeaders headers = request.getHeaders();
+        assertThat(headers.keySet())
+            .doesNotContain(
+                HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text().toString(),
+                HttpConversionUtil.ExtensionHeaderNames.SCHEME.text().toString(),
+                HttpConversionUtil.ExtensionHeaderNames.PATH.text().toString())
+            .contains("content-type");
+    }
+
+    @Test
+    void shouldNotStripNonSyntheticHeadersHttp11() {
+        DefaultHttpRequest httpReq = new DefaultHttpRequest(HTTP_1_1, GET, "/");
+        httpReq.headers().add("content-type", "application/json");
+        httpReq.headers().add("x-custom", "value");
+        Request request = new Request(mockChannelHandlerContext(), REMOTE, httpReq);
+        org.zalando.logbook.HttpHeaders headers = request.getHeaders();
+        assertThat(headers.keySet()).contains("content-type", "x-custom");
     }
 
     private ChannelHandlerContext mockChannelHandlerContext() {

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/ResponseUnitTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/ResponseUnitTest.java
@@ -68,17 +68,12 @@ class ResponseUnitTest {
     }
 
     @Test
-    void shouldReturnProtocolVersionWhenContextIsNull() {
-        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-        // Uses the two-arg constructor (context = null)
-        Response response = new Response(REMOTE, httpResp);
-        assertThat(response.getProtocolVersion()).isEqualTo("HTTP/1.1");
-    }
-
-    @Test
     void shouldReturnCorrectStatusCode() {
+        Channel channel = mock(Channel.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
         DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
-        Response response = new Response(REMOTE, httpResp);
+        Response response = new Response(ctx, REMOTE, httpResp);
         assertThat(response.getStatus()).isEqualTo(404);
     }
 }

--- a/logbook-netty/src/test/java/org/zalando/logbook/netty/ResponseUnitTest.java
+++ b/logbook-netty/src/test/java/org/zalando/logbook/netty/ResponseUnitTest.java
@@ -1,0 +1,84 @@
+package org.zalando.logbook.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.zalando.logbook.Origin.REMOTE;
+
+class ResponseUnitTest {
+
+    @Test
+    void shouldStripSyntheticHttp2HeadersFromGetHeaders() {
+        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResp.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), "3");
+        httpResp.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
+        httpResp.headers().add(HttpConversionUtil.ExtensionHeaderNames.PATH.text(), "/real");
+        httpResp.headers().add("content-type", "text/plain");
+        Response response = new Response(mock(ChannelHandlerContext.class), REMOTE, httpResp);
+        HttpHeaders headers = response.getHeaders();
+        assertThat(headers.keySet())
+            .doesNotContain(
+                HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text().toString(),
+                HttpConversionUtil.ExtensionHeaderNames.SCHEME.text().toString(),
+                HttpConversionUtil.ExtensionHeaderNames.PATH.text().toString())
+            .contains("content-type");
+    }
+
+    @Test
+    void shouldNotStripNonSyntheticHeaders() {
+        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResp.headers().add("content-type", "application/json");
+        httpResp.headers().add("x-custom", "value");
+        Response response = new Response(mock(ChannelHandlerContext.class), REMOTE, httpResp);
+        HttpHeaders headers = response.getHeaders();
+        assertThat(headers.keySet()).contains("content-type", "x-custom");
+    }
+
+    @Test
+    void shouldReturnHttp2ProtocolVersionOnHttp2StreamChannel() {
+        Http2StreamChannel streamChannel = mock(Http2StreamChannel.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(streamChannel);
+
+        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        Response response = new Response(ctx, REMOTE, httpResp);
+        assertThat(response.getProtocolVersion()).isEqualTo("HTTP/2.0");
+    }
+
+    @Test
+    void shouldReturnHttp11ProtocolVersionOnNonHttp2Channel() {
+        Channel channel = mock(Channel.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+
+        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        Response response = new Response(ctx, REMOTE, httpResp);
+        assertThat(response.getProtocolVersion()).isEqualTo("HTTP/1.1");
+    }
+
+    @Test
+    void shouldReturnProtocolVersionWhenContextIsNull() {
+        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        // Uses the two-arg constructor (context = null)
+        Response response = new Response(REMOTE, httpResp);
+        assertThat(response.getProtocolVersion()).isEqualTo("HTTP/1.1");
+    }
+
+    @Test
+    void shouldReturnCorrectStatusCode() {
+        DefaultHttpResponse httpResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+        Response response = new Response(REMOTE, httpResp);
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+}

--- a/logbook-spring-boot-webflux-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/webflux/LogbookNettyClientCustomizer.java
+++ b/logbook-spring-boot-webflux-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/webflux/LogbookNettyClientCustomizer.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.http.client.autoconfigure.reactive.ClientHttpConnectorBuilderCustomizer;
 import org.springframework.boot.http.client.reactive.ReactorClientHttpConnectorBuilder;
 import org.zalando.logbook.Logbook;
-import org.zalando.logbook.netty.LogbookClientHandler;
+import org.zalando.logbook.netty.Http2AwareHandlerRegistrar;
 
 @RequiredArgsConstructor
 public class LogbookNettyClientCustomizer implements ClientHttpConnectorBuilderCustomizer<ReactorClientHttpConnectorBuilder> {
@@ -14,8 +14,7 @@ public class LogbookNettyClientCustomizer implements ClientHttpConnectorBuilderC
     @Override
     public ReactorClientHttpConnectorBuilder customize(ReactorClientHttpConnectorBuilder builder) {
         return builder.withHttpClientCustomizer(httpClient ->
-                httpClient.doOnConnected(connection ->
-                        connection.addHandlerLast(new LogbookClientHandler(logbook)))
+                Http2AwareHandlerRegistrar.installOnClient(httpClient, logbook)
         );
     }
 }

--- a/logbook-spring-boot-webflux-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/webflux/LogbookWebFluxAutoConfiguration.java
+++ b/logbook-spring-boot-webflux-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/webflux/LogbookWebFluxAutoConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.server.WebFilter;
 import org.zalando.logbook.Logbook;
-import org.zalando.logbook.netty.LogbookServerHandler;
+import org.zalando.logbook.netty.Http2AwareHandlerRegistrar;
 import org.zalando.logbook.spring.webflux.LogbookExchangeFilterFunction;
 import org.zalando.logbook.spring.webflux.LogbookWebFilter;
 import reactor.netty.http.server.HttpServer;
@@ -38,7 +38,7 @@ public class LogbookWebFluxAutoConfiguration {
         @ConditionalOnProperty(name = "logbook.filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = CUSTOMIZER_NAME)
         public NettyServerCustomizer logbookNettyServerCustomizer(final Logbook logbook) {
-            return httpServer -> httpServer.doOnConnection(connection -> connection.addHandlerLast(new LogbookServerHandler(logbook)));
+            return httpServer -> Http2AwareHandlerRegistrar.installOnServer(httpServer, logbook);
         }
     }
 


### PR DESCRIPTION
Adds `Http2AwareHandlerRegistrar` to `logbook-netty` with static `installOnClient` / `installOnServer` helpers that correctly wire `LogbookClientHandler` and `LogbookServerHandler` for both HTTP/1.1 and HTTP/2 (H2C and TLS H2) connections.
Updates Spring Boot WebFlux autoconfiguration to use the new registrar, and extends `Request`/`Response` to report `HTTP/2.0` protocol version on H2 stream channels.