### PR TITLE
fix: exclude apiguardian-api from faux-pas dependency

### DIFF
--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -323,6 +323,12 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>faux-pas</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apiguardian</groupId>
+                    <artifactId>apiguardian-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- logging -->
         <dependency>


### PR DESCRIPTION
## Description

This excludes `org.apiguardian:apiguardian-api` from the `org.zalando:faux-pas` dependency in `logbook-parent/pom.xml`.

`faux-pas:0.9.0` pulls in `apiguardian-api:1.1.1`, while Logbook already uses `apiguardian-api:1.1.2`. Excluding the older transitive dependency avoids the DependencyConvergence version mismatch.

## Motivation and Context

Fixes #2236.

This change addresses the Maven Enforcer `DependencyConvergence` failure caused by two different versions of `org.apiguardian:apiguardian-api` appearing in the dependency graph.

Validation:

* Ran `git diff --check` successfully.
* Checked the local patched `logbook-parent` dependency tree.
* The old transitive path from `org.zalando:faux-pas:0.9.0` to `org.apiguardian:apiguardian-api:1.1.1` no longer appeared.

Caveat:
A standalone consumer/enforcer verification was attempted, but the temporary POM failed before dependency resolution due to local parent POM resolution. No application code was changed.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All commits are [[signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)