### PR TITLE
fix: back off ECS sink when custom sink exists

### DIFF
--- a/logbook-spring-boot-ecs-autoconfigure/pom.xml
+++ b/logbook-spring-boot-ecs-autoconfigure/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>logbook-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/logbook-spring-boot-ecs-autoconfigure/src/main/java/org/zalando/logbook/ecs/autoconfigure/LogbookEcsAutoConfiguration.java
+++ b/logbook-spring-boot-ecs-autoconfigure/src/main/java/org/zalando/logbook/ecs/autoconfigure/LogbookEcsAutoConfiguration.java
@@ -33,6 +33,7 @@ public class LogbookEcsAutoConfiguration {
     @API(status = INTERNAL)
     @Bean
     @Conditional(ConditionalOnNativeEcsStructuredLoggingFormat.class)
+    @ConditionalOnMissingBean(Sink.class)
     Sink ecsSink(StructuredHttpLogFormatter ecsStructuredHttpLogFormatter) {
         return new EcsSink(ecsStructuredHttpLogFormatter);
     }

--- a/logbook-spring-boot-ecs-autoconfigure/src/test/java/org/zalando/logbook/ecs/autoconfigure/LogbookEcsAutoConfigurationTest.java
+++ b/logbook-spring-boot-ecs-autoconfigure/src/test/java/org/zalando/logbook/ecs/autoconfigure/LogbookEcsAutoConfigurationTest.java
@@ -1,0 +1,45 @@
+package org.zalando.logbook.ecs.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpRequest;
+import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.Sink;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LogbookEcsAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(LogbookEcsAutoConfiguration.class)
+            .withPropertyValues("logging.structured.format.console=ecs");
+
+    @Test
+    void shouldBackOffWhenSinkBeanExists() {
+        contextRunner
+                .withBean("customSink", Sink.class, CustomSink::new)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(Sink.class);
+                    assertThat(context).doesNotHaveBean("ecsSink");
+                    assertThat(context.getBean(Sink.class)).isInstanceOf(CustomSink.class);
+                });
+    }
+
+    private static class CustomSink implements Sink {
+
+        @Override
+        public void write(final Precorrelation precorrelation, final HttpRequest request) throws IOException {
+        }
+
+        @Override
+        public void write(final Correlation correlation, final HttpRequest request, final HttpResponse response)
+                throws IOException {
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Summary
- make ECS sink auto-configuration back off when an application already defines a `Sink`
- add a regression test covering the custom sink case
- add `spring-boot-test` as a test dependency for `ApplicationContextRunner`

Fixes #2342

## Tests
- `./mvnw.cmd -pl logbook-spring-boot-ecs-autoconfigure '-Denforcer.skip=true' test`
- `./mvnw.cmd -pl logbook-spring-boot-ecs-autoconfigure -am -DskipTests install`