### PR TITLE
Wrap LogbookClientHttpRequestInterceptor in @ConditionalOnClass guard

### DIFF
--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -363,10 +363,15 @@ public class LogbookAutoConfiguration {
         return new DefaultHttpLogWriter();
     }
 
-    @Bean
-    @ConditionalOnMissingBean(LogbookClientHttpRequestInterceptor.class)
-    public LogbookClientHttpRequestInterceptor logbookClientHttpRequestInterceptor(Logbook logbook) {
-        return new LogbookClientHttpRequestInterceptor(logbook);
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(name = "org.springframework.http.client.ClientHttpRequestInterceptor")
+    static class ClientHttpAutoConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(LogbookClientHttpRequestInterceptor.class)
+        public LogbookClientHttpRequestInterceptor logbookClientHttpRequestInterceptor(final Logbook logbook) {
+            return new LogbookClientHttpRequestInterceptor(logbook);
+        }
     }
 
     @Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Fixes #2174

## Problem

`LogbookAutoConfiguration` was unconditionally registering a `LogbookClientHttpRequestInterceptor` bean, causing a `ClassNotFoundException` on startup in environments where `spring-web` is not on the classpath:

Caused by: java.lang.ClassNotFoundException: 
org.springframework.http.client.ClientHttpRequestInterceptor

This affects applications that use `logbook-spring-boot-starter` with other HTTP clients (OkHttp, Apache HttpClient) but without `spring-boot-starter-web`.

## Fix

Wrapped the bean registration in a new `ClientHttpAutoConfiguration` inner class with `@ConditionalOnClass(name = "org.springframework.http.client.ClientHttpRequestInterceptor")` so the bean is only created when Spring Web is present, consistent with how other optional integrations are already handled in the same file — `HttpClientAutoConfiguration`, `OpenFeignConfiguration`, etc.

## No behaviour change for existing users

Applications that already have `spring-web` on the classpath are completely unaffected the bean is registered exactly as before.
