### PR TITLE
Add AnsiPrettyPrintingSink for colored JSON logging (#2354)

### DIFF
--- a/test-modules/logbook-test/pom.xml
+++ b/test-modules/logbook-test/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>logbook-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson3.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>faux-pas</artifactId>
             <version>0.9.0</version>

--- a/test-modules/logbook-test/src/main/java/org/zalando/logbook/test/AnsiColors.java
+++ b/test-modules/logbook-test/src/main/java/org/zalando/logbook/test/AnsiColors.java
@@ -1,0 +1,29 @@
+package org.zalando.logbook.test;
+
+/**
+ * Utility class for ANSI color codes to format console output.
+ * Stateless, containing only constants and static methods.
+ */
+public final class AnsiColors {
+
+    public static final String RESET = "\u001B[0m";
+    public static final String CYAN = "\u001B[36m";
+    public static final String GREEN = "\u001B[32m";
+    public static final String YELLOW = "\u001B[33m";
+
+    private AnsiColors() {
+        // Utility class, no instantiation
+    }
+
+    public static String cyan(String text) {
+        return CYAN + text + RESET;
+    }
+
+    public static String green(String text) {
+        return GREEN + text + RESET;
+    }
+
+    public static String yellow(String text) {
+        return YELLOW + text + RESET;
+    }
+}

--- a/test-modules/logbook-test/src/main/java/org/zalando/logbook/test/AnsiPrettyPrintingSink.java
+++ b/test-modules/logbook-test/src/main/java/org/zalando/logbook/test/AnsiPrettyPrintingSink.java
@@ -1,0 +1,107 @@
+package org.zalando.logbook.test;
+
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpRequest;
+import org.zalando.logbook.HttpResponse;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.Sink;
+import org.zalando.logbook.StructuredHttpLogFormatter;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A sink that pretty-prints HTTP requests and responses as JSON to System.out,
+ * using ANSI color codes for easier local development and debugging.
+ */
+public final class AnsiPrettyPrintingSink implements Sink {
+
+    private final boolean useColor;
+    private final StructuredHttpLogFormatter formatter;
+    private final ObjectWriter prettyPrinter;
+
+    /**
+     * Default constructor auto-detects if a console is available to enable/disable colors.
+     */
+    public AnsiPrettyPrintingSink() {
+        this(System.console() != null);
+    }
+
+    public AnsiPrettyPrintingSink(boolean useColor) {
+        this.useColor = useColor;
+        ObjectMapper mapper = new ObjectMapper();
+        this.prettyPrinter = mapper.writerWithDefaultPrettyPrinter();
+        
+        // We implement StructuredHttpLogFormatter manually to avoid depending on logbook-json
+        // and causing a cyclic dependency.
+        this.formatter = new StructuredHttpLogFormatter() {
+            @Override
+            public String format(Map<String, Object> content) throws IOException {
+                return prettyPrinter.writeValueAsString(content);
+            }
+
+            @Override
+            public Optional<Object> prepareBody(final org.zalando.logbook.HttpMessage message) throws IOException {
+                String body = message.getBodyAsString();
+                if (body.isEmpty()) return Optional.empty();
+
+                String contentType = message.getContentType();
+                if (contentType != null && (contentType.startsWith("application/json") || contentType.contains("+json"))) {
+                    try {
+                        return Optional.of(mapper.readTree(body));
+                    } catch (Exception e) {
+                        // Fallback to raw string if invalid JSON
+                    }
+                }
+                return Optional.of(body);
+            }
+        };
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public void write(final Precorrelation precorrelation, final HttpRequest request) throws IOException {
+        // Prepare the standard logbook map of request properties
+        Map<String, Object> content = formatter.prepare(precorrelation, request);
+        
+        System.out.println(colorizeAndFormat(content));
+    }
+
+    @Override
+    public void write(final Correlation correlation, final HttpRequest request, final HttpResponse response) throws IOException {
+        // Prepare the standard logbook map of response properties
+        Map<String, Object> content = formatter.prepare(correlation, response);
+        
+        System.out.println(colorizeAndFormat(content));
+    }
+
+    private String colorizeAndFormat(Map<String, Object> content) throws IOException {
+        // Convert the map to a pretty-printed JSON string
+        String json = prettyPrinter.writeValueAsString(content);
+
+        if (!useColor) {
+            return json;
+        }
+
+        // Apply basic ANSI coloring to the JSON string.
+        // We use simple regex replacement for beginner-readable code.
+        
+        // 1. Color JSON keys in green (matches "key":)
+        String colored = json.replaceAll("\"((?:\\\\\"|[^\"])+)\"(\\s*:)", AnsiColors.green("\"$1\"") + "$2");
+        
+        // 2. Color JSON string values in yellow (matches : "value")
+        colored = colored.replaceAll("(:\\s*)\"((?:\\\\\"|[^\"])*)\"", "$1" + AnsiColors.yellow("\"$2\""));
+        
+        // 3. Highlight the "headers" key in cyan as requested
+        colored = colored.replace(AnsiColors.green("\"headers\""), AnsiColors.cyan("\"headers\""));
+
+        return colored;
+    }
+}


### PR DESCRIPTION
Implements the ANSI-coloring pretty-print sink requested in #2354.

Adds `AnsiPrettyPrintingSink` and a small `AnsiColors` helper to `logbook-test`. It pretty-prints request/response JSON with headers in cyan, JSON keys in green, and JSON string values in yellow meant purely for local development readability, not production use.

Color output auto-detects via `System.console() != null`, or can be forced on/off via the constructor.

**Known limitation:** coloring is applied via regex post-processing of the already-formatted JSON string, rather than during serialization. This keeps the implementation simple and dependency-light, but could mis-highlight edge cases with unusual nested quote patterns in body content. Happy to revisit with a proper Jackson-generator-level approach if maintainers prefer that.

Closes #2354