### PR TITLE
Allow wrapping async completion listeners in servlet filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,33 @@ context.addFilter("LogbookFilter", new LogbookFilter(logbook))
 
 The first logbook filter will log unauthorized requests **only**. The second filter will log authorized requests, as always.
 
+#### Async Completion Listener
+
+For asynchronous requests the response is written on a different thread than the one that handled the request. `LogbookFilter` registers an `AsyncOnCompleteListener` to log the response once it becomes
+available, so any thread-local context — a tracing context, an MDC, a security context — is no longer visible by the time the response is logged.
+
+`AsyncOnCompleteListenerWrapper` wraps that listener before it is registered, on the request thread, which is where such context can still be captured:
+
+```java
+AsyncOnCompleteListenerWrapper wrapper = listener -> {
+    final ContextSnapshot snapshot = contextSnapshotFactory.captureAll();
+    return event -> {
+        try (ContextSnapshot.Scope ignored = snapshot.setThreadLocals()) {
+            listener.onComplete(event);
+        }
+    };
+};
+
+context.addFilter("LogbookFilter", new LogbookFilter(logbook).withAsyncOnCompleteListenerWrapper(wrapper))
+    .addMappingForUrlPatterns(EnumSet.of(REQUEST, ASYNC), true, "/*");
+```
+
+`SecureLogbookFilter` supports the same. The default, `AsyncOnCompleteListenerWrapper.identity()`, registers the listener as-is.
+
+With the Spring Boot starter it is enough to declare an `AsyncOnCompleteListenerWrapper` bean; it is picked up by both the `logbookFilter` and the `secureLogbookFilter`.
+
+Note that `wrap` is called once per filter for every asynchronous request — twice when both filters are registered — and always on the request thread. Implementations must therefore be stateless and thread-safe, and should capture the context inside `wrap` as shown above rather than storing it in a field.
+
 ### HTTP Client
 
 The `logbook-httpclient` module contains both an `HttpRequestInterceptor` and an `HttpResponseInterceptor` to use with the `HttpClient`:
@@ -1056,6 +1083,7 @@ or the following table to see a list of possible integration points:
 | `Sink`                   |                       | `DefaultSink`                                                             |
 | `HttpLogFormatter`       |                       | `JsonHttpLogFormatter`                                                    |
 | `HttpLogWriter`          |                       | `DefaultHttpLogWriter`                                                    |
