### PR TITLE
Add logbook-jdkhttpclient module for JDK HttpClient (#2006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,17 +879,17 @@ resourceConfig.register(new LogbookServerFilter(logbook));
 
 ### JDK HttpClient
 
-The logbook-jdkhttpclient module contains a LogbookHttpClient decorator to use with the
-built-in java.net.http.HttpClient:
+The `logbook-jdkhttpclient` module contains a `LogbookHttpClient` decorator to use with the
+built-in `java.net.http.HttpClient`:
 
-`java
+```java
 HttpClient client = new LogbookHttpClient(HttpClient.newHttpClient(), logbook);
 
 HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-`
+```
 
-Note: this module currently supports the synchronous send() method only; sendAsync()
-throws UnsupportedOperationException and is planned for a follow-up.
+Note: this module currently supports the synchronous `send()` method only; `sendAsync()`
+throws `UnsupportedOperationException` and is planned for a follow-up.
 
 ### JDK HTTP Server
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ library/framework/etc. to it.
   * [HTTP Client](#http-client)
   * [HTTP Client 5](#http-client-5)
   * [JAX-RS 3.x (aka Jakarta RESTful Web Services)](#jax-rs-3x-aka-jakarta-restful-web-services)
+  * [JDK HttpClient](#jdk-httpclient)
   * [JDK HTTP Server](#jdk-http-server)
   * [Netty](#netty)
   * [OkHttp v2.x](#okhttp-v2x)
@@ -878,17 +879,17 @@ resourceConfig.register(new LogbookServerFilter(logbook));
 
 ### JDK HttpClient
 
-The `logbook-jdkhttpclient` module contains a `LogbookHttpClient` decorator to use with the
-built-in `java.net.http.HttpClient`:
+The logbook-jdkhttpclient module contains a LogbookHttpClient decorator to use with the
+built-in java.net.http.HttpClient:
 
-```java
+`java
 HttpClient client = new LogbookHttpClient(HttpClient.newHttpClient(), logbook);
 
 HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-```
+`
 
-Note: this module currently supports the synchronous `send()` method only; `sendAsync()`
-throws `UnsupportedOperationException` and is planned for a follow-up.
+Note: this module currently supports the synchronous send() method only; sendAsync()
+throws UnsupportedOperationException and is planned for a follow-up.
 
 ### JDK HTTP Server
 

--- a/README.md
+++ b/README.md
@@ -876,6 +876,20 @@ A `LogbookServerFilter` for be used with HTTP servers
 resourceConfig.register(new LogbookServerFilter(logbook));
 ```
 
+### JDK HttpClient
+
+The `logbook-jdkhttpclient` module contains a `LogbookHttpClient` decorator to use with the
+built-in `java.net.http.HttpClient`:
+
+```java
+HttpClient client = new LogbookHttpClient(HttpClient.newHttpClient(), logbook);
+
+HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+```
+
+Note: this module currently supports the synchronous `send()` method only; `sendAsync()`
+throws `UnsupportedOperationException` and is planned for a follow-up.
+
 ### JDK HTTP Server
 
 The `logbook-jdkserver` module provides support for

--- a/logbook-bom/pom.xml
+++ b/logbook-bom/pom.xml
@@ -51,6 +51,11 @@
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
+                <artifactId>logbook-jdkhttpclient</artifactId>
+                <version>4.2.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
                 <artifactId>logbook-json</artifactId>
                 <version>4.2.0-SNAPSHOT</version>
             </dependency>

--- a/logbook-jdkhttpclient/pom.xml
+++ b/logbook-jdkhttpclient/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.zalando</groupId>
+        <artifactId>logbook-parent</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../logbook-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>logbook-jdkhttpclient</artifactId>
+    <name>${project.artifactId}</name>
+    <description>HTTP Client wrapper for request and response logging in JDK HttpClient</description>
+    <scm>
+        <url>https://github.com/zalando/logbook</url>
+        <connection>scm:git:git@github.com:zalando/logbook.git</connection>
+        <developerConnection>scm:git:git@github.com:zalando/logbook.git</developerConnection>
+    </scm>
+    <dependencies>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>logbook-api</artifactId>
+        </dependency>
+        <!-- testing -->
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>logbook-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>logbook-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <!-- This is a workaround to having module names before switching to Java 9+ -->
+                            <!-- It will set our desired Automatic-Module-Name inside META/INF/MANIFEST.MF file -->
+                            <Automatic-Module-Name>org.zalando.logbook.jdkhttpclient</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/JdkRequest.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/JdkRequest.java
@@ -1,0 +1,278 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import lombok.AllArgsConstructor;
+import org.zalando.logbook.ContentType;
+import org.zalando.logbook.Origin;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.zalando.fauxpas.FauxPas.throwingUnaryOperator;
+
+final class JdkRequest implements org.zalando.logbook.HttpRequest {
+
+    private final AtomicReference<State> state;
+    private final HttpRequest request;
+
+    private interface State {
+        default State with() {
+            return this;
+        }
+
+        default State without() {
+            return this;
+        }
+
+        default State buffer(final HttpRequest request) throws IOException {
+            return this;
+        }
+
+        HttpRequest getRequest();
+
+        default byte[] getBody() {
+            return new byte[0];
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Unbuffered implements State {
+        private final HttpRequest request;
+
+        @Override
+        public State with() {
+            return new Offering(request);
+        }
+
+        @Override
+        public HttpRequest getRequest() {
+            return request;
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Offering implements State {
+        private final HttpRequest request;
+
+        @Override
+        public State without() {
+            return new Unbuffered(request);
+        }
+
+        @Override
+        public State buffer(final HttpRequest request) throws IOException {
+            if (request.bodyPublisher().isEmpty()) {
+                return new Passing(request);
+            }
+
+            final byte[] body = drain(request.bodyPublisher().get());
+
+            final HttpRequest.Builder builder = HttpRequest.newBuilder(request.uri())
+                    .method(request.method(), BodyPublishers.ofByteArray(body));
+
+            request.headers().map().forEach((name, values) -> {
+                for (final String value : values) {
+                    builder.header(name, value);
+                }
+            });
+
+            request.timeout().ifPresent(builder::timeout);
+            request.version().ifPresent(builder::version);
+            builder.expectContinue(request.expectContinue());
+
+            final HttpRequest copy = builder.build();
+            return new Buffering(copy, body);
+        }
+
+        @Override
+        public HttpRequest getRequest() {
+            return request;
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Buffering implements State {
+        private final HttpRequest copy;
+        private final byte[] body;
+
+        @Override
+        public State without() {
+            return new Ignoring(copy, body);
+        }
+
+        @Override
+        public HttpRequest getRequest() {
+            return copy;
+        }
+
+        @Override
+        public byte[] getBody() {
+            return body;
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Ignoring implements State {
+        private final HttpRequest copy;
+        private final byte[] body;
+
+        @Override
+        public State with() {
+            return new Buffering(copy, body);
+        }
+
+        @Override
+        public HttpRequest getRequest() {
+            return copy;
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Passing implements State {
+        private final HttpRequest request;
+
+        @Override
+        public HttpRequest getRequest() {
+            return request;
+        }
+    }
+
+    JdkRequest(final HttpRequest request) {
+        this.request = request;
+        this.state = new AtomicReference<>(new Unbuffered(request));
+    }
+
+    @Override
+    public Origin getOrigin() {
+        return Origin.LOCAL;
+    }
+
+    @Override
+    public String getRemote() {
+        return "localhost";
+    }
+
+    @Override
+    public String getMethod() {
+        return request.method();
+    }
+
+    @Override
+    public String getScheme() {
+        return request.uri().getScheme();
+    }
+
+    @Override
+    public String getHost() {
+        return request.uri().getHost();
+    }
+
+    @Override
+    public Optional<Integer> getPort() {
+        return Optional.of(request.uri().getPort()).filter(p -> p != -1);
+    }
+
+    @Override
+    public String getPath() {
+        return request.uri().getPath();
+    }
+
+    @Override
+    public String getQuery() {
+        return Optional.ofNullable(request.uri().getQuery()).orElse("");
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return request.version()
+                .map(v -> v == HttpClient.Version.HTTP_2 ? "HTTP/2" : "HTTP/1.1")
+                .orElse("HTTP/1.1");
+    }
+
+    @Override
+    public org.zalando.logbook.HttpHeaders getHeaders() {
+        return org.zalando.logbook.HttpHeaders.of(request.headers().map());
+    }
+
+    @Override
+    public String getContentType() {
+        return request.headers().firstValue("Content-Type").orElse("");
+    }
+
+    @Override
+    public Charset getCharset() {
+        return request.headers().firstValue("Content-Type")
+                .map(ContentType::parseCharset)
+                .orElse(UTF_8);
+    }
+
+    @Override
+    public org.zalando.logbook.HttpRequest withBody() {
+        state.updateAndGet(State::with);
+        return this;
+    }
+
+    @Override
+    public org.zalando.logbook.HttpRequest withoutBody() {
+        state.updateAndGet(State::without);
+        return this;
+    }
+
+    @Override
+    public byte[] getBody() {
+        return state.updateAndGet(throwingUnaryOperator(s -> s.buffer(request))).getBody();
+    }
+
+    HttpRequest toHttpRequest() {
+        return state.get().getRequest();
+    }
+
+    private static byte[] drain(final HttpRequest.BodyPublisher publisher) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final CompletableFuture<byte[]> future = new CompletableFuture<>();
+
+        publisher.subscribe(new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(final Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(final ByteBuffer item) {
+                final byte[] bytes = new byte[item.remaining()];
+                item.get(bytes);
+                out.write(bytes, 0, bytes.length);
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                future.complete(out.toByteArray());
+            }
+        });
+
+        try {
+            return future.join();
+        } catch (final CompletionException e) {
+            final Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw new IOException("Failed to drain request body", cause);
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClient.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClient.java
@@ -1,0 +1,159 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apiguardian.api.API;
+import org.zalando.logbook.Logbook;
+
+import jakarta.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+@API(status = EXPERIMENTAL)
+@Slf4j
+public final class LogbookHttpClient extends HttpClient {
+
+    private final HttpClient delegate;
+    private final Logbook logbook;
+
+    public LogbookHttpClient(final Logbook logbook, final HttpClient delegate) {
+        this.logbook = Objects.requireNonNull(logbook);
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    public LogbookHttpClient(final HttpClient delegate, final Logbook logbook) {
+        this(logbook, delegate);
+    }
+
+    public LogbookHttpClient(final Logbook logbook) {
+        this(logbook, HttpClient.newHttpClient());
+    }
+
+    @Override
+    public <T> HttpResponse<T> send(
+            final HttpRequest request,
+            final HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+
+        final JdkRequest jdkRequest = new JdkRequest(request);
+        final Logbook.ResponseProcessingStage stage = logRequest(jdkRequest);
+
+        final ByteArrayOutputStream responseBodyCache = new ByteArrayOutputStream();
+        final HttpResponse.BodyHandler<T> wrappedHandler = responseInfo -> {
+            final HttpResponse.BodySubscriber<T> subscriber = responseBodyHandler.apply(responseInfo);
+            return new TeeingBodySubscriber<>(subscriber, responseBodyCache);
+        };
+
+        final HttpResponse<T> response = delegate.send(jdkRequest.toHttpRequest(), wrappedHandler);
+
+        logResponse(stage, response, responseBodyCache.toByteArray());
+
+        return response;
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            final HttpRequest request,
+            final HttpResponse.BodyHandler<T> responseBodyHandler) {
+        throw new UnsupportedOperationException("sendAsync is not supported yet");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            final HttpRequest request,
+            final HttpResponse.BodyHandler<T> responseBodyHandler,
+            final HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        throw new UnsupportedOperationException("sendAsync is not supported yet");
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return delegate.cookieHandler();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return delegate.connectTimeout();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return delegate.followRedirects();
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return delegate.proxy();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return delegate.sslContext();
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return delegate.sslParameters();
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return delegate.authenticator();
+    }
+
+    @Override
+    public Version version() {
+        return delegate.version();
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return delegate.executor();
+    }
+
+    @Override
+    public WebSocket.Builder newWebSocketBuilder() {
+        return delegate.newWebSocketBuilder();
+    }
+
+    @Nullable
+    private Logbook.ResponseProcessingStage logRequest(final JdkRequest request) {
+        Logbook.ResponseProcessingStage stage = null;
+        try {
+            stage = logbook.process(request).write();
+        } catch (final Exception e) {
+            log.warn("Unable to log request. Will skip the request & response logging step.", e);
+        }
+        return stage;
+    }
+
+    private static void logResponse(
+            @Nullable final Logbook.ResponseProcessingStage stage,
+            final HttpResponse<?> response,
+            final byte[] responseBody) {
+        if (stage != null) {
+            try {
+                stage.process(new RemoteResponse(response, responseBody)).write();
+            } catch (final Exception e) {
+                log.warn("Unable to log response. Will skip the response logging step.", e);
+            }
+        } else {
+            log.warn("Unable to log response: ResponseProcessingStage is null. Will skip the response logging step.");
+        }
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/RemoteResponse.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/RemoteResponse.java
@@ -1,0 +1,136 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import lombok.AllArgsConstructor;
+import org.zalando.logbook.ContentType;
+import org.zalando.logbook.Origin;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+final class RemoteResponse implements org.zalando.logbook.HttpResponse {
+
+    private final AtomicReference<State> state = new AtomicReference<>(new Unbuffered());
+    private final HttpResponse<?> response;
+    private final byte[] body;
+
+    private interface State {
+        default State with() {
+            return this;
+        }
+
+        default State without() {
+            return this;
+        }
+
+        default State buffer(final byte[] body) {
+            return this;
+        }
+
+        default byte[] getBody() {
+            return new byte[0];
+        }
+    }
+
+    private static final class Unbuffered implements State {
+        @Override
+        public State with() {
+            return new Offering();
+        }
+    }
+
+    private static final class Offering implements State {
+        @Override
+        public State without() {
+            return new Unbuffered();
+        }
+
+        @Override
+        public State buffer(final byte[] body) {
+            return new Buffering(body);
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Buffering implements State {
+        private final byte[] body;
+
+        @Override
+        public State without() {
+            return new Ignoring(body);
+        }
+
+        @Override
+        public byte[] getBody() {
+            return body;
+        }
+    }
+
+    @AllArgsConstructor
+    private static final class Ignoring implements State {
+        private final byte[] body;
+
+        @Override
+        public State with() {
+            return new Buffering(body);
+        }
+    }
+
+    RemoteResponse(final HttpResponse<?> response, final byte[] body) {
+        this.response = Objects.requireNonNull(response);
+        this.body = Objects.requireNonNull(body);
+    }
+
+    @Override
+    public Origin getOrigin() {
+        return Origin.REMOTE;
+    }
+
+    @Override
+    public int getStatus() {
+        return response.statusCode();
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return response.version() == HttpClient.Version.HTTP_2 ? "HTTP/2" : "HTTP/1.1";
+    }
+
+    @Override
+    public org.zalando.logbook.HttpHeaders getHeaders() {
+        return org.zalando.logbook.HttpHeaders.of(response.headers().map());
+    }
+
+    @Override
+    public String getContentType() {
+        return response.headers().firstValue("Content-Type").orElse("");
+    }
+
+    @Override
+    public Charset getCharset() {
+        return response.headers().firstValue("Content-Type")
+                .map(ContentType::parseCharset)
+                .orElse(UTF_8);
+    }
+
+    @Override
+    public org.zalando.logbook.HttpResponse withBody() {
+        state.updateAndGet(State::with);
+        return this;
+    }
+
+    @Override
+    public org.zalando.logbook.HttpResponse withoutBody() {
+        state.updateAndGet(State::without);
+        return this;
+    }
+
+    @Override
+    public byte[] getBody() {
+        return state.updateAndGet(s -> s.buffer(body)).getBody();
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/TeeingBodySubscriber.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/TeeingBodySubscriber.java
@@ -1,0 +1,51 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import java.io.ByteArrayOutputStream;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+
+final class TeeingBodySubscriber<T> implements BodySubscriber<T> {
+
+    private final BodySubscriber<T> delegate;
+    private final ByteArrayOutputStream output;
+
+    TeeingBodySubscriber(final BodySubscriber<T> delegate, final ByteArrayOutputStream output) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.output = Objects.requireNonNull(output);
+    }
+
+    @Override
+    public CompletionStage<T> getBody() {
+        return delegate.getBody();
+    }
+
+    @Override
+    public void onSubscribe(final Flow.Subscription subscription) {
+        delegate.onSubscribe(subscription);
+    }
+
+    @Override
+    public void onNext(final List<ByteBuffer> item) {
+        for (final ByteBuffer buffer : item) {
+            final ByteBuffer duplicate = buffer.duplicate();
+            final byte[] bytes = new byte[duplicate.remaining()];
+            duplicate.get(bytes);
+            output.write(bytes, 0, bytes.length);
+        }
+        delegate.onNext(item);
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        delegate.onError(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        delegate.onComplete();
+    }
+}

--- a/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/package-info.java
+++ b/logbook-jdkhttpclient/src/main/java/org/zalando/logbook/jdkhttpclient/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package org.zalando.logbook.jdkhttpclient;

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/AbstractHttpTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/AbstractHttpTest.java
@@ -1,0 +1,280 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Precorrelation;
+import org.zalando.logbook.core.DefaultHttpLogFormatter;
+import org.zalando.logbook.core.DefaultSink;
+import org.zalando.logbook.test.TestStrategy;
+
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.Options.ChunkedEncodingPolicy.NEVER;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+abstract class AbstractHttpTest {
+
+    final WireMockServer server = new WireMockServer(options().dynamicPort().gzipDisabled(true));
+
+    final WireMockServer nonChunkedServer = new WireMockServer(options().dynamicPort().gzipDisabled(true)
+            .useChunkedTransferEncoding(NEVER));
+
+    final HttpLogWriter writer = mock(HttpLogWriter.class);
+
+    protected final Logbook logbook = Logbook.builder()
+            .strategy(new TestStrategy())
+            .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+            .build();
+
+    @BeforeEach
+    void defaultBehaviour() {
+        server.start();
+        nonChunkedServer.start();
+        when(writer.isActive()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
+        nonChunkedServer.stop();
+    }
+
+    @Test
+    void shouldLogRequestWithoutBody() throws IOException, InterruptedException {
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
+
+        sendAndReceive();
+
+        final String message = captureRequest();
+
+        assertThat(message)
+                .startsWith("Outgoing Request:")
+                .contains(format("GET http://localhost:%d/ HTTP/1.1", server.port()))
+                .doesNotContain("Content-Type", "Hello, world!");
+    }
+
+    @Test
+    void shouldLogRequestWithBody() throws IOException, InterruptedException {
+        server.stubFor(post("/").withRequestBody(equalTo("Hello, world!")).willReturn(aResponse().withStatus(204)));
+
+        sendAndReceive("Hello, world!");
+
+        final String message = captureRequest();
+
+        assertThat(message)
+                .startsWith("Outgoing Request:")
+                .contains(
+                        format("POST http://localhost:%d/ HTTP/1.1", server.port()),
+                        "Content-Type: text/plain",
+                        "Hello, world!");
+    }
+
+    protected String captureRequest() throws IOException {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer).write(any(Precorrelation.class), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void shouldNotLogRequestIfInactive() throws IOException, InterruptedException {
+        when(writer.isActive()).thenReturn(false);
+
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
+
+        sendAndReceive();
+
+        verify(writer, never()).write(any(Precorrelation.class), any());
+    }
+
+    @Test
+    void shouldLogResponseWithoutBody() throws IOException, InterruptedException {
+        server.stubFor(get("/").willReturn(aResponse().withStatus(204)));
+
+        sendAndReceive();
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 204 No Content")
+                .doesNotContainIgnoringCase("Content-Type")
+                .doesNotContain("Hello, world!");
+    }
+
+    @Test
+    void shouldLogResponseWithChunkedBody() throws IOException, InterruptedException {
+        server.stubFor(post("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
+
+        final HttpResponse<String> response = sendAndReceive("Hello, world!");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("Hello, world!");
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK")
+                .containsIgnoringCase("Content-Type: text/plain")
+                .contains("Hello, world!");
+    }
+
+    @Test
+    void shouldLogResponseWithBody() throws IOException, InterruptedException {
+        server.stubFor(post("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")
+                .withHeader("Content-Length", "13")));
+
+        final HttpResponse<String> response = sendAndReceive("Hello, world!");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("Hello, world!");
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK")
+                .containsIgnoringCase("Content-Type: text/plain")
+                .contains("Hello, world!");
+    }
+
+    protected String captureResponse() throws IOException {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer).write(any(Correlation.class), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void shouldNotLogResponseIfInactive() throws IOException, InterruptedException {
+        when(writer.isActive()).thenReturn(false);
+
+        server.stubFor(get("/").willReturn(aResponse().withStatus(200)));
+
+        sendAndReceive();
+
+        verify(writer, never()).write(any(Correlation.class), any());
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenLogbookRequestInterceptorHasException() throws IOException, InterruptedException {
+        doThrow(new IOException("Writing request went wrong")).when(writer).write(any(Precorrelation.class), any());
+
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
+
+        final HttpResponse<String> response = sendAndReceive();
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        verify(writer).write(any(Precorrelation.class), any());
+        verify(writer, never()).write(any(Correlation.class), any());
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenLogbookResponseInterceptorHasException() throws IOException, InterruptedException {
+        doThrow(new IOException("Writing response went wrong")).when(writer).write(any(Correlation.class), any());
+
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Hello, world!")
+                .withHeader("Content-Type", "text/plain")));
+
+        final HttpResponse<String> response = sendAndReceive();
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        verify(writer).write(any(Precorrelation.class), any());
+    }
+
+    @Test
+    void shouldHandleLargeChunkedResponseBody() throws IOException, InterruptedException {
+        final int size = 80 * 1024;
+        final byte[] largeBody = new byte[size];
+        Arrays.fill(largeBody, (byte) 'A');
+
+        server.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody(largeBody)));
+
+        final HttpResponse<String> response = sendAndReceive();
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).hasSize(size);
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK")
+                .containsIgnoringCase("Content-Type: text/plain")
+                .contains("A".repeat(size));
+    }
+
+    @Test
+    void shouldHandleLargeNonChunkedResponseBody() throws IOException, InterruptedException {
+        final int size = 80 * 1024;
+        final byte[] largeBody = new byte[size];
+        Arrays.fill(largeBody, (byte) 'A');
+
+        nonChunkedServer.stubFor(get("/").willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody(largeBody)));
+
+        final HttpResponse<String> response = sendAndReceive(nonChunkedServer);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).hasSize(size);
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK")
+                .containsIgnoringCase("Content-Type: text/plain")
+                .contains("A".repeat(size));
+    }
+
+    private HttpResponse<String> sendAndReceive() throws IOException, InterruptedException {
+        return sendAndReceive((String) null);
+    }
+
+    protected HttpResponse<String> sendAndReceive(@Nullable final String body) throws IOException, InterruptedException {
+        return sendAndReceive(server, body);
+    }
+
+    private HttpResponse<String> sendAndReceive(final WireMockServer server) throws IOException, InterruptedException {
+        return sendAndReceive(server, null);
+    }
+
+    protected abstract HttpResponse<String> sendAndReceive(WireMockServer server, @Nullable String body)
+            throws IOException, InterruptedException;
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/JdkRequestTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/JdkRequestTest.java
@@ -1,0 +1,257 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Flow;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class JdkRequestTest {
+
+    private JdkRequest unit(final HttpRequest request) {
+        return new JdkRequest(request);
+    }
+
+    private HttpRequest get(final String uri) {
+        return HttpRequest.newBuilder(URI.create(uri)).GET().build();
+    }
+
+    private HttpRequest post(final String uri, final String body) {
+        return HttpRequest.newBuilder(URI.create(uri))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+    }
+
+    @Test
+    void shouldResolveOriginAndRemote() {
+        final JdkRequest unit = unit(get("http://localhost/"));
+
+        assertThat(unit.getOrigin()).isEqualTo(org.zalando.logbook.Origin.LOCAL);
+        assertThat(unit.getRemote()).isEqualTo("localhost");
+    }
+
+    @Test
+    void shouldRetrieveUriParts() {
+        final JdkRequest unit = unit(get("http://localhost:8080/path?query=1"));
+
+        assertThat(unit.getScheme()).isEqualTo("http");
+        assertThat(unit.getHost()).isEqualTo("localhost");
+        assertThat(unit.getPort()).contains(8080);
+        assertThat(unit.getPath()).isEqualTo("/path");
+        assertThat(unit.getQuery()).isEqualTo("query=1");
+        assertThat(unit.getRequestUri()).isEqualTo("http://localhost:8080/path?query=1");
+    }
+
+    @Test
+    void shouldHandleDefaultPortAndEmptyQuery() {
+        final JdkRequest unit = unit(get("http://localhost/"));
+
+        assertThat(unit.getPort()).isEmpty();
+        assertThat(unit.getQuery()).isEmpty();
+        assertThat(unit.getRequestUri()).isEqualTo("http://localhost/");
+    }
+
+    @Test
+    void shouldRetrieveMethod() {
+        assertThat(unit(get("http://localhost/")).getMethod()).isEqualTo("GET");
+        assertThat(unit(post("http://localhost/", "test")).getMethod()).isEqualTo("POST");
+    }
+
+    @Test
+    void shouldResolveProtocolVersion() {
+        final HttpRequest http1 = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+        assertThat(unit(http1).getProtocolVersion()).isEqualTo("HTTP/1.1");
+
+        final HttpRequest http2 = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        assertThat(unit(http2).getProtocolVersion()).isEqualTo("HTTP/2");
+
+        final HttpRequest defaultVer = HttpRequest.newBuilder(URI.create("http://localhost/")).build();
+        assertThat(unit(defaultVer).getProtocolVersion()).isEqualTo("HTTP/1.1");
+    }
+
+    @Test
+    void shouldRetrieveHeaders() {
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .header("X-Single", "one")
+                .header("X-Multi", "val1")
+                .header("X-Multi", "val2")
+                .build();
+
+        final JdkRequest unit = unit(request);
+        assertThat(unit.getHeaders()).hasSize(2);
+        assertThat(unit.getHeaders().get("x-single")).containsExactly("one");
+        assertThat(unit.getHeaders().get("x-multi")).containsExactly("val1", "val2");
+    }
+
+    @Test
+    void shouldResolveContentTypeAndCharset() {
+        final HttpRequest req1 = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .header("Content-Type", "text/plain; charset=ISO-8859-1")
+                .build();
+        final JdkRequest unit1 = unit(req1);
+        assertThat(unit1.getContentType()).isEqualTo("text/plain; charset=ISO-8859-1");
+        assertThat(unit1.getCharset()).isEqualTo(ISO_8859_1);
+
+        final HttpRequest req2 = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .header("Content-Type", "application/json")
+                .build();
+        final JdkRequest unit2 = unit(req2);
+        assertThat(unit2.getContentType()).isEqualTo("application/json");
+        assertThat(unit2.getCharset()).isEqualTo(UTF_8);
+
+        final HttpRequest req3 = HttpRequest.newBuilder(URI.create("http://localhost/")).build();
+        final JdkRequest unit3 = unit(req3);
+        assertThat(unit3.getContentType()).isEmpty();
+        assertThat(unit3.getCharset()).isEqualTo(UTF_8);
+    }
+
+    @Test
+    void shouldReturnEmptyBodyUntilCaptured() throws IOException {
+        final HttpRequest original = post("http://localhost/", "Hello, world!");
+        final JdkRequest unit = unit(original);
+
+        assertThat(unit.getBody()).isEmpty();
+        assertThat(unit.toHttpRequest()).isSameAs(original);
+
+        assertThat(new String(unit.withBody().getBody(), UTF_8)).isEqualTo("Hello, world!");
+        assertThat(unit.toHttpRequest()).isNotSameAs(original);
+    }
+
+    @Test
+    void shouldHandleRequestWithoutBodyPublisher() throws IOException {
+        final HttpRequest original = get("http://localhost/");
+        final JdkRequest unit = unit(original);
+
+        assertThat(unit.withBody().getBody()).isEmpty();
+        assertThat(unit.toHttpRequest()).isSameAs(original);
+    }
+
+    @Test
+    void shouldBeSafeAgainstMultipleWithBodyAndWithoutBody() throws IOException {
+        final HttpRequest original = post("http://localhost/", "Hello, world!");
+        final JdkRequest unit = unit(original);
+
+        unit.withBody().withBody();
+        assertThat(unit.toHttpRequest()).isSameAs(original);
+        assertThat(new String(unit.getBody(), UTF_8)).isEqualTo("Hello, world!");
+
+        unit.withoutBody().withoutBody();
+        assertThat(unit.getBody()).isEmpty();
+        assertThat(unit.toHttpRequest()).isNotSameAs(original);
+
+        unit.withBody();
+        assertThat(new String(unit.getBody(), UTF_8)).isEqualTo("Hello, world!");
+    }
+
+    @Test
+    void shouldPreserveAttributesOnRebuild() throws IOException {
+        final HttpRequest original = HttpRequest.newBuilder(URI.create("http://localhost/path?q=1"))
+                .method("POST", HttpRequest.BodyPublishers.ofString("test-body"))
+                .header("X-Foo", "bar")
+                .header("X-List", "a")
+                .header("X-List", "b")
+                .timeout(Duration.ofSeconds(12))
+                .version(HttpClient.Version.HTTP_2)
+                .expectContinue(true)
+                .build();
+
+        final JdkRequest unit = unit(original);
+        unit.withBody().getBody();
+
+        final HttpRequest rebuilt = unit.toHttpRequest();
+        assertThat(rebuilt.uri()).isEqualTo(URI.create("http://localhost/path?q=1"));
+        assertThat(rebuilt.method()).isEqualTo("POST");
+        assertThat(rebuilt.headers().map()).containsEntry("X-Foo", List.of("bar"));
+        assertThat(rebuilt.headers().map()).containsEntry("X-List", List.of("a", "b"));
+        assertThat(rebuilt.timeout()).contains(Duration.ofSeconds(12));
+        assertThat(rebuilt.version()).contains(HttpClient.Version.HTTP_2);
+        assertThat(rebuilt.expectContinue()).isTrue();
+        assertThat(rebuilt.bodyPublisher()).isPresent();
+    }
+
+    @Test
+    void shouldHandleDrainingFailure() {
+        final HttpRequest.BodyPublisher failingPublisher = new HttpRequest.BodyPublisher() {
+            @Override
+            public long contentLength() {
+                return 0;
+            }
+
+            @Override
+            public void subscribe(final Flow.Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new Flow.Subscription() {
+                    @Override
+                    public void request(long n) {
+                        subscriber.onError(new IOException("Simulated network read error"));
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+            }
+        };
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .POST(failingPublisher)
+                .build();
+
+        final JdkRequest unit = unit(request);
+        unit.withBody();
+
+        assertThatThrownBy(unit::getBody)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Simulated network read error");
+    }
+
+    @Test
+    void shouldWrapNonIOExceptionDrainingFailure() {
+        final HttpRequest.BodyPublisher runtimeErrorPublisher = new HttpRequest.BodyPublisher() {
+            @Override
+            public long contentLength() {
+                return 0;
+            }
+
+            @Override
+            public void subscribe(final Flow.Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new Flow.Subscription() {
+                    @Override
+                    public void request(long n) {
+                        subscriber.onError(new IllegalStateException("Runtime failure"));
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+            }
+        };
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost/"))
+                .POST(runtimeErrorPublisher)
+                .build();
+
+        final JdkRequest unit = unit(request);
+        unit.withBody();
+
+        assertThatThrownBy(unit::getBody)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to drain request body")
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientTest.java
@@ -1,0 +1,161 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.Test;
+
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LogbookHttpClientTest extends AbstractHttpTest {
+
+    private final HttpClient delegate = HttpClient.newHttpClient();
+    private final LogbookHttpClient client = new LogbookHttpClient(logbook, delegate);
+
+    @Override
+    protected HttpResponse<String> sendAndReceive(final WireMockServer server, @Nullable final String body)
+            throws IOException, InterruptedException {
+        final HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(server.baseUrl() + "/"))
+                .version(HttpClient.Version.HTTP_1_1);
+        if (body == null) {
+            builder.GET();
+        } else {
+            builder.POST(HttpRequest.BodyPublishers.ofString(body))
+                    .header("Content-Type", "text/plain");
+        }
+        return client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void shouldSurviveRebuildWithAllAttributes() throws IOException, InterruptedException {
+        server.stubFor(post("/test?key=value")
+                .withHeader("X-Custom", equalTo("custom-val"))
+                .withHeader("X-Multi", equalTo("val1"))
+                .withRequestBody(equalTo("payload"))
+                .willReturn(aResponse().withStatus(200).withBody("ok")));
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(server.baseUrl() + "/test?key=value"))
+                .method("POST", HttpRequest.BodyPublishers.ofString("payload"))
+                .header("Content-Type", "text/plain")
+                .header("X-Custom", "custom-val")
+                .header("X-Multi", "val1")
+                .header("X-Multi", "val2")
+                .timeout(Duration.ofSeconds(15))
+                .version(HttpClient.Version.HTTP_1_1)
+                .expectContinue(true)
+                .build();
+
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("ok");
+
+        final String loggedRequest = captureRequest();
+        assertThat(loggedRequest)
+                .contains("POST http://localhost:" + server.port() + "/test?key=value HTTP/1.1")
+                .contains("X-Custom: custom-val")
+                .contains("payload");
+    }
+
+    @Test
+    void shouldHandleMultiChunkRequestBody() throws IOException, InterruptedException {
+        server.stubFor(post("/multi")
+                .withRequestBody(equalTo("chunk1chunk2chunk3"))
+                .willReturn(aResponse().withStatus(200).withBody("received")));
+
+        final List<byte[]> chunks = List.of(
+                "chunk1".getBytes(),
+                "chunk2".getBytes(),
+                "chunk3".getBytes()
+        );
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(server.baseUrl() + "/multi"))
+                .POST(HttpRequest.BodyPublishers.ofByteArrays(chunks))
+                .header("Content-Type", "text/plain")
+                .build();
+
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("received");
+
+        final String logged = captureRequest();
+        assertThat(logged).contains("chunk1chunk2chunk3");
+    }
+
+    @Test
+    void shouldDelegateAllHttpClientMethods() {
+        final HttpClient mockDelegate = mock(HttpClient.class);
+        final CookieHandler cookieHandler = mock(CookieHandler.class);
+        final Duration timeout = Duration.ofSeconds(5);
+        final HttpClient.Redirect redirect = HttpClient.Redirect.ALWAYS;
+        final ProxySelector proxy = ProxySelector.of(new InetSocketAddress("localhost", 8080));
+        final Authenticator authenticator = mock(Authenticator.class);
+        final Executor executor = mock(Executor.class);
+
+        when(mockDelegate.cookieHandler()).thenReturn(Optional.of(cookieHandler));
+        when(mockDelegate.connectTimeout()).thenReturn(Optional.of(timeout));
+        when(mockDelegate.followRedirects()).thenReturn(redirect);
+        when(mockDelegate.proxy()).thenReturn(Optional.of(proxy));
+        when(mockDelegate.sslContext()).thenReturn(delegate.sslContext());
+        when(mockDelegate.sslParameters()).thenReturn(delegate.sslParameters());
+        when(mockDelegate.authenticator()).thenReturn(Optional.of(authenticator));
+        when(mockDelegate.version()).thenReturn(HttpClient.Version.HTTP_2);
+        when(mockDelegate.executor()).thenReturn(Optional.of(executor));
+        
+        final WebSocket.Builder webSocketBuilder = mock(WebSocket.Builder.class);
+        when(mockDelegate.newWebSocketBuilder()).thenReturn(webSocketBuilder);
+
+        final LogbookHttpClient wrapper = new LogbookHttpClient(mockDelegate, logbook);
+
+        assertThat(wrapper.cookieHandler()).contains(cookieHandler);
+        assertThat(wrapper.connectTimeout()).contains(timeout);
+        assertThat(wrapper.followRedirects()).isEqualTo(redirect);
+        assertThat(wrapper.proxy()).contains(proxy);
+        assertThat(wrapper.sslContext()).isNotNull();
+        assertThat(wrapper.sslParameters()).isNotNull();
+        assertThat(wrapper.authenticator()).contains(authenticator);
+        assertThat(wrapper.version()).isEqualTo(HttpClient.Version.HTTP_2);
+        assertThat(wrapper.executor()).contains(executor);
+        assertThat(wrapper.newWebSocketBuilder()).isNotNull();
+    }
+
+    @Test
+    void shouldThrowUnsupportedOperationExceptionOnSendAsync() {
+        final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost/")).build();
+
+        assertThatThrownBy(() -> client.sendAsync(request, HttpResponse.BodyHandlers.discarding()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("sendAsync is not supported yet");
+
+        assertThatThrownBy(() -> client.sendAsync(request, HttpResponse.BodyHandlers.discarding(), null))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("sendAsync is not supported yet");
+    }
+
+    @Test
+    void shouldSupportDefaultClientConstructor() {
+        final LogbookHttpClient defaultClient = new LogbookHttpClient(logbook);
+        assertThat(defaultClient.version()).isEqualTo(HttpClient.Version.HTTP_2);
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/LogbookHttpClientTest.java
@@ -15,6 +15,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.WebSocket;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -157,5 +158,47 @@ class LogbookHttpClientTest extends AbstractHttpTest {
     void shouldSupportDefaultClientConstructor() {
         final LogbookHttpClient defaultClient = new LogbookHttpClient(logbook);
         assertThat(defaultClient.version()).isEqualTo(HttpClient.Version.HTTP_2);
+    }
+
+    @Test
+    void shouldHandleLargeChunkedRequestBody() throws IOException, InterruptedException {
+        final int size = 80 * 1024;
+        final byte[] largeBody = new byte[size];
+        Arrays.fill(largeBody, (byte) 'A');
+
+        server.stubFor(post("/").willReturn(aResponse().withStatus(200)));
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(server.baseUrl() + "/"))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(largeBody))
+                .header("Content-Type", "text/plain")
+                .build();
+
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+
+        final String message = captureRequest();
+        assertThat(message).contains("A".repeat(size));
+    }
+
+    @Test
+    void shouldHandleLargeNonChunkedRequestBody() throws IOException, InterruptedException {
+        final int size = 80 * 1024;
+        final byte[] largeBody = new byte[size];
+        Arrays.fill(largeBody, (byte) 'A');
+
+        nonChunkedServer.stubFor(post("/").willReturn(aResponse().withStatus(200)));
+
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(nonChunkedServer.baseUrl() + "/"))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(largeBody))
+                .header("Content-Type", "text/plain")
+                .build();
+
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+
+        final String message = captureRequest();
+        assertThat(message).contains("A".repeat(size));
     }
 }

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/RemoteResponseTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/RemoteResponseTest.java
@@ -1,0 +1,109 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.logbook.Origin;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class RemoteResponseTest {
+
+    @SuppressWarnings("unchecked")
+    private HttpResponse<Void> mockResponse(final int status, final HttpClient.Version version, final Map<String, List<String>> headers) {
+        final HttpResponse<Void> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(status);
+        when(response.version()).thenReturn(version);
+        when(response.headers()).thenReturn(HttpHeaders.of(headers, (k, v) -> true));
+        return response;
+    }
+
+    @Test
+    void shouldResolveOriginStatusAndReasonPhrase() {
+        final HttpResponse<Void> response = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of());
+        final RemoteResponse unit = new RemoteResponse(response, new byte[0]);
+
+        assertThat(unit.getOrigin()).isEqualTo(Origin.REMOTE);
+        assertThat(unit.getStatus()).isEqualTo(200);
+        assertThat(unit.getReasonPhrase()).isEqualTo("OK");
+    }
+
+    @Test
+    void shouldResolveProtocolVersion() {
+        final HttpResponse<Void> http1 = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of());
+        assertThat(new RemoteResponse(http1, new byte[0]).getProtocolVersion()).isEqualTo("HTTP/1.1");
+
+        final HttpResponse<Void> http2 = mockResponse(200, HttpClient.Version.HTTP_2, Map.of());
+        assertThat(new RemoteResponse(http2, new byte[0]).getProtocolVersion()).isEqualTo("HTTP/2");
+    }
+
+    @Test
+    void shouldResolveHeaders() {
+        final HttpResponse<Void> response = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of(
+                "X-Custom", List.of("value1"),
+                "X-Multi", List.of("a", "b")
+        ));
+        final RemoteResponse unit = new RemoteResponse(response, new byte[0]);
+
+        assertThat(unit.getHeaders()).hasSize(2);
+        assertThat(unit.getHeaders().get("x-custom")).containsExactly("value1");
+        assertThat(unit.getHeaders().get("x-multi")).containsExactly("a", "b");
+    }
+
+    @Test
+    void shouldResolveContentTypeAndCharset() {
+        final HttpResponse<Void> res1 = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of(
+                "Content-Type", List.of("text/plain; charset=ISO-8859-1")
+        ));
+        final RemoteResponse unit1 = new RemoteResponse(res1, new byte[0]);
+        assertThat(unit1.getContentType()).isEqualTo("text/plain; charset=ISO-8859-1");
+        assertThat(unit1.getCharset()).isEqualTo(ISO_8859_1);
+
+        final HttpResponse<Void> res2 = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of(
+                "Content-Type", List.of("application/json")
+        ));
+        final RemoteResponse unit2 = new RemoteResponse(res2, new byte[0]);
+        assertThat(unit2.getContentType()).isEqualTo("application/json");
+        assertThat(unit2.getCharset()).isEqualTo(UTF_8);
+
+        final HttpResponse<Void> res3 = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of());
+        final RemoteResponse unit3 = new RemoteResponse(res3, new byte[0]);
+        assertThat(unit3.getContentType()).isEmpty();
+        assertThat(unit3.getCharset()).isEqualTo(UTF_8);
+    }
+
+    @Test
+    void shouldReturnEmptyBodyUntilCaptured() throws IOException {
+        final HttpResponse<Void> response = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of());
+        final byte[] body = "response data".getBytes(UTF_8);
+        final RemoteResponse unit = new RemoteResponse(response, body);
+
+        assertThat(unit.getBody()).isEmpty();
+        assertThat(unit.withBody().getBody()).isEqualTo(body);
+    }
+
+    @Test
+    void shouldSupportStateTransitions() throws IOException {
+        final HttpResponse<Void> response = mockResponse(200, HttpClient.Version.HTTP_1_1, Map.of());
+        final byte[] body = "response data".getBytes(UTF_8);
+        final RemoteResponse unit = new RemoteResponse(response, body);
+
+        unit.withBody().withBody();
+        assertThat(unit.getBody()).isEqualTo(body);
+
+        unit.withoutBody().withoutBody();
+        assertThat(unit.getBody()).isEmpty();
+
+        unit.withBody();
+        assertThat(unit.getBody()).isEqualTo(body);
+    }
+}

--- a/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/TeeingBodySubscriberTest.java
+++ b/logbook-jdkhttpclient/src/test/java/org/zalando/logbook/jdkhttpclient/TeeingBodySubscriberTest.java
@@ -1,0 +1,74 @@
+package org.zalando.logbook.jdkhttpclient;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class TeeingBodySubscriberTest {
+
+    @Test
+    void shouldNotMutateBufferPositionForDelegate() {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final AtomicInteger delegatePositionSeen = new AtomicInteger(-1);
+        final AtomicInteger delegateLimitSeen = new AtomicInteger(-1);
+
+        @SuppressWarnings("unchecked")
+        final BodySubscriber<String> delegate = mock(BodySubscriber.class);
+
+        final TeeingBodySubscriber<String> subscriber = new TeeingBodySubscriber<>(delegate, output);
+
+        final byte[] data = "Hello, world!".getBytes(UTF_8);
+        final ByteBuffer buffer = ByteBuffer.wrap(data);
+        final int initialPosition = buffer.position();
+        final int initialLimit = buffer.limit();
+
+        subscriber.onNext(List.of(buffer));
+
+        assertThat(output.toByteArray()).isEqualTo(data);
+        // The original buffer passed to delegate should have its initial position and limit intact
+        assertThat(buffer.position()).isEqualTo(initialPosition);
+        assertThat(buffer.limit()).isEqualTo(initialLimit);
+
+        verify(delegate).onNext(List.of(buffer));
+    }
+
+    @Test
+    void shouldForwardLifecycleMethodsToDelegate() {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        @SuppressWarnings("unchecked")
+        final BodySubscriber<Void> delegate = mock(BodySubscriber.class);
+        final Flow.Subscription subscription = mock(Flow.Subscription.class);
+        final Throwable error = new RuntimeException("test error");
+        final CompletionStage<Void> future = CompletableFuture.completedFuture(null);
+
+        when(delegate.getBody()).thenReturn(future);
+
+        final TeeingBodySubscriber<Void> subscriber = new TeeingBodySubscriber<>(delegate, output);
+
+        subscriber.onSubscribe(subscription);
+        verify(delegate).onSubscribe(subscription);
+
+        subscriber.onError(error);
+        verify(delegate).onError(error);
+
+        subscriber.onComplete();
+        verify(delegate).onComplete();
+
+        assertThat(subscriber.getBody()).isSameAs(future);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>logbook-httpclient</module>
         <module>logbook-httpclient5</module>
         <module>logbook-jaxrs</module>
+        <module>logbook-jdkhttpclient</module>
         <module>logbook-jdkserver</module>
         <module>logbook-json</module>
         <module>logbook-json-jackson2</module>


### PR DESCRIPTION
## Description
Implements Phase 1 of the `logbook-jdkhttpclient` module providing request and response logging support for JDK 11+'s built-in `java.net.http.HttpClient`:

- **`LogbookHttpClient`**: Decorator extending `java.net.http.HttpClient` that wraps the synchronous `send()` method with Logbook's two-stage request/response logging lifecycle. All abstract `HttpClient` getter/delegator methods are passed through to the delegate. Both `sendAsync()` overloads are stubbed throwing `UnsupportedOperationException` (planned for follow-up).
- **`JdkRequest`**: Implements `org.zalando.logbook.HttpRequest` wrapping `java.net.http.HttpRequest` with a lazy body-buffering state machine (`Unbuffered` -> `Offering` -> `Buffering` / `Ignoring` / `Passing`). Drains the `BodyPublisher` on-demand via reactive streams and reconstructs the `HttpRequest` with all original attributes (headers, method, URI, timeout, version, expectContinue) intact for transport.
- **`TeeingBodySubscriber`**: Decorates the response `HttpResponse.BodySubscriber<T>` and tees incoming `ByteBuffer`s into a cache without mutating buffer positions or limits for the delegate subscriber.
- **`RemoteResponse`**: Implements `org.zalando.logbook.HttpResponse` wrapping `HttpResponse<?>` and cached response bytes with state machine transitions.
- **Resilience**: Pre-send request logging and post-send response logging are isolated in try/catch blocks to ensure logging failures never break the underlying HTTP invocation.
- **Documentation**: Registered in `pom.xml`, `logbook-bom/pom.xml`, and added configuration instructions in `README.md`.
- **Test Suite**: Comprehensive WireMock test suite covering single-chunk, multi-chunk, chunked, and non-chunked transfer encoding, inactive writer short-circuits, delegator methods, and failure scenarios. JaCoCo 100% line and branch coverage enforced.

## Motivation and Context
Closes #2006.

Provides first-class, zero-dependency logging support for applications using Java's standard `java.net.http.HttpClient` without requiring third-party HTTP client libraries (such as Apache HttpClient or OkHttp).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
