### PR TITLE
Fix WebFlux empty response double consumption

### DIFF
--- a/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunction.java
+++ b/logbook-spring-webflux/src/main/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunction.java
@@ -48,9 +48,12 @@ public class LogbookExchangeFilterFunction implements ExchangeFilterFunction {
                                 if (clientResponse.shouldBuffer() && (springHeaders.getContentLength() > 0 || springHeaders.get(TRANSFER_ENCODING) != null)) {
                                     return it
                                             .bodyToMono(byte[].class)
+                                            .defaultIfEmpty(new byte[0])
                                             .doOnNext(clientResponse::buffer)
-                                            .map(b -> response.mutate().body(Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(b))).build())
-                                            .defaultIfEmpty(it);
+                                            .map(b -> response.mutate().body(ignored -> b.length == 0
+                                                    ? Flux.empty()
+                                                    : Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(b)))
+                                                    .build());
                                 } else {
                                     return Mono.just(it);
                                 }

--- a/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
+++ b/logbook-spring-webflux/src/test/java/org/zalando/logbook/spring/webflux/LogbookExchangeFilterFunctionTest.java
@@ -7,9 +7,16 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.zalando.logbook.Correlation;
@@ -19,10 +26,16 @@ import org.zalando.logbook.Precorrelation;
 import org.zalando.logbook.core.DefaultHttpLogFormatter;
 import org.zalando.logbook.core.DefaultSink;
 import org.zalando.logbook.test.TestStrategy;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -253,6 +266,71 @@ class LogbookExchangeFilterFunctionTest {
                 .contains("HTTP/1.1 200 OK")
                 .contains("Transfer-Encoding: chunked")
                 .contains("Hello, world!");
+    }
+
+    @Test
+    void shouldReplayConsumedResponseBodyWithoutResubscribing() throws IOException {
+        final AtomicInteger subscriptions = new AtomicInteger();
+        final byte[] expected = "Hello, world!".getBytes(StandardCharsets.UTF_8);
+        final ClientResponse response = ClientResponse
+                .create(HttpStatus.OK)
+                .header("Content-Length", String.valueOf(expected.length))
+                .body(Flux.defer(() -> {
+                    if (subscriptions.incrementAndGet() == 1) {
+                        return Flux.just(
+                                DefaultDataBufferFactory.sharedInstance.wrap(expected)
+                        );
+                    }
+                    return Flux.error(new IllegalStateException(
+                            "The client response body can only be consumed once."
+                    ));
+                }))
+                .build();
+        final ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com/test")).build();
+        final ExchangeFunction exchange = ignored -> Mono.just(response);
+
+        final ClientResponse returned = new LogbookExchangeFilterFunction(logbook).filter(request, exchange).block();
+        final byte[] actual = returned.bodyToMono(byte[].class).block();
+
+        assertThat(actual).isEqualTo(expected);
+        assertThat(subscriptions).hasValue(1);
+
+        captureRequest();
+        assertThat(captureResponse()).contains("Hello, world!");
+    }
+
+    @Test
+    void shouldReplayConsumedEmptyResponseWithoutResubscribing() throws IOException {
+        final AtomicInteger subscriptions = new AtomicInteger();
+        final ClientResponse response = ClientResponse
+                .create(HttpStatus.OK)
+                .header("Transfer-Encoding", "chunked")
+                .body(Flux.defer(() -> {
+                    if (subscriptions.incrementAndGet() == 1) {
+                        return Flux.empty();
+                    }
+                    return Flux.error(new IllegalStateException(
+                            "The client response body can only be consumed once."
+                    ));
+                }))
+                .build();
+        final ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com/empty")).build();
+        final ExchangeFunction exchange = ignored -> Mono.just(response);
+
+        final ClientResponse returned = new LogbookExchangeFilterFunction(logbook).filter(request, exchange).block();
+        final List<DataBuffer> body = returned
+                .bodyToFlux(DataBuffer.class)
+                .collectList()
+                .block();
+
+        assertThat(body).isEmpty();
+        assertThat(subscriptions).hasValue(1);
+
+        captureRequest();
+        assertThat(captureResponse())
+                .contains("HTTP/1.1 200 OK")
+                .contains("Transfer-Encoding: chunked")
+                .doesNotContain("Hello, world!");
     }
 
     @Test


### PR DESCRIPTION
Rebuild buffered WebFlux responses without resubscribing to their one-shot body publishers.
Add regression tests for empty and non-empty response replay while preserving logging.
Fixes #1516