### PR TITLE
fix(spring): gate secureLogbookFilter on SecurityFilterChain bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ The `logbook-spring` module contains a `ClientHttpRequestInterceptor` to use wit
 Logbook comes with a convenient auto configuration for Spring Boot users. It sets up all of the following parts automatically with sensible defaults:
 
 - Servlet filter
-- Second Servlet filter for unauthorized requests (if Spring Security is detected)
+- Second Servlet filter for unauthorized requests (if a `SecurityFilterChain` bean is present)
 - Header-/Parameter-/Body-Filters
 - HTTP-/JSON-style formatter
 - Logging writer
@@ -1093,7 +1093,7 @@ The following tables show the available configuration (sorted alphabetically):
 | `logbook.obfuscate.replacement`          | A value to be used instead of an obfuscated one                                                                                                                                                                     | `XXX`              |
 | `logbook.predicate.include`              | Include only certain paths and methods (if defined)                                                                                                                                                                 | `[]`               |
 | `logbook.predicate.exclude`              | Exclude certain  paths and methods  (overrides `logbook.predicate.include`)                                                                                                                                         | `[]`               |
-| `logbook.secure-filter.enabled`          | Enable the [`SecureLogbookFilter`](#servlet)                                                                                                                                                                        | `true`             |
+| `logbook.secure-filter.enabled`          | Enable the [`SecureLogbookFilter`](#security). Only registered when a `SecurityFilterChain` bean exists. Requires all 401/403 responses to be produced by a filter between the two Logbook filters; set to `false` if authorization failures are handled in the dispatcher (e.g. permit-all chains with method security)                                                                                                                                                                        | `true`             |
 | `logbook.strategy`                       | [Strategy](#strategy) (`default`, `status-at-least`, `body-only-if-status-at-least`, `without-body`)                                                                                                                | `default`          |
 | `logbook.write.chunk-size`               | Splits log lines into smaller chunks of size up-to `chunk-size`.                                                                                                                                                    | `0` (disabled)     |
 | `logbook.write.status-code-based`        | Enables status-code-aware log levels. Responses with 2xx/3xx are logged at `TRACE`, 4xx at `WARN`, 5xx at `ERROR`. Requests are always logged at `TRACE`.                                                          | `false`            |

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -470,6 +470,7 @@ public class LogbookAutoConfiguration {
         private static final String FILTER_NAME = "secureLogbookFilter";
 
         @Bean
+        @ConditionalOnBean(SecurityFilterChain.class)
         @ConditionalOnProperty(name = "logbook.secure-filter.enabled", havingValue = "true", matchIfMissing = true)
         @ConditionalOnMissingBean(name = FILTER_NAME)
         public FilterRegistrationBean<?> secureLogbookFilter(final Logbook logbook) {

--- a/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/logbook-spring-boot-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -104,7 +104,7 @@
       "name": "logbook.secure-filter.enabled",
       "type": "java.lang.Boolean",
       "defaultValue": true,
-      "description": "Enables/disables security servlet filter support."
+      "description": "Enables/disables the SecureLogbookFilter. Only takes effect when a SecurityFilterChain bean is present. The two-filter setup requires all 401/403 responses to be produced by a filter between secureLogbookFilter and logbookFilter; apps that return 401/403 from the dispatcher (e.g. permit-all chains with method security or @ControllerAdvice) must set this to false."
     },
     {
       "name": "logbook.strategy",

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/SecurityFilterTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/SecurityFilterTest.java
@@ -1,27 +1,31 @@
 package org.zalando.logbook.autoconfigure;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.security.web.SecurityFilterChain;
+import org.zalando.logbook.Logbook;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
-@LogbookTest
 class SecurityFilterTest {
 
-    @Autowired
-    @Qualifier("secureLogbookFilter")
-    private FilterRegistrationBean secureLogbookFilter;
-
-    @Autowired
-    @Qualifier("logbookFilter")
-    private FilterRegistrationBean logbookFilter;
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+            .withUserConfiguration(LogbookAutoConfiguration.JakartaSecurityServletFilterConfiguration.class);
 
     @Test
-    void shouldInitializeFilters() {
-        assertThat(secureLogbookFilter).isNotNull();
-        assertThat(logbookFilter).isNotNull();
+    void shouldRegisterSecureLogbookFilterWhenSecurityFilterChainIsPresent() {
+        contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .withBean("securityFilterChain", SecurityFilterChain.class, () -> mock(SecurityFilterChain.class))
+                .run(context -> assertThat(context).hasBean("secureLogbookFilter"));
+    }
+
+    @Test
+    void shouldNotRegisterSecureLogbookFilterWithoutSecurityFilterChain() {
+        contextRunner
+                .withBean("logbook", Logbook.class, Logbook::create)
+                .run(context -> assertThat(context).doesNotHaveBean("secureLogbookFilter"));
     }
 
 }


### PR DESCRIPTION
## Summary

- Add `@ConditionalOnBean(SecurityFilterChain.class)` to the `secureLogbookFilter` bean registration so the filter is not auto-enabled when `spring-security-web` is only present transitively on the classpath without an actual security filter chain.
- Document the two-filter setup precondition on `logbook.secure-filter.enabled` in configuration metadata and the README (apps that produce 401/403 in the dispatcher must set the property to `false`).
- Rewrite `SecurityFilterTest` to use `WebApplicationContextRunner`, covering both the presence and absence of a `SecurityFilterChain` bean.

Fixes #2369

## Test plan

- [x] `./mvnw test` in `logbook-spring-boot-autoconfigure` (99 tests, all passing)
- [x] `SecurityFilterTest` verifies `secureLogbookFilter` is registered when a `SecurityFilterChain` bean exists
- [x] `SecurityFilterTest` verifies `secureLogbookFilter` is not registered without a `SecurityFilterChain` bean