### PR TITLE
Fixed problems with logging chunked request bodies using LogbookHttpR…

### DIFF
--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/BufferingDynamicSizeDataStreamChannel.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/BufferingDynamicSizeDataStreamChannel.java
@@ -1,20 +1,18 @@
 package org.zalando.logbook.httpclient5;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.nio.DataStreamChannel;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import static lombok.AccessLevel.PACKAGE;
+final class BufferingDynamicSizeDataStreamChannel implements DataStreamChannel {
 
-@RequiredArgsConstructor(access = PACKAGE)
-final class BufferingFixedSizeDataStreamChannel implements DataStreamChannel {
-    private final byte[] buffer;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
     byte[] getBuffer() {
-        return buffer;
+        return buffer.toByteArray();
     }
 
     @Override
@@ -22,7 +20,7 @@ final class BufferingFixedSizeDataStreamChannel implements DataStreamChannel {
     }
 
     @Override
-    public int write(ByteBuffer src) {
+    public int write(final ByteBuffer src) {
         return ByteBufferUtils.fixedSizeCopy(src, buffer);
     }
 
@@ -31,6 +29,6 @@ final class BufferingFixedSizeDataStreamChannel implements DataStreamChannel {
     }
 
     @Override
-    public void endStream(List<? extends Header> trailers) {
+    public void endStream(final List<? extends Header> trailers) {
     }
 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/ByteBufferUtils.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/ByteBufferUtils.java
@@ -11,19 +11,24 @@ class ByteBufferUtils {
     static int fixedSizeCopy(ByteBuffer src, byte[] dest) {
         if (src.hasArray()) {
             byte[] array = src.array();
-            System.arraycopy(array, 0, dest, 0, dest.length);
+            int offset = src.arrayOffset() + src.position();
+            int length = src.remaining();
+            System.arraycopy(array, offset, dest, 0, length);
+            return length;
         } else {
             src.get(dest, 0, dest.length);
             src.flip();
+            return dest.length;
         }
-        return dest.length;
     }
 
     static int fixedSizeCopy(ByteBuffer src, ByteArrayOutputStream dest) {
         if (src.hasArray()) {
             byte[] array = src.array();
-            dest.write(array, 0, array.length);
-            return array.length;
+            int offset = src.arrayOffset() + src.position();
+            int length = src.remaining();
+            dest.write(array, offset, length);
+            return length;
         } else {
             byte[] bytes = new byte[src.remaining()];
             src.get(bytes, 0, bytes.length);

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/ByteBufferUtils.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/ByteBufferUtils.java
@@ -2,18 +2,33 @@ package org.zalando.logbook.httpclient5;
 
 import lombok.experimental.UtilityClass;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
 @UtilityClass
 class ByteBufferUtils {
 
-    static void fixedSizeCopy(ByteBuffer src, byte[] dest) {
+    static int fixedSizeCopy(ByteBuffer src, byte[] dest) {
         if (src.hasArray()) {
             byte[] array = src.array();
             System.arraycopy(array, 0, dest, 0, dest.length);
         } else {
             src.get(dest, 0, dest.length);
             src.flip();
+        }
+        return dest.length;
+    }
+
+    static int fixedSizeCopy(ByteBuffer src, ByteArrayOutputStream dest) {
+        if (src.hasArray()) {
+            byte[] array = src.array();
+            dest.write(array, 0, array.length);
+            return array.length;
+        } else {
+            byte[] bytes = new byte[src.remaining()];
+            src.get(bytes, 0, bytes.length);
+            dest.write(bytes, 0, bytes.length);
+            return bytes.length;
         }
     }
 

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LocalRequest.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LocalRequest.java
@@ -88,11 +88,17 @@ final class LocalRequest implements org.zalando.logbook.HttpRequest {
                     return new Buffering(copy.getBody());
                 }
             } else if (entity instanceof AsyncDataProducer) {
-                int contentLength = (int) entity.getContentLength();
-                byte[] body = new byte[contentLength];
-                BufferingFixedSizeDataStreamChannel channel = new BufferingFixedSizeDataStreamChannel(body);
-                ((AsyncDataProducer) entity).produce(channel);
-                return new Buffering(channel.getBuffer());
+                final long contentLength = entity.getContentLength();
+                if (contentLength >= 0) {
+                    final byte[] body = new byte[(int) contentLength];
+                    final BufferingFixedSizeDataStreamChannel channel = new BufferingFixedSizeDataStreamChannel(body);
+                    ((AsyncDataProducer) entity).produce(channel);
+                    return new Buffering(channel.getBuffer());
+                } else {
+                    final BufferingDynamicSizeDataStreamChannel channel = new BufferingDynamicSizeDataStreamChannel();
+                    ((AsyncDataProducer) entity).produce(channel);
+                    return new Buffering(channel.getBuffer());
+                }
             } else {
                 return new Passing();
             }

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/AbstractHttpTest.java
@@ -95,7 +95,7 @@ abstract class AbstractHttpTest {
                         "Hello, world!");
     }
 
-    private String captureRequest() throws IOException {
+    protected String captureRequest() throws IOException {
         final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(writer).write(any(Precorrelation.class), captor.capture());
         return captor.getValue();

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/BufferingDynamicSizeDataStreamChannelTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/BufferingDynamicSizeDataStreamChannelTest.java
@@ -35,4 +35,16 @@ final class BufferingDynamicSizeDataStreamChannelTest {
         channel.endStream();
         channel.endStream(emptyList());
     }
+
+    @Test
+    void testHeapByteBufferUsesOnlyReadableRange() {
+        byte[] expected = "body".getBytes(UTF_8);
+        byte[] backing = "prefixbodytail".getBytes(UTF_8);
+        ByteBuffer buffer = ByteBuffer.wrap(backing, 6, 4).slice();
+
+        channel.write(buffer);
+
+        assertThat(channel.getBuffer()).isEqualTo(expected);
+    }
+
 }

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/BufferingDynamicSizeDataStreamChannelTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/BufferingDynamicSizeDataStreamChannelTest.java
@@ -1,0 +1,38 @@
+package org.zalando.logbook.httpclient5;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class BufferingDynamicSizeDataStreamChannelTest {
+
+    private final BufferingDynamicSizeDataStreamChannel channel = new BufferingDynamicSizeDataStreamChannel();
+    private final byte[] data = "hello".getBytes(UTF_8);
+
+    @Test
+    void testHeapByteBuffer() {
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        channel.write(buffer);
+        assertThat(channel.getBuffer()).isEqualTo(data);
+    }
+
+    @Test
+    void testOffHeapByteBuffer() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
+        buffer.put(data);
+        buffer.flip();
+        channel.write(buffer);
+        assertThat(channel.getBuffer()).isEqualTo(data);
+    }
+
+    @Test
+    void dummyUnitTest() {
+        channel.requestOutput();
+        channel.endStream();
+        channel.endStream(emptyList());
+    }
+}

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/BufferingFixedSizeDataStreamChannelTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/BufferingFixedSizeDataStreamChannelTest.java
@@ -49,4 +49,17 @@ final class BufferingFixedSizeDataStreamChannelTest {
         channel.endStream();
         channel.endStream(emptyList());
     }
+
+    @Test
+    void testHeapByteBufferUsesOnlyReadableRange() {
+        byte[] expected = "body".getBytes(UTF_8);
+        byte[] backing = "prefixbodytail".getBytes(UTF_8);
+        buffer = ByteBuffer.wrap(backing, 6, expected.length).slice();
+        channel = new BufferingFixedSizeDataStreamChannel(new byte[expected.length]);
+
+        channel.write(buffer);
+
+        assertThat(channel.getBuffer()).isEqualTo(expected);
+    }
+
 }

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumerTest.java
@@ -12,19 +12,30 @@ import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityProducer;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.net.URI;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest {
 
@@ -60,6 +71,43 @@ public final class LogbookHttpAsyncResponseConsumerTest extends AbstractHttpTest
         String responseBody = responseRef.get();
         if (responseBody != null) httpResponse.setEntity(new StringEntity(responseBody));
         return httpResponse;
+    }
+
+    private ClassicHttpResponse sendAndReceiveWithChunkedBody(WireMockServer server, final String body)
+            throws ExecutionException, InterruptedException {
+        BasicHttpRequest request = new BasicHttpRequest(Method.POST, URI.create(server.baseUrl()));
+        request.setHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN.toString());
+
+        AtomicReference<String> responseRef = new AtomicReference<>(null);
+        CountDownLatch latch = new CountDownLatch(1);
+        HttpResponse response = client.execute(
+                new BasicRequestProducer(request, new StringAsyncEntityProducer(body, TEXT_PLAIN)),
+                new LogbookHttpAsyncResponseConsumer<>(SimpleResponseConsumer.create(), SimpleHttpResponse::getBodyBytes, true),
+                HttpClientContext.create(),
+                getCallback(responseRef, latch)
+        ).get();
+
+        BasicClassicHttpResponse httpResponse = new BasicClassicHttpResponse(response.getCode(), response.getReasonPhrase());
+        latch.await(5, SECONDS);
+        String responseBody = responseRef.get();
+        if (responseBody != null) httpResponse.setEntity(new StringEntity(responseBody));
+        return httpResponse;
+    }
+
+    @Test
+    void shouldLogRequestWithBodyOfUnknownContentLength() throws IOException, ExecutionException, InterruptedException {
+        server.stubFor(post("/").withRequestBody(equalTo("Hello, world!")).willReturn(aResponse().withStatus(204)));
+
+        sendAndReceiveWithChunkedBody(server, "Hello, world!");
+
+        final String message = captureRequest();
+
+        assertThat(message)
+                .startsWith("Outgoing Request:")
+                .contains(
+                        format("POST http://localhost:%d/ HTTP/1.1", server.port()),
+                        "Content-Type: text/plain",
+                        "Hello, world!");
     }
 
     private static FutureCallback<SimpleHttpResponse> getCallback(AtomicReference<String> responseRef, CountDownLatch latch) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current implementation of httpclient5 LogbookHttpAsyncResponseConsumer is incorrectly handling chunked request bodies (`contentLength = -1`). This fix addresses this issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`LogbookHttpRequestInterceptor` is designed for synchronous `HttpClient5`, but users can also register it with `HttpAsyncClientBuilder` (as done e.g. by the Elasticsearch Java client). In the async I/O model, the request entity is produced via `AsyncDataProducer`, which may not know the body size upfront —               
  `getContentLength()` returns `-1` for chunked/streaming payloads. `LocalRequest` was allocating `new byte[(int) entity.getContentLength()]` unconditionally, causing a `NegativeArraySizeException`.                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  The fix introduces `BufferingDynamicSizeDataStreamChannel`, backed by a `ByteArrayOutputStream`, used when content length is unknown. When the length is known (`>= 0`), the existing fixed-size path is preserved. A regression test using `StringAsyncEntityProducer` (which always returns `-1` for content length) was added to 
  `LogbookHttpAsyncResponseConsumerTest` to cover this case.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
