### PR TITLE
fix: honour the log level in EcsSink

### DIFF
--- a/logbook-spring-boot-ecs-autoconfigure/pom.xml
+++ b/logbook-spring-boot-ecs-autoconfigure/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/logbook-spring-boot-ecs-autoconfigure/src/main/java/org/zalando/logbook/ecs/EcsSink.java
+++ b/logbook-spring-boot-ecs-autoconfigure/src/main/java/org/zalando/logbook/ecs/EcsSink.java
@@ -23,6 +23,11 @@ public class EcsSink implements Sink {
     private final StructuredHttpLogFormatter structuredHttpLogFormatter;
 
     @Override
+    public boolean isActive() {
+        return LOGGER.isTraceEnabled();
+    }
+
+    @Override
     public void write(Precorrelation precorrelation, HttpRequest httpRequest) throws IOException {
         Map<String, Object> content = structuredHttpLogFormatter.prepare(precorrelation, httpRequest);
         write(content);

--- a/logbook-spring-boot-ecs-autoconfigure/src/test/java/org/zalando/logbook/ecs/EcsSinkTest.java
+++ b/logbook-spring-boot-ecs-autoconfigure/src/test/java/org/zalando/logbook/ecs/EcsSinkTest.java
@@ -1,0 +1,35 @@
+package org.zalando.logbook.ecs;
+
+import ch.qos.logback.classic.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.Sink;
+
+import static ch.qos.logback.classic.Level.INFO;
+import static ch.qos.logback.classic.Level.TRACE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class EcsSinkTest {
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(Logbook.class);
+
+    @AfterEach
+    void reset() {
+        logger.setLevel(null);
+    }
+
+    @Test
+    void shouldUseTraceLevelForActivation() {
+        final Sink unit = new EcsSink(content -> "");
+
+        logger.setLevel(TRACE);
+        assertTrue(unit.isActive());
+
+        logger.setLevel(INFO);
+        assertFalse(unit.isActive());
+    }
+
+}


### PR DESCRIPTION
Fixes #2387

## Description

EcsSink did not override `Sink#isActive()`, so it inherited the interface default `return true`. `DefaultLogbook#process` uses `sink.isActive()` as its only short-circuit, and `Strategy#process` defaults to `request.withBody()`, which eagerly buffers the body.

The consequence is that with ECS structured logging enabled, setting `logging.level.org.zalando.logbook.Logbook` below TRACE suppresses the output but not the work: every request and response body is still buffered, stringified and formatted into an ECS map, and only then handed to LOGGER.atTrace(), which discards it. Measured on a Spring Boot app, a 100 KB body POSTed to a handler that never reads it: 0 bytes buffered with DefaultSink, 102400 bytes with EcsSink, logger OFF in both cases.

TRACE is the correct level to check: `EcsSink` writes via `LOGGER.atTrace()` on `LoggerFactory.getLogger(Logbook.class)`, the same logger and level that `DefaultHttpLogWriter#isActive` already guards on. The new test mirrors `DefaultHttpLogWriterTest#shouldUseTraceLevelForActivation`, which required adding logback-classic to this module's test scope.

## Motivation and Context
Fix high CPU usage after upgrading from 4.0.3 to 4.0.4 (or 4.1).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) 
