### PR TITLE
Auto-configure Logbook interceptor for Spring RestClient

### DIFF
--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -86,6 +86,18 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <scope>provided</scope>
             <exclusions>

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -381,7 +381,6 @@ public class LogbookAutoConfiguration {
             RestClient.class,
             RestClientCustomizer.class
     })
-    @ConditionalOnBean(LogbookClientHttpRequestInterceptor.class)
     static class RestClientAutoConfiguration {
 
         @Bean

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -18,12 +18,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.restclient.RestClientCustomizer;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.Ordered;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.client.RestClient;
 import org.zalando.logbook.BodyFilter;
 import org.zalando.logbook.CorrelationId;
 import org.zalando.logbook.HeaderFilter;
@@ -371,6 +373,22 @@ public class LogbookAutoConfiguration {
         @ConditionalOnMissingBean(LogbookClientHttpRequestInterceptor.class)
         public LogbookClientHttpRequestInterceptor logbookClientHttpRequestInterceptor(final Logbook logbook) {
             return new LogbookClientHttpRequestInterceptor(logbook);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass({
+            RestClient.class,
+            RestClientCustomizer.class
+    })
+    @ConditionalOnBean(LogbookClientHttpRequestInterceptor.class)
+    static class RestClientAutoConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(name = "logbookRestClientCustomizer")
+        public RestClientCustomizer logbookRestClientCustomizer(
+                final LogbookClientHttpRequestInterceptor interceptor) {
+            return builder -> builder.requestInterceptor(interceptor);
         }
     }
 

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/RestClientAutoConfigurationTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/RestClientAutoConfigurationTest.java
@@ -1,0 +1,27 @@
+package org.zalando.logbook.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.restclient.RestClientCustomizer;
+import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@LogbookTest
+class RestClientAutoConfigurationTest {
+
+    @Autowired
+    @Qualifier("logbookRestClientCustomizer")
+    private RestClientCustomizer customizer;
+
+    @Autowired
+    private LogbookClientHttpRequestInterceptor interceptor;
+
+    @Test
+    void shouldAutoConfigureRestClientCustomizer() {
+        assertThat(customizer).isNotNull();
+        assertThat(interceptor).isNotNull();
+    }
+
+}

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/RestClientTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/RestClientTest.java
@@ -1,0 +1,72 @@
+package org.zalando.logbook.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.restclient.RestClientCustomizer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.web.client.RestClient;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RestClientTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+    @Test
+    void shouldRegisterRestClientCustomizer() {
+        this.contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .withUserConfiguration(
+                        LogbookAutoConfiguration.ClientHttpAutoConfiguration.class,
+                        LogbookAutoConfiguration.RestClientAutoConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(LogbookClientHttpRequestInterceptor.class);
+                    assertThat(context).hasBean("logbookRestClientCustomizer");
+                    assertThat(context).hasSingleBean(RestClientCustomizer.class);
+                });
+    }
+
+    @Test
+    void shouldApplyInterceptorToRestClientBuilder() {
+        this.contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .withUserConfiguration(
+                        LogbookAutoConfiguration.ClientHttpAutoConfiguration.class,
+                        LogbookAutoConfiguration.RestClientAutoConfiguration.class)
+                .run(context -> {
+                    final LogbookClientHttpRequestInterceptor interceptor =
+                            context.getBean(LogbookClientHttpRequestInterceptor.class);
+                    final RestClientCustomizer customizer = context.getBean(
+                            "logbookRestClientCustomizer", RestClientCustomizer.class);
+
+                    final RestClient.Builder builder = mock(RestClient.Builder.class);
+                    when(builder.requestInterceptor(same(interceptor))).thenReturn(builder);
+
+                    customizer.customize(builder);
+
+                    verify(builder).requestInterceptor(same(interceptor));
+                });
+    }
+
+    @Test
+    void shouldBackOffWhenCustomRestClientCustomizerBeanNamePresent() {
+        this.contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .withBean("logbookRestClientCustomizer", RestClientCustomizer.class,
+                        () -> builder -> {
+                        })
+                .withBean(LogbookClientHttpRequestInterceptor.class,
+                        () -> new LogbookClientHttpRequestInterceptor(Logbook.create()))
+                .withUserConfiguration(LogbookAutoConfiguration.RestClientAutoConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasBean("logbookRestClientCustomizer");
+                    assertThat(context.getBeansOfType(RestClientCustomizer.class)).hasSize(1);
+                });
+    }
+
+}


### PR DESCRIPTION
## Description
Register a `RestClientCustomizer` that applies `LogbookClientHttpRequestInterceptor` to Spring `RestClient.Builder` instances.

This mirrors the existing auto-configuration support for Apache HttpClient 4/5 and Feign, so outbound `RestClient` traffic is logged automatically when Logbook's Spring Boot starter is on the classpath.

## Motivation and Context
Fixes #2355

`RestClient` is the preferred outbound HTTP client in Spring Boot 4.x (Logbook 4.x target). Without this customizer, outbound calls are silent unless developers wire the interceptor manually.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All commits are signed

## Test plan
- [x] `mvn -pl logbook-spring-boot-autoconfigure test -Dtest=RestClientTest` — 3/3 GREEN
- [x] `mvn -pl logbook-spring-boot-autoconfigure test` — 101/101 GREEN (incl. JaCoCo)