### PR TITLE
Fix CachingHttpResponse dropping attributes on withoutBody()

### DIFF
--- a/logbook-core/src/main/java/org/zalando/logbook/core/CachingHttpResponse.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/CachingHttpResponse.java
@@ -5,6 +5,8 @@ import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.attributes.HttpAttributes;
 
+import java.io.IOException;
+
 final class CachingHttpResponse implements ForwardingHttpResponse {
 
     private final HttpResponse response;
@@ -36,4 +38,17 @@ final class CachingHttpResponse implements ForwardingHttpResponse {
         return httpAttributes;
     }
 
+    @Override
+    public HttpResponse withBody() throws IOException {
+        // preserve attributes when body is re-attached
+        return new CachingHttpResponse(response.withBody(), httpAttributes);
+    }
+
+    @Override
+    public HttpResponse withoutBody() {
+        // preserve attributes when body is stripped — fixes attribute loss
+        // in strategies like BodyOnlyIfStatusAtLeastStrategy that call
+        // response.withoutBody() on the cached response
+        return new CachingHttpResponse(response.withoutBody(), httpAttributes);
+    }
 }

--- a/logbook-core/src/main/java/org/zalando/logbook/core/CachingHttpResponse.java
+++ b/logbook-core/src/main/java/org/zalando/logbook/core/CachingHttpResponse.java
@@ -40,15 +40,11 @@ final class CachingHttpResponse implements ForwardingHttpResponse {
 
     @Override
     public HttpResponse withBody() throws IOException {
-        // preserve attributes when body is re-attached
         return new CachingHttpResponse(response.withBody(), httpAttributes);
     }
 
     @Override
     public HttpResponse withoutBody() {
-        // preserve attributes when body is stripped — fixes attribute loss
-        // in strategies like BodyOnlyIfStatusAtLeastStrategy that call
-        // response.withoutBody() on the cached response
         return new CachingHttpResponse(response.withoutBody(), httpAttributes);
     }
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/core/BodyOnlyIfStatusAtLeastStrategyTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/BodyOnlyIfStatusAtLeastStrategyTest.java
@@ -9,6 +9,8 @@ import org.zalando.logbook.HttpRequest;
 import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.Logbook;
 import org.zalando.logbook.Sink;
+import org.zalando.logbook.attributes.AttributeExtractor;
+import org.zalando.logbook.attributes.HttpAttributes;
 import org.zalando.logbook.test.MockHttpRequest;
 import org.zalando.logbook.test.MockHttpResponse;
 
@@ -71,6 +73,34 @@ class BodyOnlyIfStatusAtLeastStrategyTest {
 
         assertThat(writtenRequest.getValue().getBodyAsString()).isEqualTo("Hello");
         assertThat(writtenResponse.getValue().getBodyAsString()).isEqualTo("World");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {200, 201, 301})
+    void shouldPreserveResponseAttributesWhenStatusBelowMinimum(final int status) throws IOException {
+        // attributes from AttributeExtractor must appear in the log even when
+        // the response body is suppressed due to status < minimum
+        final HttpAttributes attributes = HttpAttributes.of("customAttribute", "someValue");
+
+        final Logbook logbookWithExtractor = Logbook.builder()
+                .strategy(new BodyOnlyIfStatusAtLeastStrategy(400))
+                .attributeExtractor(new AttributeExtractor() {
+                    @Override
+                    public HttpAttributes extract(final HttpRequest request, final HttpResponse response) {
+                        return attributes;
+                    }
+                })
+                .sink(sink)
+                .build();
+
+        logbookWithExtractor.process(request).write()
+                .process(response.withStatus(status)).write();
+
+        final ArgumentCaptor<HttpResponse> writtenResponse = ArgumentCaptor.forClass(HttpResponse.class);
+        verify(sink).writeBoth(any(), any(), writtenResponse.capture());
+
+        assertThat(writtenResponse.getValue().getAttributes())
+                .containsEntry("customAttribute", "someValue");
     }
 
 }

--- a/logbook-core/src/test/java/org/zalando/logbook/core/CachingHttpResponseTest.java
+++ b/logbook-core/src/test/java/org/zalando/logbook/core/CachingHttpResponseTest.java
@@ -1,6 +1,7 @@
 package org.zalando.logbook.core;
 
 import org.junit.jupiter.api.Test;
+import java.io.IOException;
 import org.zalando.logbook.HttpHeaders;
 import org.zalando.logbook.HttpResponse;
 import org.zalando.logbook.attributes.HttpAttributes;
@@ -44,6 +45,28 @@ final class CachingHttpResponseTest {
         final CachingHttpResponse unit2 = new CachingHttpResponse(delegate, attributes);
 
         assertThat(unit2.getAttributes()).isEqualTo(attributes);
+    }
+
+    @Test
+    void shouldPreserveAttributesAfterWithoutBody() {
+        final HttpAttributes attributes = HttpAttributes.of("key", "value");
+        final CachingHttpResponse unit = new CachingHttpResponse(MockHttpResponse.create(), attributes);
+
+        final HttpResponse withoutBody = unit.withoutBody();
+
+        // attributes must survive withoutBody() — this is the fix for
+        // BodyOnlyIfStatusAtLeastStrategy dropping response attributes
+        assertThat(withoutBody.getAttributes()).isEqualTo(attributes);
+    }
+
+    @Test
+    void shouldPreserveAttributesAfterWithBody() throws IOException {
+        final HttpAttributes attributes = HttpAttributes.of("key", "value");
+        final CachingHttpResponse unit = new CachingHttpResponse(MockHttpResponse.create(), attributes);
+
+        final HttpResponse withBody = unit.withBody();
+
+        assertThat(withBody.getAttributes()).isEqualTo(attributes);
     }
 
 }


### PR DESCRIPTION
Fixes #2115

## Root cause

When `BodyOnlyIfStatusAtLeastStrategy` called `response.withoutBody()` on a `CachingHttpResponse`, the resulting response lost all `HttpAttributes` extracted by `AttributeExtractor`. This happened because `CachingHttpResponse` inherited `ForwardingHttpResponse.withoutBody()` which delegates to the underlying response and discards the cached attributes entirely.

## Fix

Override `withoutBody()` and `withBody()` in `CachingHttpResponse` to return a new `CachingHttpResponse` that preserves the original `HttpAttributes`, consistent with how `FilteredHttpResponse` handles its own state across these calls.

## Test coverage

- `CachingHttpResponseTest` - two new tests verifying attributes survive `withoutBody()` and `withBody()`
- `BodyOnlyIfStatusAtLeastStrategyTest` - new parameterized test verifying response attributes are present in the log even when status is below the minimum threshold