### PR TITLE
Add Support For Native JDK HttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ library/framework/etc. to it.
   * [Servlet](#servlet)
   * [HTTP Client](#http-client)
   * [HTTP Client 5](#http-client-5)
+  * [JDK HTTP Client](#jdk-http-client)
   * [JAX-RS 3.x (aka Jakarta RESTful Web Services)](#jax-rs-3x-aka-jakarta-restful-web-services)
   * [JDK HTTP Server](#jdk-http-server)
   * [Netty](#netty)

--- a/README.md
+++ b/README.md
@@ -860,6 +860,31 @@ CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
 client.execute(producer, new LogbookHttpAsyncResponseConsumer<>(consumer), callback)
 ```
 
+### JDK HTTP Client
+
+The `logbook-jdkhttpclient` module decorates the JDK `HttpClient`:
+
+```xml
+<dependency>
+    <groupId>org.zalando</groupId>
+    <artifactId>logbook-jdkhttpclient</artifactId>
+    <version>${logbook.version}</version>
+</dependency>
+```
+
+Wrap the client explicitly before use:
+
+```java
+HttpClient client = LogbookHttpClient.wrap(HttpClient.newHttpClient(), logbook);
+HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+```
+
+`sendAsync` and push promises are supported. Clients created with `HttpClient.newBuilder()` must also wrap the resulting client.
+
+Set `logbook.jdkhttpclient.decompress-response=true` to decode gzip response bodies only for Logbook's output. The response body and headers returned to the caller remain unchanged.
+
+With Spring Boot, use the provided `LogbookHttpClientFactory` to create or wrap direct JDK clients. `RestClient` builders are instrumented automatically regardless of their underlying HTTP implementation.
+
 ### JAX-RS 3.x (aka Jakarta RESTful Web Services)
 
 The `logbook-jaxrs` module contains:
@@ -1085,6 +1110,7 @@ The following tables show the available configuration (sorted alphabetically):
 | `logbook.format.style`                   | [Formatting style](#formatting) (`http`, `json`, `curl` or `splunk`)                                                                                                                                                | `json`             |
 | `logbook.httpclient.decompress-response` | Enables/disables additional decompression process for HttpClient with gzip encoded body (to logging purposes only). This means extra decompression and possible performance impact.                                 | `false` (disabled) |
 | `logbook.httpclient5.decompress-response`| Enables/disables additional decompression process for HttpClient with gzip encoded body (to logging purposes only). This means extra decompression and possible performance impact.                                 | `false` (disabled) |
+| `logbook.jdkhttpclient.decompress-response`| Enables/disables additional decompression process for JDK HttpClient with gzip encoded body (to logging purposes only). This means extra decompression and possible performance impact.                             | `false` (disabled) |
 | `logbook.minimum-status`                 | Minimum status to enable logging (`status-at-least` and `body-only-if-status-at-least`)                                                                                                                             | `400`              |
 | `logbook.obfuscate.headers`              | List of header names that need obfuscation                                                                                                                                                                          | `[Authorization]`  |
 | `logbook.obfuscate.json-body-fields`     | List of JSON body fields to be obfuscated                                                                                                                                                                           | `[]`               |

--- a/logbook-bom/pom.xml
+++ b/logbook-bom/pom.xml
@@ -46,6 +46,11 @@
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
+                <artifactId>logbook-jdkhttpclient</artifactId>
+                <version>4.2.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
                 <artifactId>logbook-jaxrs</artifactId>
                 <version>4.2.0-SNAPSHOT</version>
             </dependency>

--- a/logbook-jdkhttpclient/pom.xml
+++ b/logbook-jdkhttpclient/pom.xml
@@ -7,9 +7,9 @@
         <version>4.2.0-SNAPSHOT</version>
         <relativePath>../logbook-parent/pom.xml</relativePath>
     </parent>
-    <artifactId>logbook-spring-boot-starter</artifactId>
+    <artifactId>logbook-jdkhttpclient</artifactId>
     <name>${project.artifactId}</name>
-    <description>Spring Boot Auto Configuration for Logbook and most of its libraries/adapters</description>
+    <description>JDK HTTP Client interceptor for request and response logging</description>
     <scm>
         <url>https://github.com/zalando/logbook</url>
         <connection>scm:git:git@github.com:zalando/logbook.git</connection>
@@ -18,26 +18,33 @@
     <dependencies>
         <dependency>
             <groupId>org.zalando</groupId>
-            <artifactId>logbook-spring-boot-autoconfigure</artifactId>
+            <artifactId>logbook-api</artifactId>
+        </dependency>
+        <!-- testing -->
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>logbook-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>
-            <artifactId>logbook-jdkhttpclient</artifactId>
+            <artifactId>logbook-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.zalando</groupId>
-            <artifactId>logbook-spring-boot-ecs-autoconfigure</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <failIfNoTests>false</failIfNoTests>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -46,7 +53,7 @@
                         <manifestEntries>
                             <!-- This is a workaround to having module names before switching to Java 9+ -->
                             <!-- It will set our desired Automatic-Module-Name inside META/INF/MANIFEST.MF file -->
-                            <Automatic-Module-Name>org.zalando.logbook.spring.boot.starter</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.zalando.logbook.jdkhttpclient</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/BufferingBodyHandler.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/BufferingBodyHandler.java
@@ -1,0 +1,70 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import java.io.ByteArrayOutputStream;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow.Subscription;
+
+final class BufferingBodyHandler<T> implements HttpResponse.BodyHandler<T> {
+
+    private final HttpResponse.BodyHandler<T> delegate;
+    private final CompletableFuture<Void> completion = new CompletableFuture<>();
+    private volatile byte[] body;
+
+    BufferingBodyHandler(final HttpResponse.BodyHandler<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public HttpResponse.BodySubscriber<T> apply(final HttpResponse.ResponseInfo responseInfo) {
+        final HttpResponse.BodySubscriber<T> subscriber = delegate.apply(responseInfo);
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        return new HttpResponse.BodySubscriber<>() {
+            @Override
+            public CompletionStage<T> getBody() {
+                return subscriber.getBody();
+            }
+
+            @Override
+            public void onSubscribe(final Subscription subscription) {
+                subscriber.onSubscribe(subscription);
+            }
+
+            @Override
+            public void onNext(final List<ByteBuffer> items) {
+                for (final ByteBuffer item : items) {
+                    final ByteBuffer copy = item.asReadOnlyBuffer();
+                    final byte[] bytes = new byte[copy.remaining()];
+                    copy.get(bytes);
+                    buffer.writeBytes(bytes);
+                }
+                subscriber.onNext(items);
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+                subscriber.onError(throwable);
+                completion.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                subscriber.onComplete();
+                body = buffer.toByteArray();
+                completion.complete(null);
+            }
+        };
+    }
+
+    byte[] getBody() {
+        return body == null ? new byte[0] : body.clone();
+    }
+
+    CompletionStage<Void> completion() {
+        return completion;
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/BufferingBodyPublisher.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/BufferingBodyPublisher.java
@@ -1,0 +1,87 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import java.io.ByteArrayOutputStream;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class BufferingBodyPublisher implements HttpRequest.BodyPublisher {
+
+    private final HttpRequest.BodyPublisher delegate;
+    private ByteArrayOutputStream body = new ByteArrayOutputStream();
+    private Runnable completed = () -> { };
+    private Runnable incomplete = () -> { };
+
+    BufferingBodyPublisher(final HttpRequest.BodyPublisher delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public long contentLength() {
+        return delegate.contentLength();
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+        final ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        final AtomicBoolean terminal = new AtomicBoolean();
+        delegate.subscribe(new Subscriber<>() {
+            @Override
+            public void onSubscribe(final Subscription subscription) {
+                subscriber.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(final long count) {
+                        subscription.request(count);
+                    }
+
+                    @Override
+                    public void cancel() {
+                        terminal.set(true);
+                        incomplete.run();
+                        subscription.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(final ByteBuffer item) {
+                final ByteBuffer copy = item.asReadOnlyBuffer();
+                final byte[] bytes = new byte[copy.remaining()];
+                copy.get(bytes);
+                capture.writeBytes(bytes);
+                subscriber.onNext(item);
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+                if (terminal.compareAndSet(false, true)) {
+                    incomplete.run();
+                }
+                subscriber.onError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                if (terminal.compareAndSet(false, true)) {
+                    body = capture;
+                    completed.run();
+                }
+                subscriber.onComplete();
+            }
+        });
+    }
+
+    void onComplete(final Runnable completed) {
+        this.completed = completed;
+    }
+
+    void onIncomplete(final Runnable incomplete) {
+        this.incomplete = incomplete;
+    }
+
+    byte[] getBody() {
+        return body.toByteArray();
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LocalRequest.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LocalRequest.java
@@ -1,0 +1,87 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.Origin;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.Optional;
+
+final class LocalRequest implements org.zalando.logbook.HttpRequest {
+
+    private final HttpRequest request;
+    private final BufferingBodyPublisher bodyPublisher;
+    private boolean withBody;
+
+    LocalRequest(final HttpRequest request, final BufferingBodyPublisher bodyPublisher) {
+        this.request = request;
+        this.bodyPublisher = bodyPublisher;
+    }
+
+    @Override
+    public Origin getOrigin() {
+        return Origin.LOCAL;
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return request.version().map(Object::toString).orElse("HTTP/1.1");
+    }
+
+    @Override
+    public String getRemote() {
+        return "localhost";
+    }
+
+    @Override
+    public String getMethod() {
+        return request.method();
+    }
+
+    @Override
+    public String getScheme() {
+        return request.uri().getScheme();
+    }
+
+    @Override
+    public String getHost() {
+        return request.uri().getHost();
+    }
+
+    @Override
+    public Optional<Integer> getPort() {
+        return Optional.of(request.uri().getPort()).filter(port -> port != -1);
+    }
+
+    @Override
+    public String getPath() {
+        return request.uri().getPath();
+    }
+
+    @Override
+    public String getQuery() {
+        return Optional.ofNullable(request.uri().getQuery()).orElse("");
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return HttpHeaders.of(request.headers().map());
+    }
+
+    @Override
+    public byte[] getBody() {
+        return withBody && bodyPublisher != null ? bodyPublisher.getBody() : new byte[0];
+    }
+
+    @Override
+    public LocalRequest withBody() {
+        withBody = true;
+        return this;
+    }
+
+    @Override
+    public LocalRequest withoutBody() {
+        withBody = false;
+        return this;
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClient.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClient.java
@@ -1,0 +1,245 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Logbook.RequestWritingStage;
+import org.zalando.logbook.Logbook.ResponseProcessingStage;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class LogbookHttpClient extends HttpClient {
+
+    private static final Logger log = LoggerFactory.getLogger(LogbookHttpClient.class);
+
+    private final HttpClient delegate;
+    private final Logbook logbook;
+    private final boolean decompressResponse;
+
+    private LogbookHttpClient(final HttpClient delegate, final Logbook logbook, final boolean decompressResponse) {
+        this.delegate = delegate;
+        this.logbook = logbook;
+        this.decompressResponse = decompressResponse;
+    }
+
+    public static HttpClient wrap(final HttpClient delegate, final Logbook logbook) {
+        return wrap(delegate, logbook, false);
+    }
+
+    public static HttpClient wrap(final HttpClient delegate, final Logbook logbook, final boolean decompressResponse) {
+        return new LogbookHttpClient(delegate, logbook, decompressResponse);
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return delegate.cookieHandler();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return delegate.connectTimeout();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return delegate.followRedirects();
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return delegate.proxy();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return delegate.sslContext();
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return delegate.sslParameters();
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return delegate.authenticator();
+    }
+
+    @Override
+    public Version version() {
+        return delegate.version();
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return delegate.executor();
+    }
+
+    @Override
+    public WebSocket.Builder newWebSocketBuilder() {
+        return delegate.newWebSocketBuilder();
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public void shutdownNow() {
+        delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(final Duration duration) throws InterruptedException {
+        return delegate.awaitTermination(duration);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public <T> HttpResponse<T> send(final HttpRequest request, final HttpResponse.BodyHandler<T> bodyHandler)
+            throws IOException, InterruptedException {
+        if (bodyHandler == null) {
+            return delegate.send(request, null);
+        }
+        final Exchange<T> exchange = exchange(request, bodyHandler);
+        final HttpResponse<T> response = delegate.send(exchange.request, exchange.bodyHandler);
+        exchange.log(response);
+        return response;
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
+            final HttpResponse.BodyHandler<T> bodyHandler) {
+        if (bodyHandler == null) {
+            return delegate.sendAsync(request, null);
+        }
+        final Exchange<T> exchange = exchange(request, bodyHandler);
+        return delegate.sendAsync(exchange.request, exchange.bodyHandler).thenApply(response -> {
+            exchange.log(response);
+            return response;
+        });
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(final HttpRequest request,
+            final HttpResponse.BodyHandler<T> bodyHandler, final HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        if (bodyHandler == null || pushPromiseHandler == null) {
+            return delegate.sendAsync(request, bodyHandler, pushPromiseHandler);
+        }
+        final Exchange<T> exchange = exchange(request, bodyHandler);
+        return delegate.sendAsync(exchange.request, exchange.bodyHandler, (initiatingRequest, promisedRequest, acceptor) ->
+                pushPromiseHandler.applyPushPromise(initiatingRequest, promisedRequest, pushedBodyHandler -> {
+                    final Exchange<T> pushExchange = exchange(promisedRequest, pushedBodyHandler);
+                    return acceptor.apply(pushExchange.bodyHandler).thenApply(response -> {
+                        pushExchange.log(response);
+                        return response;
+                    });
+                })).thenApply(response -> {
+                    exchange.log(response);
+                    return response;
+                });
+    }
+
+    private <T> Exchange<T> exchange(final HttpRequest request, final HttpResponse.BodyHandler<T> bodyHandler) {
+        final HttpRequest.Builder builder = HttpRequest.newBuilder(request, (name, value) -> true);
+        final BufferingBodyPublisher publisher = request.bodyPublisher().map(BufferingBodyPublisher::new).orElse(null);
+        if (publisher != null) {
+            builder.method(request.method(), publisher);
+        }
+        final HttpRequest copiedRequest = builder.build();
+        final Exchange<T> exchange = new Exchange<>(copiedRequest, new BufferingBodyHandler<>(bodyHandler),
+                requestStage(copiedRequest, publisher));
+        if (publisher == null) {
+            exchange.writeRequest();
+        } else {
+            publisher.onComplete(exchange::writeRequest);
+            publisher.onIncomplete(exchange::skipRequest);
+        }
+        return exchange;
+    }
+
+    private RequestWritingStage requestStage(final HttpRequest request, final BufferingBodyPublisher publisher) {
+        try {
+            return logbook.process(new LocalRequest(request, publisher));
+        } catch (final Exception e) {
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
+            return null;
+        }
+    }
+
+    private final class Exchange<T> {
+        private final HttpRequest request;
+        private final BufferingBodyHandler<T> bodyHandler;
+        private final RequestWritingStage stage;
+        private final CompletableFuture<ResponseProcessingStage> responseStage = new CompletableFuture<>();
+        private final AtomicBoolean requestWritten = new AtomicBoolean();
+
+        private Exchange(final HttpRequest request, final BufferingBodyHandler<T> bodyHandler,
+                final RequestWritingStage stage) {
+            this.request = request;
+            this.bodyHandler = bodyHandler;
+            this.stage = stage;
+        }
+
+        private void writeRequest() {
+            if (!requestWritten.compareAndSet(false, true)) {
+                return;
+            }
+            if (stage == null) {
+                responseStage.complete(null);
+                return;
+            }
+
+            try {
+                responseStage.complete(stage.write());
+            } catch (final Exception e) {
+                log.warn("Unable to log request. Will skip the request & response logging step.", e);
+                responseStage.complete(null);
+            }
+        }
+
+        private void skipRequest() {
+            // An individual publisher subscription can be retried by the JDK.
+        }
+
+        private void log(final HttpResponse<T> response) {
+            responseStage.thenCombine(bodyHandler.completion(), (stage, ignored) -> {
+                if (stage == null) {
+                    return null;
+                }
+
+                try {
+                    stage.process(new RemoteResponse(response, bodyHandler, decompressResponse)).write();
+                } catch (final Exception e) {
+                    log.warn("Unable to log response. Will skip the response logging step.", e);
+                }
+                return null;
+            });
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientFactory.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientFactory.java
@@ -1,0 +1,25 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.zalando.logbook.Logbook;
+
+import java.net.http.HttpClient;
+
+public final class LogbookHttpClientFactory {
+
+    private final Logbook logbook;
+    private final boolean decompressResponse;
+
+    public LogbookHttpClientFactory(final Logbook logbook, final boolean decompressResponse) {
+        this.logbook = logbook;
+        this.decompressResponse = decompressResponse;
+    }
+
+    public HttpClient wrap(final HttpClient delegate) {
+        return LogbookHttpClient.wrap(delegate, logbook, decompressResponse);
+    }
+
+    public HttpClient create() {
+        return wrap(HttpClient.newHttpClient());
+    }
+
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/RemoteResponse.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/RemoteResponse.java
@@ -1,0 +1,82 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.zalando.logbook.HttpHeaders;
+import org.zalando.logbook.Origin;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.zip.GZIPInputStream;
+
+final class RemoteResponse implements org.zalando.logbook.HttpResponse {
+
+    private final HttpResponse<?> response;
+    private final BufferingBodyHandler<?> bodyHandler;
+    private final boolean decompressResponse;
+    private boolean withBody;
+
+    RemoteResponse(final HttpResponse<?> response, final BufferingBodyHandler<?> bodyHandler,
+            final boolean decompressResponse) {
+        this.response = response;
+        this.bodyHandler = bodyHandler;
+        this.decompressResponse = decompressResponse;
+    }
+
+    @Override
+    public Origin getOrigin() {
+        return Origin.REMOTE;
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return response.version().toString();
+    }
+
+    @Override
+    public int getStatus() {
+        return response.statusCode();
+    }
+
+    @Override
+    public String getReasonPhrase() {
+        return "";
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return HttpHeaders.of(response.headers().map());
+    }
+
+    @Override
+    public byte[] getBody() throws IOException {
+        if (!withBody) {
+            return new byte[0];
+        }
+
+        final byte[] body = bodyHandler.getBody();
+        return decompressResponse && isGzip() ? decompress(body) : body;
+    }
+
+    @Override
+    public RemoteResponse withBody() {
+        withBody = true;
+        return this;
+    }
+
+    @Override
+    public RemoteResponse withoutBody() {
+        withBody = false;
+        return this;
+    }
+
+    private boolean isGzip() {
+        return response.headers().allValues("Content-Encoding").stream()
+                .anyMatch(value -> "gzip".equalsIgnoreCase(value) || "x-gzip".equalsIgnoreCase(value));
+    }
+
+    private static byte[] decompress(final byte[] body) throws IOException {
+        try (GZIPInputStream input = new GZIPInputStream(new ByteArrayInputStream(body))) {
+            return input.readAllBytes();
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/package-info.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/package-info.java
@@ -1,0 +1,2 @@
+@org.apiguardian.api.API(status = org.apiguardian.api.API.Status.EXPERIMENTAL)
+package org.zalando.logbook.jdkhttpclient;

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/BufferingBodyHandlerTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/BufferingBodyHandlerTest.java
@@ -1,0 +1,176 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Subscription;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class BufferingBodyHandlerTest {
+
+    @Test
+    void shouldCaptureBytesAndPreserveTheCallersNonByteArrayResult() {
+        final BufferingBodyHandler<String> handler = new BufferingBodyHandler<>(info -> new StringSubscriber());
+        final HttpResponse.BodySubscriber<String> subscriber = handler.apply(new ResponseInfo());
+
+        subscriber.onSubscribe(new RequestingSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap("res".getBytes(UTF_8)), ByteBuffer.wrap("ponse".getBytes(UTF_8))));
+        subscriber.onComplete();
+
+        assertThat(subscriber.getBody().toCompletableFuture().join()).isEqualTo("caller-value");
+        assertThat(handler.getBody()).isEqualTo("response".getBytes(UTF_8));
+        assertThat(handler.completion().toCompletableFuture()).isCompleted();
+    }
+
+    @Test
+    void shouldExposeEmptyBodyAfterExceptionalTerminalSignal() {
+        final BufferingBodyHandler<String> handler = new BufferingBodyHandler<>(info -> new StringSubscriber());
+        final HttpResponse.BodySubscriber<String> subscriber = handler.apply(new ResponseInfo());
+        final IllegalStateException error = new IllegalStateException("failed");
+
+        subscriber.onSubscribe(new RequestingSubscription());
+        subscriber.onError(error);
+
+        assertThat(handler.getBody()).isEmpty();
+        assertThat(subscriber.getBody().toCompletableFuture()).isCompletedExceptionally();
+        assertThat(handler.completion().toCompletableFuture()).isCompletedExceptionally();
+    }
+
+    @Test
+    void shouldHideBodyBeforeATerminalSignal() {
+        final BufferingBodyHandler<String> handler = new BufferingBodyHandler<>(info -> new StringSubscriber());
+
+        handler.apply(new ResponseInfo());
+
+        assertThat(handler.getBody()).isEmpty();
+    }
+
+    @Test
+    void shouldForwardEmptyBodyAndSubscriptionRequests() {
+        final BufferingBodyHandler<String> handler = new BufferingBodyHandler<>(info -> new StringSubscriber());
+        final HttpResponse.BodySubscriber<String> subscriber = handler.apply(new ResponseInfo());
+        final TrackingSubscription subscription = new TrackingSubscription();
+
+        subscriber.onSubscribe(subscription);
+        subscriber.onNext(List.of());
+        subscriber.onComplete();
+
+        assertThat(subscription.requested).isEqualTo(1);
+        assertThat(handler.getBody()).isEmpty();
+    }
+
+    @Test
+    void shouldForwardCancellationToTheDelegateSubscription() {
+        final BufferingBodyHandler<String> handler = new BufferingBodyHandler<>(info -> new CancellingStringSubscriber());
+        final HttpResponse.BodySubscriber<String> subscriber = handler.apply(new ResponseInfo());
+        final TrackingSubscription subscription = new TrackingSubscription();
+
+        subscriber.onSubscribe(subscription);
+
+        assertThat(subscription.cancelled).isTrue();
+    }
+
+    private static final class StringSubscriber implements HttpResponse.BodySubscriber<String> {
+        private final CompletableFuture<String> body = new CompletableFuture<>();
+        private Subscription subscription;
+
+        @Override
+        public CompletionStage<String> getBody() {
+            return body;
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(final List<ByteBuffer> buffers) {
+            buffers.forEach(ByteBuffer::get);
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            body.completeExceptionally(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            body.complete("caller-value");
+        }
+    }
+
+    private static final class RequestingSubscription implements Subscription {
+        @Override
+        public void request(final long count) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    }
+
+    private static final class TrackingSubscription implements Subscription {
+        private long requested;
+        private boolean cancelled;
+
+        @Override
+        public void request(final long count) {
+            requested += count;
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+        }
+    }
+
+    private static final class CancellingStringSubscriber implements HttpResponse.BodySubscriber<String> {
+        @Override
+        public CompletionStage<String> getBody() {
+            return CompletableFuture.completedFuture("caller-value");
+        }
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscription.cancel();
+        }
+
+        @Override
+        public void onNext(final List<ByteBuffer> buffers) {
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+
+    private static final class ResponseInfo implements HttpResponse.ResponseInfo {
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(java.util.Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_1_1;
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/BufferingBodyPublisherTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/BufferingBodyPublisherTest.java
@@ -1,0 +1,200 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class BufferingBodyPublisherTest {
+
+    @Test
+    void shouldCopyBytesWithoutChangingTheBufferForwardedToTheCaller() {
+        final RecordingPublisher delegate = new RecordingPublisher(ByteBuffer.wrap("hello".getBytes(UTF_8)));
+        final BufferingBodyPublisher publisher = new BufferingBodyPublisher(delegate);
+        final ConsumingSubscriber subscriber = new ConsumingSubscriber();
+
+        publisher.subscribe(subscriber);
+
+        assertThat(publisher.contentLength()).isEqualTo(5);
+        assertThat(subscriber.body()).isEqualTo("hello".getBytes(UTF_8));
+        assertThat(publisher.getBody()).isEqualTo("hello".getBytes(UTF_8));
+        assertThat(delegate.requested).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCaptureEmptyAndMultipleBuffers() {
+        final BufferingBodyPublisher publisher = new BufferingBodyPublisher(new RecordingPublisher(
+                ByteBuffer.allocate(0), ByteBuffer.wrap("he".getBytes(UTF_8)), ByteBuffer.wrap("llo".getBytes(UTF_8))));
+
+        publisher.subscribe(new ConsumingSubscriber());
+
+        assertThat(publisher.getBody()).isEqualTo("hello".getBytes(UTF_8));
+    }
+
+    @Test
+    void shouldForwardErrorsAndCancellation() {
+        final RecordingPublisher delegate = new RecordingPublisher(new IllegalStateException("failed"));
+        final BufferingBodyPublisher publisher = new BufferingBodyPublisher(delegate);
+        final ErrorSubscriber subscriber = new ErrorSubscriber();
+
+        publisher.subscribe(subscriber);
+
+        assertThat(subscriber.error).isInstanceOf(IllegalStateException.class);
+        assertThat(delegate.requested).isEqualTo(1);
+    }
+
+    @Test
+    void shouldForwardCancellationToTheDelegateSubscription() {
+        final RecordingPublisher delegate = new RecordingPublisher(ByteBuffer.wrap("hello".getBytes(UTF_8)));
+        final BufferingBodyPublisher publisher = new BufferingBodyPublisher(delegate);
+
+        publisher.subscribe(new CancellingSubscriber());
+
+        assertThat(delegate.cancelled).isTrue();
+    }
+
+    @Test
+    void shouldReplaceCapturedBodyForEachSubscription() {
+        final BufferingBodyPublisher publisher = new BufferingBodyPublisher(
+                new RecordingPublisher(ByteBuffer.wrap("hello".getBytes(UTF_8))));
+
+        publisher.subscribe(new ConsumingSubscriber());
+        publisher.subscribe(new ConsumingSubscriber());
+
+        assertThat(publisher.getBody()).isEqualTo("hello".getBytes(UTF_8));
+    }
+
+    private static final class RecordingPublisher implements HttpRequest.BodyPublisher {
+        private final List<ByteBuffer> buffers;
+        private final Throwable error;
+        private final long contentLength;
+        private long requested;
+        private boolean cancelled;
+
+        RecordingPublisher(final ByteBuffer... buffers) {
+            this.buffers = List.of(buffers).stream()
+                    .map(buffer -> ByteBuffer.wrap(copy(buffer)))
+                    .toList();
+            this.error = null;
+            this.contentLength = this.buffers.stream().mapToLong(ByteBuffer::remaining).sum();
+        }
+
+        RecordingPublisher(final Throwable error) {
+            this.buffers = List.of();
+            this.error = error;
+            this.contentLength = 0;
+        }
+
+        @Override
+        public long contentLength() {
+            return contentLength;
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(final long count) {
+                    requested += count;
+                    if (error != null) {
+                        subscriber.onError(error);
+                    } else {
+                        buffers.stream().map(ByteBuffer::duplicate).forEach(subscriber::onNext);
+                        subscriber.onComplete();
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    cancelled = true;
+                }
+            });
+        }
+    }
+
+    private static final class ConsumingSubscriber implements Subscriber<ByteBuffer> {
+        private final List<Byte> bytes = new ArrayList<>();
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(final ByteBuffer buffer) {
+            while (buffer.hasRemaining()) {
+                bytes.add(buffer.get());
+            }
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+
+        byte[] body() {
+            final byte[] body = new byte[bytes.size()];
+            for (int index = 0; index < body.length; index++) {
+                body[index] = bytes.get(index);
+            }
+            return body;
+        }
+    }
+
+    private static final class ErrorSubscriber implements Subscriber<ByteBuffer> {
+        private Throwable error;
+
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(final ByteBuffer buffer) {
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            error = throwable;
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+
+    private static final class CancellingSubscriber implements Subscriber<ByteBuffer> {
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscription.cancel();
+        }
+
+        @Override
+        public void onNext(final ByteBuffer buffer) {
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+
+    private static byte[] copy(final ByteBuffer buffer) {
+        final ByteBuffer copy = buffer.asReadOnlyBuffer();
+        final byte[] bytes = new byte[copy.remaining()];
+        copy.get(bytes);
+        return bytes;
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LocalRequestTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LocalRequestTest.java
@@ -1,0 +1,77 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Origin;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class LocalRequestTest {
+
+    @Test
+    void shouldMapRequestMetadataHeadersAndDefaultCharset() throws Exception {
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("https://example.org:8443/orders?limit=1"))
+                .header("X-Trace", "one")
+                .header("X-Trace", "two")
+                .POST(HttpRequest.BodyPublishers.ofString("created"))
+                .build();
+        final BufferingBodyPublisher publisher = new BufferingBodyPublisher(request.bodyPublisher().orElseThrow());
+        final LocalRequest logbookRequest = new LocalRequest(request, publisher);
+
+        publisher.subscribe(new DiscardingSubscriber());
+
+        assertThat(logbookRequest.getOrigin()).isEqualTo(Origin.LOCAL);
+        assertThat(logbookRequest.getMethod()).isEqualTo("POST");
+        assertThat(logbookRequest.getProtocolVersion()).isEqualTo("HTTP/1.1");
+        assertThat(logbookRequest.getRemote()).isEqualTo("localhost");
+        assertThat(logbookRequest.getScheme()).isEqualTo("https");
+        assertThat(logbookRequest.getHost()).isEqualTo("example.org");
+        assertThat(logbookRequest.getPort()).contains(8443);
+        assertThat(logbookRequest.getPath()).isEqualTo("/orders");
+        assertThat(logbookRequest.getQuery()).isEqualTo("limit=1");
+        assertThat(logbookRequest.getHeaders().get("X-Trace")).containsExactly("one", "two");
+        assertThat(logbookRequest.getCharset()).isEqualTo(UTF_8);
+        assertThat(logbookRequest.getBody()).isEmpty();
+        assertThat(logbookRequest.withBody().getBody()).isEqualTo("created".getBytes(UTF_8));
+        assertThat(logbookRequest.withoutBody().getBody()).isEmpty();
+    }
+
+    @Test
+    void shouldUseContentTypeForTypeAndCharset() {
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("http://example.org/orders"))
+                .header("Content-Type", "text/plain; charset=ISO-8859-1")
+                .GET()
+                .build();
+        final LocalRequest logbookRequest = new LocalRequest(request, new BufferingBodyPublisher(HttpRequest.BodyPublishers.noBody()));
+
+        assertThat(logbookRequest.getContentType()).isEqualTo("text/plain");
+        assertThat(logbookRequest.getCharset()).isEqualTo(ISO_8859_1);
+        assertThat(logbookRequest.getPort()).isEmpty();
+    }
+
+    private static final class DiscardingSubscriber implements Subscriber<ByteBuffer> {
+        @Override
+        public void onSubscribe(final Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(final ByteBuffer item) {
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientFactoryTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientFactoryTest.java
@@ -1,0 +1,20 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Logbook;
+
+import java.net.http.HttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LogbookHttpClientFactoryTest {
+
+    @Test
+    void wrapsJdkHttpClients() {
+        final HttpClient client = new LogbookHttpClientFactory(Logbook.create(), false)
+                .wrap(HttpClient.newHttpClient());
+
+        assertThat(client).isInstanceOf(LogbookHttpClient.class);
+    }
+
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientTest.java
@@ -1,0 +1,792 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.test.TestStrategy;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.function.Function;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static java.net.http.HttpRequest.BodyPublishers.ofString;
+import static java.net.http.HttpResponse.BodyHandlers.ofInputStream;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class LogbookHttpClientTest {
+
+    private final CapturingWriter writer = new CapturingWriter();
+    private final WireMockServer server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
+
+    @BeforeEach
+    void startServer() {
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop();
+    }
+
+    @Test
+    void logsSyncExchangeWithoutChangingStringBody() throws Exception {
+        server.stubFor(post("/").willReturn(aResponse().withBody("response")));
+
+        final HttpResponse<String> response = client().send(postRequest(), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+        server.verify(postRequestedFor(com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .withRequestBody(equalTo("request")));
+        assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("request"))
+                .anySatisfy(message -> assertThat(message).contains("response"));
+    }
+
+    @Test
+    void logsAsyncExchangeWithoutChangingStringBody() {
+        server.stubFor(post("/").willReturn(aResponse().withBody("response")));
+
+        final HttpResponse<String> response = client().sendAsync(postRequest(), ofString()).join();
+
+        assertThat(response.body()).isEqualTo("response");
+        server.verify(postRequestedFor(com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo("/"))
+                .withRequestBody(equalTo("request")));
+        assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("request"))
+                .anySatisfy(message -> assertThat(message).contains("response"));
+    }
+
+    @Test
+    void logsInputStreamResponseOnlyAfterTheStreamCompletes() throws Exception {
+        server.stubFor(get("/").willReturn(aResponse().withBody("streamed-response").withChunkedDribbleDelay(2, 1_000)));
+
+        final HttpResponse<InputStream> response = client().send(getRequest(), ofInputStream());
+
+        assertThat(response.body()).isNotNull();
+        assertThat(writer.responseMessage()).isNotDone();
+        try (InputStream body = response.body()) {
+            assertThat(body.readAllBytes()).isEqualTo("streamed-response".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        }
+        assertThat(writer.responseMessage().join()).contains("streamed-response");
+    }
+
+    @Test
+    void doesNotLogResponseWhenBodyDeliveryFails() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            final HttpResponse.BodySubscriber<String> subscriber = invocation.<HttpResponse.BodyHandler<String>>getArgument(1)
+                    .apply(new ResponseInfo());
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(final long count) {
+                }
+
+                @Override
+                public void cancel() {
+                }
+            });
+            subscriber.onError(new IOException("body failed"));
+            return response(invocation.getArgument(0), "response");
+        });
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(delegate, logbook(writer)).send(getRequest(), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void preservesCustomResponseBodyHandlerResult() throws Exception {
+        server.stubFor(get("/").willReturn(aResponse().withBody("response")));
+        final HttpResponse.BodyHandler<Integer> handler = info -> HttpResponse.BodySubscribers.mapping(
+                HttpResponse.BodySubscribers.ofString(java.nio.charset.StandardCharsets.UTF_8), ignored -> 42);
+
+        final HttpResponse<Integer> response = client().send(getRequest(), handler);
+
+        assertThat(response.body()).isEqualTo(42);
+        assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("response"));
+    }
+
+    @Test
+    void logsHttpErrorResponse() throws Exception {
+        server.stubFor(get("/").willReturn(aResponse().withStatus(500).withBody("response")));
+
+        final HttpResponse<String> response = client().send(getRequest(), ofString());
+
+        assertThat(response.statusCode()).isEqualTo(500);
+        assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("500"))
+                .anySatisfy(message -> assertThat(message).contains("response"));
+    }
+
+    @Test
+    void doesNotChangeResponseWhenWriterThrows() throws Exception {
+        final HttpLogWriter failingWriter = mock(HttpLogWriter.class);
+        doThrow(new IOException("writer failed")).when(failingWriter).write(any(Precorrelation.class), any());
+        final Logbook logbook = logbook(failingWriter);
+        server.stubFor(get("/").willReturn(aResponse().withBody("response")));
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(HttpClient.newHttpClient(), logbook)
+                .send(getRequest(), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+    }
+
+    @Test
+    void doesNotChangeResponseWhenResponseWriterThrows() throws Exception {
+        final HttpLogWriter failingWriter = mock(HttpLogWriter.class);
+        doThrow(new IOException("writer failed")).when(failingWriter).write(any(Correlation.class), any());
+        final Logbook logbook = logbook(failingWriter);
+        server.stubFor(get("/").willReturn(aResponse().withBody("response")));
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(HttpClient.newHttpClient(), logbook)
+                .send(getRequest(), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+    }
+
+    @Test
+    void propagatesDelegateFailureWithoutLoggingResponse() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.send(any(), any())).thenThrow(new IOException("transport failed"));
+
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer)).send(getRequest(), ofString()))
+                .isInstanceOf(IOException.class)
+                .hasMessage("transport failed");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void propagatesAsyncDelegateFailureWithoutLoggingResponse() {
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.sendAsync(any(), any())).thenReturn(CompletableFuture.failedFuture(
+                new IllegalStateException("transport failed")));
+
+        final CompletableFuture<HttpResponse<String>> future = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .sendAsync(getRequest(), ofString());
+
+        assertThatThrownBy(future::join).hasCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("transport failed");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void writesCompletePublisherBodyOnceBeforePropagatingTransportFailure() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            assertThat(writer.requests).isEmpty();
+            publisher.complete();
+            assertThat(writer.requests).hasSize(1);
+            assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("request"));
+            publisher.complete();
+            assertThat(writer.requests).hasSize(1);
+            throw new IOException("transport failed");
+        });
+
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString())).isInstanceOf(IOException.class);
+
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void writesOneCompleteRequestWhenPublisherIsSubscribedTwice() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            subscribe(invocation.getArgument(0), false);
+            publisher.complete();
+            return response(invocation.getArgument(0), "response");
+        });
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.messages().stream().filter(message -> message.contains("request"))).hasSize(1);
+    }
+
+    @Test
+    void retainsCompletedRequestWhenLaterSubscriptionIsCancelled() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            publisher.complete();
+            subscribe(invocation.getArgument(0), true);
+            return response(invocation.getArgument(0), "response");
+        });
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("request"));
+    }
+
+    @Test
+    void writesOneCompleteRequestWhenSubscriptionIsCancelledBeforeAnotherCompletes() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), true);
+            subscribe(invocation.getArgument(0), false);
+            publisher.complete(1);
+            publisher.complete(1);
+            return response(invocation.getArgument(0), "response");
+        });
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.messages().stream().filter(message -> message.contains("request"))).hasSize(1);
+    }
+
+    @Test
+    void writesOneCompleteRequestWhenSubscriptionFailsBeforeAnotherCompletes() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            subscribe(invocation.getArgument(0), false);
+            publisher.fail(0);
+            publisher.complete(1);
+            publisher.complete(1);
+            return response(invocation.getArgument(0), "response");
+        });
+
+        final HttpResponse<String> response = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString());
+
+        assertThat(response.body()).isEqualTo("response");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.messages().stream().filter(message -> message.contains("request"))).hasSize(1);
+    }
+
+    @Test
+    void writesCompletePublisherBodyBeforeAsyncTransportFailure() {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>sendAsync(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            publisher.complete();
+            return CompletableFuture.failedFuture(new IllegalStateException("transport failed"));
+        });
+
+        final CompletableFuture<HttpResponse<String>> future = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .sendAsync(request(publisher), ofString());
+
+        assertThatThrownBy(future::join).hasRootCauseMessage("transport failed");
+        assertThat(writer.requests).hasSize(1);
+        assertThat(writer.messages()).anySatisfy(message -> assertThat(message).contains("request"));
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void forwardsNullBodyHandlerToDelegate() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), org.mockito.ArgumentMatchers.isNull())).thenThrow(new NullPointerException());
+
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer)).send(getRequest(), null))
+                .isInstanceOf(NullPointerException.class);
+        verify(delegate).send(getRequest(), null);
+    }
+
+    @Test
+    void returnsDelegateResponseForNullBodyHandler() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        final HttpRequest request = getRequest();
+        final HttpResponse<String> expected = response(request, "response");
+        when(delegate.<String>send(request, null)).thenReturn(expected);
+
+        final HttpResponse<String> actual = LogbookHttpClient.wrap(delegate, logbook(writer)).send(request, null);
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    void forwardsNullAsyncHandlersToDelegate() {
+        final HttpClient delegate = mock(HttpClient.class);
+        final HttpRequest request = getRequest();
+        when(delegate.sendAsync(any(), org.mockito.ArgumentMatchers.isNull())).thenReturn(CompletableFuture.failedFuture(
+                new NullPointerException()));
+        when(delegate.sendAsync(any(), any(), org.mockito.ArgumentMatchers.isNull())).thenReturn(
+                CompletableFuture.failedFuture(new NullPointerException()));
+        when(delegate.sendAsync(any(), org.mockito.ArgumentMatchers.isNull(), any())).thenReturn(
+                CompletableFuture.failedFuture(new NullPointerException()));
+        final HttpResponse.PushPromiseHandler<String> pushPromiseHandler =
+                (initiating, promised, acceptor) -> acceptor.apply(ofString());
+
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer)).sendAsync(request, null).join())
+                .hasRootCauseInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer))
+                .sendAsync(request, ofString(), null).join()).hasRootCauseInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer))
+                .sendAsync(request, (HttpResponse.BodyHandler<String>) null, pushPromiseHandler).join())
+                .hasRootCauseInstanceOf(NullPointerException.class);
+
+        verify(delegate).sendAsync(request, null);
+        verify(delegate).sendAsync(org.mockito.ArgumentMatchers.eq(request), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.isNull());
+        verify(delegate).sendAsync(org.mockito.ArgumentMatchers.eq(request), org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void writesNoBodyRequestBeforeDelegating() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            assertThat(writer.requests).hasSize(1);
+            return response(invocation.getArgument(0), "response");
+        });
+
+        LogbookHttpClient.wrap(delegate, logbook(writer)).send(getRequest(), ofString());
+
+    }
+
+    @Test
+    void doesNotWriteRequestWhenPublisherFails() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            publisher.fail();
+            throw new IOException("transport failed");
+        });
+
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString())).isInstanceOf(IOException.class);
+
+        assertThat(writer.requests).isEmpty();
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void doesNotWriteRequestWhenPublisherIsCancelled() throws Exception {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), true);
+            publisher.fail();
+            throw new IOException("transport failed");
+        });
+
+        assertThatThrownBy(() -> LogbookHttpClient.wrap(delegate, logbook(writer))
+                .send(request(publisher), ofString())).isInstanceOf(IOException.class);
+
+        assertThat(writer.requests).isEmpty();
+        assertThat(writer.responses).isEmpty();
+    }
+
+    @Test
+    void returnsAsyncResponseBeforeRequestPublisherCompletes() {
+        final ControlledPublisher publisher = new ControlledPublisher("request");
+        final HttpClient delegate = mock(HttpClient.class);
+        final CompletableFuture<HttpResponse<String>> delegateResponse = new CompletableFuture<>();
+        when(delegate.<String>sendAsync(any(), any())).thenAnswer(invocation -> {
+            subscribe(invocation.getArgument(0), false);
+            return delegateResponse;
+        });
+
+        final CompletableFuture<HttpResponse<String>> response = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .sendAsync(request(publisher), ofString());
+        assertThat(writer.requests).isEmpty();
+        delegateResponse.complete(response(getRequest(), "response"));
+        assertThat(response.join().body()).isEqualTo("response");
+        assertThat(writer.events).isEmpty();
+        publisher.complete();
+
+        assertThat(writer.events).containsExactly("request");
+    }
+
+    @Test
+    void doesNotChangeResponseWhenRequestProcessingFails() throws Exception {
+        final Logbook logbook = mock(Logbook.class);
+        final HttpClient delegate = mock(HttpClient.class);
+        final HttpResponse<String> expected = response(getRequest(), "response");
+        when(logbook.process(any())).thenThrow(new IOException("logging failed"));
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            complete(invocation.getArgument(1));
+            return expected;
+        });
+
+        final HttpResponse<String> actual = LogbookHttpClient.wrap(delegate, logbook).send(getRequest(), ofString());
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    void doesNotChangeResponseWhenRequestWritingFails() throws Exception {
+        final Logbook logbook = mock(Logbook.class);
+        final Logbook.RequestWritingStage requestStage = mock(Logbook.RequestWritingStage.class);
+        final HttpClient delegate = mock(HttpClient.class);
+        final HttpResponse<String> expected = response(getRequest(), "response");
+        when(logbook.process(any())).thenReturn(requestStage);
+        when(requestStage.write()).thenThrow(new IOException("logging failed"));
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            complete(invocation.getArgument(1));
+            return expected;
+        });
+
+        final HttpResponse<String> actual = LogbookHttpClient.wrap(delegate, logbook).send(getRequest(), ofString());
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    void doesNotChangeResponseWhenResponseProcessingFails() throws Exception {
+        final Logbook logbook = mock(Logbook.class);
+        final Logbook.RequestWritingStage requestStage = mock(Logbook.RequestWritingStage.class);
+        final Logbook.ResponseProcessingStage responseStage = mock(Logbook.ResponseProcessingStage.class);
+        final Logbook.ResponseWritingStage responseWriter = mock(Logbook.ResponseWritingStage.class);
+        final HttpClient delegate = mock(HttpClient.class);
+        final HttpResponse<String> expected = response(getRequest(), "response");
+        when(logbook.process(any())).thenReturn(requestStage);
+        when(requestStage.write()).thenReturn(responseStage);
+        when(responseStage.process(any())).thenReturn(responseWriter);
+        doThrow(new IOException("logging failed")).when(responseWriter).write();
+        when(delegate.<String>send(any(), any())).thenAnswer(invocation -> {
+            complete(invocation.getArgument(1));
+            return expected;
+        });
+
+        final HttpResponse<String> actual = LogbookHttpClient.wrap(delegate, logbook).send(getRequest(), ofString());
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    void forwardsDelegateConfigurationMethods() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        final WebSocket.Builder webSocketBuilder = mock(WebSocket.Builder.class);
+        final SSLContext sslContext = SSLContext.getDefault();
+        final SSLParameters sslParameters = new SSLParameters();
+        when(delegate.cookieHandler()).thenReturn(Optional.of(mock(CookieHandler.class)));
+        when(delegate.connectTimeout()).thenReturn(Optional.of(Duration.ofSeconds(1)));
+        when(delegate.followRedirects()).thenReturn(HttpClient.Redirect.ALWAYS);
+        when(delegate.proxy()).thenReturn(Optional.of(mock(ProxySelector.class)));
+        when(delegate.sslContext()).thenReturn(sslContext);
+        when(delegate.sslParameters()).thenReturn(sslParameters);
+        when(delegate.authenticator()).thenReturn(Optional.of(mock(Authenticator.class)));
+        when(delegate.version()).thenReturn(HttpClient.Version.HTTP_2);
+        when(delegate.executor()).thenReturn(Optional.of(mock(Executor.class)));
+        when(delegate.newWebSocketBuilder()).thenReturn(webSocketBuilder);
+        final HttpClient client = LogbookHttpClient.wrap(delegate, logbook(writer));
+
+        assertThat(client.cookieHandler()).isPresent();
+        assertThat(client.connectTimeout()).contains(Duration.ofSeconds(1));
+        assertThat(client.followRedirects()).isEqualTo(HttpClient.Redirect.ALWAYS);
+        assertThat(client.proxy()).isPresent();
+        assertThat(client.sslContext()).isSameAs(sslContext);
+        assertThat(client.sslParameters()).isSameAs(sslParameters);
+        assertThat(client.authenticator()).isPresent();
+        assertThat(client.version()).isEqualTo(HttpClient.Version.HTTP_2);
+        assertThat(client.executor()).isPresent();
+        assertThat(client.newWebSocketBuilder()).isSameAs(webSocketBuilder);
+    }
+
+    @Test
+    void forwardsDelegateLifecycleMethods() throws Exception {
+        final HttpClient delegate = mock(HttpClient.class);
+        when(delegate.awaitTermination(Duration.ofSeconds(1))).thenReturn(true);
+        when(delegate.isTerminated()).thenReturn(true);
+        final HttpClient client = LogbookHttpClient.wrap(delegate, logbook(writer));
+
+        client.shutdown();
+        client.shutdownNow();
+        assertThat(client.isTerminated()).isTrue();
+        assertThat(client.awaitTermination(Duration.ofSeconds(1))).isTrue();
+        client.close();
+
+        verify(delegate).shutdown();
+        verify(delegate).shutdownNow();
+        verify(delegate).isTerminated();
+        verify(delegate).awaitTermination(Duration.ofSeconds(1));
+        verify(delegate).close();
+    }
+
+    @Test
+    void wrapsPushPromiseHandlerAndLogsAnIndependentExchange() {
+        final HttpClient delegate = mock(HttpClient.class);
+        final HttpRequest initialRequest = getRequest();
+        final HttpRequest promisedRequest = HttpRequest.newBuilder(serverUri("/push")).GET().build();
+        final HttpResponse<String> initialResponse = response(initialRequest, "initial");
+        final HttpResponse<String> promisedResponse = response(promisedRequest, "pushed");
+        final CompletableFuture<HttpResponse<String>> initialFuture = new CompletableFuture<>();
+        final CompletableFuture<HttpResponse<String>> promisedFuture = new CompletableFuture<>();
+        final ArgumentCaptor<HttpResponse.BodyHandler<String>> initialBodyHandler = ArgumentCaptor.forClass(HttpResponse.BodyHandler.class);
+        final ArgumentCaptor<HttpResponse.PushPromiseHandler<String>> pushHandler = ArgumentCaptor.forClass(HttpResponse.PushPromiseHandler.class);
+        when(delegate.sendAsync(any(), initialBodyHandler.capture(), pushHandler.capture())).thenReturn(initialFuture);
+
+        final CompletableFuture<HttpResponse<String>> result = LogbookHttpClient.wrap(delegate, logbook(writer))
+                .sendAsync(initialRequest, ofString(), (initiating, promised, acceptor) -> acceptor.apply(ofString()));
+        final Function<HttpResponse.BodyHandler<String>, CompletableFuture<HttpResponse<String>>> acceptor = handler -> {
+            assertThat(handler).isInstanceOf(BufferingBodyHandler.class);
+            complete(handler);
+            return promisedFuture;
+        };
+        pushHandler.getValue().applyPushPromise(initialRequest, promisedRequest, acceptor);
+        promisedFuture.complete(promisedResponse);
+        complete(initialBodyHandler.getValue());
+        initialFuture.complete(initialResponse);
+
+        assertThat(result.join()).isSameAs(initialResponse);
+        assertThat(writer.requests).hasSize(2);
+        assertThat(writer.responses).hasSize(2);
+        assertThat(writer.requests.stream().map(Precorrelation::getId)).doesNotHaveDuplicates();
+    }
+
+    private HttpClient client() {
+        return LogbookHttpClient.wrap(HttpClient.newHttpClient(), logbook(writer));
+    }
+
+    private Logbook logbook(final HttpLogWriter logWriter) {
+        return Logbook.builder().strategy(new TestStrategy())
+                .sink(new DefaultSink(new DefaultHttpLogFormatter(), logWriter)).build();
+    }
+
+    private HttpRequest postRequest() {
+        return HttpRequest.newBuilder(serverUri("/")).header("X-Test", "value").POST(ofString("request")).build();
+    }
+
+    private HttpRequest getRequest() {
+        return HttpRequest.newBuilder(serverUri("/")).GET().build();
+    }
+
+    private HttpRequest request(final HttpRequest.BodyPublisher publisher) {
+        return HttpRequest.newBuilder(serverUri("/")).POST(publisher).build();
+    }
+
+    private static void subscribe(final HttpRequest request, final boolean cancel) {
+        request.bodyPublisher().orElseThrow().subscribe(new Subscriber<>() {
+            @Override
+            public void onSubscribe(final Subscription subscription) {
+                if (cancel) {
+                    subscription.cancel();
+                } else {
+                    subscription.request(1);
+                }
+            }
+
+            @Override
+            public void onNext(final ByteBuffer item) {
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        });
+    }
+
+    private URI serverUri(final String path) {
+        return URI.create(server.baseUrl() + path);
+    }
+
+    private static HttpResponse<String> response(final HttpRequest request, final String body) {
+        return new HttpResponse<>() {
+            @Override
+            public int statusCode() {
+                return 200;
+            }
+
+            @Override
+            public HttpRequest request() {
+                return request;
+            }
+
+            @Override
+            public Optional<HttpResponse<String>> previousResponse() {
+                return Optional.empty();
+            }
+
+            @Override
+            public HttpHeaders headers() {
+                return HttpHeaders.of(java.util.Map.of(), (name, value) -> true);
+            }
+
+            @Override
+            public String body() {
+                return body;
+            }
+
+            @Override
+            public Optional<javax.net.ssl.SSLSession> sslSession() {
+                return Optional.empty();
+            }
+
+            @Override
+            public URI uri() {
+                return request.uri();
+            }
+
+            @Override
+            public HttpClient.Version version() {
+                return HttpClient.Version.HTTP_1_1;
+            }
+        };
+    }
+
+    private static void complete(final HttpResponse.BodyHandler<String> handler) {
+        final HttpResponse.BodySubscriber<String> subscriber = handler.apply(new ResponseInfo());
+        subscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(final long count) {
+            }
+
+            @Override
+            public void cancel() {
+            }
+        });
+        subscriber.onComplete();
+    }
+
+    private static final class ResponseInfo implements HttpResponse.ResponseInfo {
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(java.util.Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_1_1;
+        }
+    }
+
+    private static final class CapturingWriter implements HttpLogWriter {
+        private final List<Precorrelation> requests = new ArrayList<>();
+        private final List<Correlation> responses = new ArrayList<>();
+        private final List<String> messages = new ArrayList<>();
+        private final List<String> events = new ArrayList<>();
+        private final CompletableFuture<String> responseMessage = new CompletableFuture<>();
+
+        @Override
+        public void write(final Precorrelation precorrelation, final String request) {
+            requests.add(precorrelation);
+            messages.add(request);
+            events.add("request");
+        }
+
+        @Override
+        public void write(final Correlation correlation, final String response) {
+            responses.add(correlation);
+            messages.add(response);
+            events.add("response");
+            responseMessage.complete(response);
+        }
+
+        List<String> messages() {
+            return messages;
+        }
+
+        CompletableFuture<String> responseMessage() {
+            return responseMessage;
+        }
+    }
+
+    private static final class ControlledPublisher implements HttpRequest.BodyPublisher {
+        private final byte[] body;
+        private final List<Subscriber<? super ByteBuffer>> subscribers = new ArrayList<>();
+
+        private ControlledPublisher(final String body) {
+            this.body = body.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public long contentLength() {
+            return body.length;
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
+            subscribers.add(subscriber);
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(final long count) {
+                }
+
+                @Override
+                public void cancel() {
+                }
+            });
+        }
+
+        private void complete() {
+            subscribers.forEach(subscriber -> {
+                subscriber.onNext(ByteBuffer.wrap(body));
+                subscriber.onComplete();
+            });
+        }
+
+        private void complete(final int index) {
+            final Subscriber<? super ByteBuffer> subscriber = subscribers.get(index);
+            subscriber.onNext(ByteBuffer.wrap(body));
+            subscriber.onComplete();
+        }
+
+        private void fail() {
+            subscribers.forEach(subscriber -> subscriber.onError(new IllegalStateException("publisher failed")));
+        }
+
+        private void fail(final int index) {
+            subscribers.get(index).onError(new IllegalStateException("publisher failed"));
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/RemoteResponseTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/RemoteResponseTest.java
@@ -1,0 +1,170 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Origin;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow.Subscription;
+import java.util.zip.GZIPOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class RemoteResponseTest {
+
+    @Test
+    void shouldMapResponseMetadataAndBody() throws Exception {
+        final RemoteResponse logbookResponse = new RemoteResponse(response("created", HttpHeaders.of(
+                java.util.Map.of("Content-Type", List.of("text/plain"), "X-Trace", List.of("one", "two")), (name, value) -> true)),
+                handler("created"), false);
+
+        assertThat(logbookResponse.getOrigin()).isEqualTo(Origin.REMOTE);
+        assertThat(logbookResponse.getStatus()).isEqualTo(201);
+        assertThat(logbookResponse.getProtocolVersion()).isEqualTo("HTTP_2");
+        assertThat(logbookResponse.getReasonPhrase()).isEmpty();
+        assertThat(logbookResponse.getHeaders().get("X-Trace")).containsExactly("one", "two");
+        assertThat(logbookResponse.getCharset()).isEqualTo(UTF_8);
+        assertThat(logbookResponse.getBody()).isEmpty();
+        assertThat(logbookResponse.withBody().getBody()).isEqualTo("created".getBytes(UTF_8));
+        assertThat(logbookResponse.withoutBody().getBody()).isEmpty();
+    }
+
+    @Test
+    void shouldDecompressOnlyEnabledGzipResponses() throws Exception {
+        final byte[] compressed = gzip("created");
+
+        assertThat(new RemoteResponse(response(compressed, headers("gzip")), handler(compressed), true).withBody().getBody())
+                .isEqualTo("created".getBytes(UTF_8));
+        assertThat(new RemoteResponse(response(compressed, headers("X-GZip")), handler(compressed), true).withBody().getBody())
+                .isEqualTo("created".getBytes(UTF_8));
+        assertThat(new RemoteResponse(response(compressed, headers("br")), handler(compressed), true).withBody().getBody())
+                .isEqualTo(compressed);
+        assertThat(new RemoteResponse(response(compressed, headers("gzip")), handler(compressed), false).withBody().getBody())
+                .isEqualTo(compressed);
+    }
+
+    @Test
+    void shouldDecompressWhenAnyContentEncodingValueIsGzip() throws Exception {
+        final byte[] compressed = gzip("created");
+        final HttpHeaders headers = HttpHeaders.of(java.util.Map.of("Content-Encoding", List.of("br", "X-GZip")),
+                (name, value) -> true);
+
+        assertThat(new RemoteResponse(response(compressed, headers), handler(compressed), true).withBody().getBody())
+                .isEqualTo("created".getBytes(UTF_8));
+    }
+
+    @Test
+    void shouldNotDecompressAnExcludedBody() throws Exception {
+        final RemoteResponse response = new RemoteResponse(response("not-compressed", headers("gzip")),
+                handler("not-compressed"), true);
+
+        assertThat(response.withoutBody().getBody()).isEmpty();
+    }
+
+    private static HttpHeaders headers(final String contentEncoding) {
+        return HttpHeaders.of(java.util.Map.of("Content-Encoding", List.of(contentEncoding)), (name, value) -> true);
+    }
+
+    private static BufferingBodyHandler<String> handler(final String value) {
+        return handler(value.getBytes(UTF_8));
+    }
+
+    private static BufferingBodyHandler<String> handler(final byte[] body) {
+        final BufferingBodyHandler<String> handler = new BufferingBodyHandler<>(info -> HttpResponse.BodySubscribers.replacing("caller-value"));
+        final HttpResponse.BodySubscriber<String> subscriber = handler.apply(new ResponseInfo());
+        subscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(final long count) {
+            }
+
+            @Override
+            public void cancel() {
+            }
+        });
+        subscriber.onNext(List.of(ByteBuffer.wrap(body)));
+        subscriber.onComplete();
+        return handler;
+    }
+
+    private static HttpResponse<byte[]> response(final String body, final HttpHeaders headers) {
+        return response(body.getBytes(UTF_8), headers);
+    }
+
+    private static HttpResponse<byte[]> response(final byte[] body, final HttpHeaders headers) {
+        return new HttpResponse<>() {
+            @Override
+            public int statusCode() {
+                return 201;
+            }
+
+            @Override
+            public HttpRequest request() {
+                return HttpRequest.newBuilder(URI.create("https://example.org/orders")).GET().build();
+            }
+
+            @Override
+            public Optional<HttpResponse<byte[]>> previousResponse() {
+                return Optional.empty();
+            }
+
+            @Override
+            public HttpHeaders headers() {
+                return headers;
+            }
+
+            @Override
+            public byte[] body() {
+                return body;
+            }
+
+            @Override
+            public Optional<javax.net.ssl.SSLSession> sslSession() {
+                return Optional.empty();
+            }
+
+            @Override
+            public URI uri() {
+                return URI.create("https://example.org/orders");
+            }
+
+            @Override
+            public HttpClient.Version version() {
+                return HttpClient.Version.HTTP_2;
+            }
+        };
+    }
+
+    private static byte[] gzip(final String value) throws Exception {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(output)) {
+            gzip.write(value.getBytes(UTF_8));
+        }
+        return output.toByteArray();
+    }
+
+    private static final class ResponseInfo implements HttpResponse.ResponseInfo {
+        @Override
+        public int statusCode() {
+            return 201;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(java.util.Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_2;
+        }
+    }
+}

--- a/logbook-spring-boot-autoconfigure/pom.xml
+++ b/logbook-spring-boot-autoconfigure/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>
+            <artifactId>logbook-jdkhttpclient</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.zalando</groupId>
             <artifactId>logbook-openfeign</artifactId>
             <optional>true</optional>
         </dependency>
@@ -83,6 +88,11 @@
                     <artifactId>spring-jcl</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
+++ b/logbook-spring-boot-autoconfigure/src/main/java/org/zalando/logbook/autoconfigure/LogbookAutoConfiguration.java
@@ -60,6 +60,8 @@ import org.zalando.logbook.core.StatusCodeBasedSink;
 import org.zalando.logbook.core.WithoutBodyStrategy;
 import org.zalando.logbook.httpclient.LogbookHttpRequestInterceptor;
 import org.zalando.logbook.httpclient.LogbookHttpResponseInterceptor;
+import org.zalando.logbook.jdkhttpclient.LogbookHttpClient;
+import org.zalando.logbook.jdkhttpclient.LogbookHttpClientFactory;
 import org.zalando.logbook.json.Jackson2JsonFieldBodyFilter;
 import org.zalando.logbook.json.JacksonJsonFieldBodyFilter;
 import org.zalando.logbook.json.JsonHttpLogFormatterJackson2;
@@ -371,6 +373,19 @@ public class LogbookAutoConfiguration {
         @ConditionalOnMissingBean(LogbookClientHttpRequestInterceptor.class)
         public LogbookClientHttpRequestInterceptor logbookClientHttpRequestInterceptor(final Logbook logbook) {
             return new LogbookClientHttpRequestInterceptor(logbook);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(LogbookHttpClient.class)
+    static class JdkHttpClientAutoConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(LogbookHttpClientFactory.class)
+        LogbookHttpClientFactory logbookHttpClientFactory(
+                final Logbook logbook,
+                @Value("${logbook.jdkhttpclient.decompress-response:false}") final boolean decompressResponse) {
+            return new LogbookHttpClientFactory(logbook, decompressResponse);
         }
     }
 

--- a/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/LogbookHttpClientFactoryTest.java
+++ b/logbook-spring-boot-autoconfigure/src/test/java/org/zalando/logbook/autoconfigure/LogbookHttpClientFactoryTest.java
@@ -1,0 +1,139 @@
+package org.zalando.logbook.autoconfigure;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.jdkhttpclient.LogbookHttpClient;
+import org.zalando.logbook.jdkhttpclient.LogbookHttpClientFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LogbookHttpClientFactoryTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(LogbookAutoConfiguration.JdkHttpClientAutoConfiguration.class);
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void createsFactoryWhenJdkHttpClientIntegrationIsAvailable() {
+        contextRunner.withBean(Logbook.class, Logbook::create)
+                .run(context -> assertThat(context).hasSingleBean(LogbookHttpClientFactory.class));
+    }
+
+    @Test
+    void doesNotCreateFactoryWithoutJdkHttpClientIntegration() {
+        contextRunner.withClassLoader(new FilteredClassLoader(LogbookHttpClient.class))
+                .withBean(Logbook.class, Logbook::create)
+                .run(context -> assertThat(context).doesNotHaveBean(LogbookHttpClientFactory.class));
+    }
+
+    @Test
+    void backsOffForApplicationDefinedFactory() {
+        final LogbookHttpClientFactory factory = new LogbookHttpClientFactory(Logbook.create(), false);
+
+        contextRunner.withBean(LogbookHttpClientFactory.class, () -> factory)
+                .run(context -> assertThat(context).getBean(LogbookHttpClientFactory.class).isSameAs(factory));
+    }
+
+    @Test
+    void logsDecodedGzipResponseWhenConfigured() throws Exception {
+        final CapturingWriter writer = new CapturingWriter();
+        startGzipServer();
+
+        contextRunner.withBean(Logbook.class, () -> logbook(writer))
+                .withPropertyValues("logbook.jdkhttpclient.decompress-response=true")
+                .run(context -> send(context.getBean(LogbookHttpClientFactory.class)));
+
+        assertThat(writer.messages).anySatisfy(message -> assertThat(message).contains("decoded response"));
+    }
+
+    @Test
+    void doesNotLogDecodedGzipResponseByDefault() throws Exception {
+        final CapturingWriter writer = new CapturingWriter();
+        startGzipServer();
+
+        contextRunner.withBean(Logbook.class, () -> logbook(writer))
+                .run(context -> send(context.getBean(LogbookHttpClientFactory.class)));
+
+        assertThat(writer.messages).noneSatisfy(message -> assertThat(message).contains("decoded response"));
+    }
+
+    private void startGzipServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            final byte[] body = gzip("decoded response");
+            exchange.getResponseHeaders().add("Content-Encoding", "gzip");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    private void send(final LogbookHttpClientFactory factory) {
+        final HttpClient client = factory.create();
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + server.getAddress().getPort()))
+                .GET().build();
+        final HttpResponse<String> response;
+        try {
+            response = client.send(request, ofString());
+        } catch (IOException | InterruptedException e) {
+            throw new AssertionError(e);
+        }
+        assertThat(response.body()).isNotEmpty();
+    }
+
+    private static byte[] gzip(final String body) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(output)) {
+            gzip.write(body.getBytes(StandardCharsets.UTF_8));
+        }
+        return output.toByteArray();
+    }
+
+    private static Logbook logbook(final HttpLogWriter writer) {
+        return Logbook.builder().sink(new DefaultSink(new DefaultHttpLogFormatter(), writer)).build();
+    }
+
+    private static final class CapturingWriter implements HttpLogWriter {
+        private final List<String> messages = new ArrayList<>();
+
+        @Override
+        public void write(final Precorrelation precorrelation, final String request) {
+            messages.add(request);
+        }
+
+        @Override
+        public void write(final Correlation correlation, final String response) {
+            messages.add(response);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>logbook-core</module>
         <module>logbook-httpclient</module>
         <module>logbook-httpclient5</module>
+        <module>logbook-jdkhttpclient</module>
         <module>logbook-jaxrs</module>
         <module>logbook-jdkserver</module>
         <module>logbook-json</module>


### PR DESCRIPTION
This PR adds support for the native JDK java.net.HttpClient

## Description
* It adds a new module `logbook-jdkhttpclient`
* adds an Autoconfiguration class which initializes a factory bean to instrument http clients

NOTE: 
* using this new module requires to have JDK 21 or higher. That contradicts with the current compatibility matrix

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