+| `AsyncOnCompleteListenerWrapper` | `asyncOnCompleteListenerWrapper` | Identity, see [async completion listener](#async-completion-listener)     |
 
 Multiple filters are merged into one.
 

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListener.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListener.java
@@ -1,10 +1,14 @@
 package org.zalando.logbook.servlet;
 
 import jakarta.servlet.AsyncEvent;
+import org.apiguardian.api.API;
 
 import java.io.IOException;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+@API(status = EXPERIMENTAL)
 @FunctionalInterface
-interface AsyncOnCompleteListener {
+public interface AsyncOnCompleteListener {
     void onComplete(AsyncEvent event) throws IOException;
 }

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListenerWrapper.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/AsyncOnCompleteListenerWrapper.java
@@ -1,0 +1,22 @@
+package org.zalando.logbook.servlet;
+
+import org.apiguardian.api.API;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * Wraps the {@link AsyncOnCompleteListener} that {@link LogbookFilter} registers for asynchronous requests.
+ * Wrapping happens on the request thread, which is where thread-local context, e.g. a tracing context, has to
+ * be captured in order to be available when the response is logged.
+ */
+@API(status = EXPERIMENTAL)
+@FunctionalInterface
+public interface AsyncOnCompleteListenerWrapper {
+
+    AsyncOnCompleteListener wrap(AsyncOnCompleteListener listener);
+
+    static AsyncOnCompleteListenerWrapper identity() {
+        return listener -> listener;
+    }
+
+}

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/LogbookFilter.java
@@ -39,6 +39,12 @@ public final class LogbookFilter implements HttpFilter {
     @With
     private final FormRequestMode formRequestMode;
 
+    /**
+     * Defaults to {@link AsyncOnCompleteListenerWrapper#identity()}.
+     */
+    @With
+    private final AsyncOnCompleteListenerWrapper asyncOnCompleteListenerWrapper;
+
     public LogbookFilter() {
         this(Logbook.create());
     }
@@ -48,7 +54,7 @@ public final class LogbookFilter implements HttpFilter {
     }
 
     public LogbookFilter(final Logbook logbook, @Nullable final Strategy strategy) {
-        this(logbook, strategy, FormRequestMode.fromProperties());
+        this(logbook, strategy, FormRequestMode.fromProperties(), AsyncOnCompleteListenerWrapper.identity());
     }
 
     @Override
@@ -71,7 +77,8 @@ public final class LogbookFilter implements HttpFilter {
         chain.doFilter(request, response);
 
         if (request.isAsyncStarted()) {
-            request.getAsyncContext().addListener(new LogbookAsyncListener(event -> write(response, writing)));
+            request.getAsyncContext().addListener(new LogbookAsyncListener(
+                    asyncOnCompleteListenerWrapper.wrap(event -> write(response, writing))));
 
             return;
         }

--- a/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecureLogbookFilter.java
+++ b/logbook-servlet/src/main/java/org/zalando/logbook/servlet/SecureLogbookFilter.java
@@ -15,14 +15,24 @@ import static org.apiguardian.api.API.Status.STABLE;
 @API(status = STABLE)
 public final class SecureLogbookFilter implements HttpFilter {
 
-    private final HttpFilter filter;
+    private final LogbookFilter filter;
 
     public SecureLogbookFilter() {
         this(Logbook.create());
     }
 
     public SecureLogbookFilter(final Logbook logbook) {
-        this.filter = new LogbookFilter(logbook, new SecurityStrategy());
+        this(new LogbookFilter(logbook, new SecurityStrategy()));
+    }
+
+    private SecureLogbookFilter(final LogbookFilter filter) {
+        this.filter = filter;
+    }
+
+    public SecureLogbookFilter withAsyncOnCompleteListenerWrapper(
+            final AsyncOnCompleteListenerWrapper asyncOnCompleteListenerWrapper) {
+
+        return new SecureLogbookFilter(filter.withAsyncOnCompleteListenerWrapper(asyncOnCompleteListenerWrapper));
     }
 
     @Override

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/AsyncDispatchTest.java
@@ -27,6 +27,7 @@ import org.zalando.logbook.core.DefaultSink;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static jakarta.servlet.DispatcherType.ASYNC;
 import static jakarta.servlet.DispatcherType.REQUEST;
@@ -42,6 +43,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 @EnableAutoConfiguration(excludeName = "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration")
 final class AsyncDispatchTest {
+
+    private static final AtomicReference<String> WRAPPED_ON = new AtomicReference<>();
+    private static final AtomicReference<String> COMPLETED_ON = new AtomicReference<>();
 
     @MockitoBean
     private HttpLogWriter writer;
@@ -97,8 +101,15 @@ final class AsyncDispatchTest {
         @Bean
         @SuppressWarnings({"rawtypes", "unchecked"}) // as of Spring Boot 2.x
         public FilterRegistrationBean logbookFilter(final Logbook logbook) {
-            final FilterRegistrationBean registration =
-                    new FilterRegistrationBean(new LogbookFilter(logbook));
+            final LogbookFilter filter = new LogbookFilter(logbook)
+                    .withAsyncOnCompleteListenerWrapper(listener -> {
+                        WRAPPED_ON.set(Thread.currentThread().getName());
+                        return event -> {
+                            COMPLETED_ON.set(Thread.currentThread().getName());
+                            listener.onComplete(event);
+                        };
+                    });
+            final FilterRegistrationBean registration = new FilterRegistrationBean(filter);
             registration.setDispatcherTypes(REQUEST, ASYNC);
             return registration;
         }
@@ -188,6 +199,24 @@ final class AsyncDispatchTest {
 
         assertThat(response)
                 .contains("200 OK", "text/plain", "Hello Async");
+    }
+
+    @Test
+    void shouldApplyAsyncOnCompleteListenerWrapperOnRequestThread() throws Exception {
+        WRAPPED_ON.set(null);
+        COMPLETED_ON.set(null);
+
+        final RestTemplate template = new RestTemplate();
+        template.getForObject("http://localhost:8080/servlet/async", String.class);
+
+        waitFor(Duration.ofSeconds(1));
+
+        interceptRequest();
+        assertThat(interceptResponse()).contains("Hello Async");
+
+        assertThat(COMPLETED_ON.get())
+                .isNotNull()
+                .isNotEqualTo(WRAPPED_ON.get());
     }
 
     @SneakyThrows

--- a/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookFilterTest.java
+++ b/logbook-servlet/src/test/java/org/zalando/logbook/servlet/LogbookFilterTest.java
@@ -1,24 +1,49 @@
 package org.zalando.logbook.servlet;
 
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockAsyncContext;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpLogWriter;
 import org.zalando.logbook.Logbook;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyEnumeration;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 final class LogbookFilterTest {
+
+    private final HttpLogWriter writer = mock(HttpLogWriter.class);
+
+    private final Logbook logbook = Logbook.builder()
+            .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        when(writer.isActive()).thenReturn(true);
+    }
 
     @Test
     void shouldCreateLogbookFilter() {
@@ -63,4 +88,60 @@ final class LogbookFilterTest {
 
         verify(responseWritingStage).write();
     }
+
+    @Test
+    void shouldWrapAsyncOnCompleteListener() throws Exception {
+        final AtomicBoolean wrapped = new AtomicBoolean();
+
+        final MockAsyncContext asyncContext = filterAsyncRequest(
+                new LogbookFilter(logbook).withAsyncOnCompleteListenerWrapper(recording(wrapped)),
+                new MockHttpServletResponse());
+
+        verify(writer, never()).write(any(Correlation.class), any());
+
+        asyncContext.complete();
+
+        assertThat(wrapped).isTrue();
+        verify(writer).write(any(Correlation.class), any());
+    }
+
+    @Test
+    void shouldWrapAsyncOnCompleteListenerInSecureFilter() throws Exception {
+        final AtomicBoolean wrapped = new AtomicBoolean();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(403);
+
+        filterAsyncRequest(new SecureLogbookFilter(logbook)
+                .withAsyncOnCompleteListenerWrapper(recording(wrapped)), response).complete();
+
+        assertThat(wrapped).isTrue();
+        verify(writer).write(any(Correlation.class), any());
+    }
+
+    @Test
+    void shouldNotWrapAsyncOnCompleteListenerByDefault() throws Exception {
+        filterAsyncRequest(new LogbookFilter(logbook), new MockHttpServletResponse()).complete();
+
+        verify(writer).write(any(Correlation.class), any());
+    }
+
+    private static AsyncOnCompleteListenerWrapper recording(final AtomicBoolean wrapped) {
+        return listener -> event -> {
+            wrapped.set(true);
+            listener.onComplete(event);
+        };
+    }
+
+    private static MockAsyncContext filterAsyncRequest(
+            final HttpFilter filter, final MockHttpServletResponse response) throws Exception {
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/");
+        request.setAsyncSupported(true);
+        final MockAsyncContext asyncContext = (MockAsyncContext) request.startAsync();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        return asyncContext;
+    }
+
 }

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -65,6 +65,7 @@ import org.zalando.logbook.json.JacksonJsonFieldBodyFilter;
 import org.zalando.logbook.json.JsonHttpLogFormatterJackson2;
 import org.zalando.logbook.json.JsonHttpLogFormatter;
 import org.zalando.logbook.openfeign.FeignLogbookLogger;
+import org.zalando.logbook.servlet.AsyncOnCompleteListenerWrapper;
 import org.zalando.logbook.servlet.LogbookFilter;
 import org.zalando.logbook.servlet.SecureLogbookFilter;
 import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
@@ -439,10 +440,21 @@ public class LogbookAutoConfiguration {
         @Bean
         @ConditionalOnProperty(name = "logbook.filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
-        public FilterRegistrationBean<?> logbookFilter(final Logbook logbook) {
+        public FilterRegistrationBean<?> logbookFilter(
+                final Logbook logbook,
+                final AsyncOnCompleteListenerWrapper asyncOnCompleteListenerWrapper) {
+
             final LogbookFilter filter = new LogbookFilter(logbook)
-                    .withFormRequestMode(properties.getFilter().getFormRequestMode());
+                    .withFormRequestMode(properties.getFilter().getFormRequestMode())
+                    .withAsyncOnCompleteListenerWrapper(asyncOnCompleteListenerWrapper);
             return newFilter(filter, FILTER_NAME, Ordered.LOWEST_PRECEDENCE);
+        }
+
+        // Declared here, rather than at the top level, so that it is not registered in non-servlet applications
+        @Bean
+        @ConditionalOnMissingBean
+        public AsyncOnCompleteListenerWrapper asyncOnCompleteListenerWrapper() {
+            return AsyncOnCompleteListenerWrapper.identity();
         }
 
         static FilterRegistrationBean<?> newFilter(final Filter filter, final String filterName, final int order) {
@@ -472,8 +484,13 @@ public class LogbookAutoConfiguration {
         @Bean
         @ConditionalOnProperty(name = "logbook.secure-filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
-        public FilterRegistrationBean<?> secureLogbookFilter(final Logbook logbook) {
-            return newFilter(new SecureLogbookFilter(logbook), FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
+        public FilterRegistrationBean<?> secureLogbookFilter(
+                final Logbook logbook,
+                final AsyncOnCompleteListenerWrapper asyncOnCompleteListenerWrapper) {
+
+            final SecureLogbookFilter filter = new SecureLogbookFilter(logbook)
+                    .withAsyncOnCompleteListenerWrapper(asyncOnCompleteListenerWrapper);
+            return newFilter(filter, FILTER_NAME, Ordered.HIGHEST_PRECEDENCE + 1);
         }
     }
 

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/AsyncOnCompleteListenerWrapperTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/AsyncOnCompleteListenerWrapperTest.java
@@ -1,0 +1,73 @@
+package org.zalando.logbook.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.logbook.servlet.AsyncOnCompleteListener;
+import org.zalando.logbook.servlet.AsyncOnCompleteListenerWrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AsyncOnCompleteListenerWrapperTest {
+
+    private static final String BEAN_NAME = "asyncOnCompleteListenerWrapper";
+
+    private static final AsyncOnCompleteListenerWrapper CUSTOM = listener -> listener;
+
+    private final WebApplicationContextRunner servlet = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(LogbookAutoConfiguration.class));
+
+    @Test
+    void shouldRegisterIdentityWrapperByDefault() {
+        servlet.run(context -> {
+            assertThat(context).hasSingleBean(AsyncOnCompleteListenerWrapper.class).hasBean(BEAN_NAME);
+
+            final AsyncOnCompleteListener listener = mock(AsyncOnCompleteListener.class);
+            assertThat(context.getBean(AsyncOnCompleteListenerWrapper.class).wrap(listener)).isSameAs(listener);
+        });
+    }
+
+    @Test
+    void shouldBackOffInFavourOfUserDefinedWrapper() {
+        servlet.withBean(BEAN_NAME, AsyncOnCompleteListenerWrapper.class, () -> CUSTOM).run(context ->
+                assertThat(context)
+                        .hasSingleBean(AsyncOnCompleteListenerWrapper.class)
+                        .getBean(AsyncOnCompleteListenerWrapper.class)
+                        .isSameAs(CUSTOM));
+    }
+
+    @Test
+    void shouldBackOffInFavourOfUserDefinedWrapperWithDifferentBeanName() {
+        servlet.withUserConfiguration(DifferentlyNamedWrapperConfiguration.class).run(context ->
+                assertThat(context)
+                        .hasSingleBean(AsyncOnCompleteListenerWrapper.class)
+                        .hasBean("myTracingWrapper")
+                        .doesNotHaveBean(BEAN_NAME));
+    }
+
+    @Test
+    void shouldNotRegisterWrapperForNonServletApplications() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(LogbookAutoConfiguration.class))
+                .run(context -> assertThat(context).doesNotHaveBean(AsyncOnCompleteListenerWrapper.class));
+
+        new ReactiveWebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(LogbookAutoConfiguration.class))
+                .run(context -> assertThat(context).doesNotHaveBean(AsyncOnCompleteListenerWrapper.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class DifferentlyNamedWrapperConfiguration {
+
+        @Bean
+        public AsyncOnCompleteListenerWrapper myTracingWrapper() {
+            return CUSTOM;
+        }
+    }
+
+}


### PR DESCRIPTION
For asynchronous requests the response is logged on a different thread than the one that handled the request, so any thread-local context is gone by then. That's why `trace-id` is missing from response logs of async endpoints.

This adds an extension point, `AsyncOnCompleteListenerWrapper`, that lets you wrap Logbook's completion listener while still on the request thread, which is where such context can be captured.

```java
new LogbookFilter(logbook).withAsyncOnCompleteListenerWrapper(wrapper);
```

With the Spring Boot starter, declaring an `AsyncOnCompleteListenerWrapper` bean is enough. It applies to both `logbookFilter` and `secureLogbookFilter`.

The default is a no-op, so nothing changes unless you opt in, and no existing constructor changes. See the README for a full example.

Closes #2283
